### PR TITLE
fix: replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,10 +25,7 @@ jobs:
           git clone https://github.com/boykush/wiki.git
       
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       
       - name: Cargo build
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,10 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Pre build
       run: |
         cargo build


### PR DESCRIPTION
- Update performance.yml to use dtolnay/rust-toolchain@stable
- Update playwright.yml to use dtolnay/rust-toolchain@stable
- Removes set-output deprecation warnings from CI

🤖 Generated with [Claude Code](https://claude.ai/code)