### PR TITLE
feat: implement empty query search returning all items (max 100)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ For comprehensive development guidelines, testing procedures, and contribution r
 - Focus on completing one TODO at a time
 - Write clean, maintainable code following Rust best practices
 - Use Claude Code's TODO functionality to track progress
+- **TDD Approach**: For new features, follow Test-Driven Development:
+  1. **Red Phase**: Write failing tests first
+  2. **Green Phase**: Implement minimal code to make tests pass
+  3. **Refactor Phase**: Improve code quality while keeping tests green
+  4. Commit after each phase with descriptive messages
 
 ### 4. Quality Checks
 Before committing any code, run the following checks in order (based on CI configuration):

--- a/modules/libs/src/search/engine.rs
+++ b/modules/libs/src/search/engine.rs
@@ -154,5 +154,4 @@ mod tests {
         let results = engine.search(&items, "");
         assert_eq!(results.len(), 100);
     }
-
 }

--- a/modules/libs/src/search/engine.rs
+++ b/modules/libs/src/search/engine.rs
@@ -15,7 +15,11 @@ impl SimpleStringSearchEngine {
 impl SearchEngine for SimpleStringSearchEngine {
     fn search(&self, items: &[SearchIndexItem], query: &str) -> Vec<SearchResult> {
         if query.is_empty() {
-            return Vec::new();
+            return items
+                .iter()
+                .take(100)
+                .map(|item| SearchResult::new(&item.title, &item.url))
+                .collect();
         }
 
         let query_lower = query.to_lowercase();
@@ -88,7 +92,7 @@ mod tests {
         let items = create_test_items();
 
         let results = engine.search(&items, "");
-        assert_eq!(results.len(), 0);
+        assert_eq!(results.len(), items.len());
     }
 
     #[test]
@@ -135,4 +139,20 @@ mod tests {
         let results = engine.search(&items, "test_");
         assert_eq!(results.len(), 1);
     }
+
+    #[test]
+    fn test_search_empty_query_limit() {
+        let engine = SimpleStringSearchEngine::new();
+        let mut items = Vec::new();
+        for i in 0..101 {
+            items.push(SearchIndexItem::new(
+                &format!("Document {}", i),
+                &format!("http://example.com/doc{}", i),
+            ));
+        }
+
+        let results = engine.search(&items, "");
+        assert_eq!(results.len(), 100);
+    }
+
 }

--- a/modules/libs/src/search/fuzzy_engine.rs
+++ b/modules/libs/src/search/fuzzy_engine.rs
@@ -206,7 +206,6 @@ mod tests {
         assert_eq!(results.len(), 100);
     }
 
-
     #[test]
     fn test_fuzzy_search_results_content() {
         let engine = FuzzySearchEngine::new();

--- a/modules/libs/src/search/fuzzy_engine.rs
+++ b/modules/libs/src/search/fuzzy_engine.rs
@@ -37,7 +37,11 @@ impl FuzzySearchEngine {
 impl SearchEngine for FuzzySearchEngine {
     fn search(&self, items: &[SearchIndexItem], query: &str) -> Vec<SearchResult> {
         if query.is_empty() {
-            return Vec::new();
+            return items
+                .iter()
+                .take(100)
+                .map(|item| SearchResult::new(&item.title, &item.url))
+                .collect();
         }
 
         let mut results_with_scores: Vec<(SearchResult, i64)> = items
@@ -136,7 +140,7 @@ mod tests {
         let items = create_test_items();
 
         let results = engine.search(&items, "");
-        assert_eq!(results.len(), 0);
+        assert_eq!(results.len(), items.len());
     }
 
     #[test]
@@ -186,6 +190,22 @@ mod tests {
         let results = engine.search(&items, "test");
         assert_eq!(results.len(), 0);
     }
+
+    #[test]
+    fn test_fuzzy_search_empty_query_limit() {
+        let engine = FuzzySearchEngine::new();
+        let mut items = Vec::new();
+        for i in 0..101 {
+            items.push(SearchIndexItem::new(
+                &format!("Document {}", i),
+                &format!("http://example.com/doc{}", i),
+            ));
+        }
+
+        let results = engine.search(&items, "");
+        assert_eq!(results.len(), 100);
+    }
+
 
     #[test]
     fn test_fuzzy_search_results_content() {


### PR DESCRIPTION
## Summary
- Implement search functionality to return all items when query is empty or blank
- Limit results to maximum of 100 items for performance optimization
- Maintain natural iteration order for empty query results
- Support both FuzzySearchEngine and SimpleStringSearchEngine

## Changes Made
- **Search Engines**: Modified both `FuzzySearchEngine` and `SimpleStringSearchEngine` to handle empty queries
- **Test Coverage**: Added comprehensive tests for empty query behavior and 100-item limit
- **TDD Approach**: Followed Test-Driven Development with Red-Green-Refactor cycle
- **Documentation**: Updated CLAUDE.md with TDD workflow guidelines

## Test Plan
- [x] Unit tests pass for both search engines
- [x] Empty query returns all available items (tested with 25 items in repository)
- [x] 100-item limit enforced when more than 100 items exist
- [x] Regular search functionality remains unchanged
- [x] Manual testing completed: `scraps search ""` and `scraps search "CLI"`
- [x] Code quality checks passed (cargo fmt, cargo clippy)

## Breaking Changes
None - this is a backward-compatible enhancement that only changes behavior for empty/blank queries.

## Performance Impact
Minimal - results are limited to 100 items maximum, using efficient iterator operations.

🤖 Generated with [Claude Code](https://claude.ai/code)