### PR TITLE
feat: add configurable num parameter to search command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,9 +29,13 @@ pub enum SubCommands {
     Serve,
 
     #[command(about = "Search scraps")]
-    Search { 
+    Search {
         query: String,
-        #[arg(short = 'n', long, help = "Maximum number of results to return (default: 100)")]
+        #[arg(
+            short = 'n',
+            long,
+            help = "Maximum number of results to return (default: 100)"
+        )]
         num: Option<usize>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,11 @@ pub enum SubCommands {
     Serve,
 
     #[command(about = "Search scraps")]
-    Search { query: String },
+    Search { 
+        query: String,
+        #[arg(short = 'n', long, help = "Maximum number of results to return (default: 100)")]
+        num: Option<usize>,
+    },
 
     #[command(about = "List a tags")]
     Tag,

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -6,7 +6,7 @@ use crate::cli::config::scrap_config::ScrapConfig;
 use crate::error::ScrapsResult;
 use crate::usecase::search::cmd::SearchCommand;
 
-pub fn run(query: &str) -> ScrapsResult<()> {
+pub fn run(query: &str, num: usize) -> ScrapsResult<()> {
     let scraps_dir_path = PathBuf::from("scraps");
     let public_dir_path = PathBuf::from("public");
 
@@ -19,7 +19,7 @@ pub fn run(query: &str) -> ScrapsResult<()> {
     };
 
     let search_command = SearchCommand::new(&scraps_dir_path, &public_dir_path);
-    let results = search_command.run(&base_url, query)?;
+    let results = search_command.run(&base_url, query, num)?;
 
     if results.is_empty() {
         println!("No results found for query: {}", query);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ fn main() -> error::ScrapsResult<()> {
         cli::SubCommands::Init { project_name } => cli::cmd::init::run(&project_name),
         cli::SubCommands::Build { verbose } => cli::cmd::build::run(verbose),
         cli::SubCommands::Serve => cli::cmd::serve::run(),
-        cli::SubCommands::Search { query, num } => cli::cmd::search::run(&query, num.unwrap_or(100)),
+        cli::SubCommands::Search { query, num } => {
+            cli::cmd::search::run(&query, num.unwrap_or(100))
+        }
         cli::SubCommands::Tag => cli::cmd::tag::run(),
         cli::SubCommands::Template {
             template_command: template_commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> error::ScrapsResult<()> {
         cli::SubCommands::Init { project_name } => cli::cmd::init::run(&project_name),
         cli::SubCommands::Build { verbose } => cli::cmd::build::run(verbose),
         cli::SubCommands::Serve => cli::cmd::serve::run(),
-        cli::SubCommands::Search { query } => cli::cmd::search::run(&query),
+        cli::SubCommands::Search { query, num } => cli::cmd::search::run(&query, num.unwrap_or(100)),
         cli::SubCommands::Tag => cli::cmd::tag::run(),
         cli::SubCommands::Template {
             template_command: template_commands,

--- a/src/usecase/search/cmd.rs
+++ b/src/usecase/search/cmd.rs
@@ -21,9 +21,9 @@ impl SearchCommand {
         }
     }
 
-    pub fn run(&self, base_url: &Url, query: &str) -> ScrapsResult<Vec<SearchResult>> {
+    pub fn run(&self, base_url: &Url, query: &str, num: usize) -> ScrapsResult<Vec<SearchResult>> {
         Self::build_search_index(self, base_url)?;
-        let results = Self::perform_search(self, query);
+        let results = Self::perform_search(self, query, num);
         Ok(results)
     }
 
@@ -39,7 +39,7 @@ impl SearchCommand {
         SearchIndexRender::new(&self.scraps_dir_path, &self.public_dir_path)?.run(base_url, &scraps)
     }
 
-    fn perform_search(&self, query: &str) -> Vec<SearchResult> {
+    fn perform_search(&self, query: &str, num: usize) -> Vec<SearchResult> {
         let search_index_path = self.public_dir_path.join("search_index.json");
 
         let indexed_str = std::fs::read_to_string(&search_index_path).unwrap();
@@ -50,7 +50,7 @@ impl SearchCommand {
             items.into_iter().map(|item| item.into_lib_type()).collect();
 
         let engine = FuzzySearchEngine::new();
-        engine.search(&lib_items, query)
+        engine.search(&lib_items, query, num)
     }
 }
 
@@ -106,7 +106,7 @@ mod tests {
             let command = SearchCommand::new(&scraps_dir_path, &public_dir_path);
             let base_url = Url::parse("http://localhost:1112/").unwrap();
 
-            let results = command.run(&base_url, "test").unwrap();
+            let results = command.run(&base_url, "test", 100).unwrap();
 
             // Should find documents containing "test"
             assert!(!results.is_empty());


### PR DESCRIPTION
## Summary
- Add `--num` parameter to search command with default value of 100
- Update SearchEngine trait to accept num parameter for result limiting
- Apply limit to both empty and non-empty query results consistently
- Maintain backward compatibility with existing behavior

## Changes
- **CLI**: Add `--num` (`-n`) parameter with default 100
- **SearchEngine trait**: Updated to accept `num` parameter
- **FuzzySearchEngine**: Apply limit to both empty queries and sorted results
- **SimpleStringSearchEngine**: Apply limit to both empty and filtered results
- **Comprehensive tests**: Added tests for various num values and edge cases

## Usage Examples
```bash
# Default behavior (100 results)
scraps search "test"

# Custom limit
scraps search "test" --num 5
scraps search "test" -n 3

# Empty query with limit
scraps search "" --num 50
```

## Test plan
- [x] All existing tests pass
- [x] New tests for num functionality added
- [x] Edge cases tested (num=0, num>available results)
- [x] Both search engines work with num parameter
- [x] Empty query respects num limit
- [x] Code formatted and linting passed

🤖 Generated with [Claude Code](https://claude.ai/code)