### PR TITLE
fix(clippy): resolve clippy warnings

### DIFF
--- a/modules/libs/src/lang.rs
+++ b/modules/libs/src/lang.rs
@@ -11,7 +11,7 @@ impl std::str::FromStr for LangCode {
     fn from_str(s: &str) -> Result<Self, String> {
         Iso639_1::try_from(s)
             .map(LangCode)
-            .map_err(|e| format!("Failed to parse language code '{}': {}", s, e))
+            .map_err(|e| format!("Failed to parse language code '{s}': {e}"))
     }
 }
 

--- a/modules/libs/src/markdown/convert.rs
+++ b/modules/libs/src/markdown/convert.rs
@@ -55,7 +55,7 @@ pub fn to_content(text: &str, base_url: &Url) -> Content {
                 match Url::parse(dest_url) {
                     Ok(url) => content_elements.push(ContentElement::Autolink(url)),
                     Err(e) => content_elements
-                        .push(ContentElement::Raw(format!("Error parsing URL: {}", e))),
+                        .push(ContentElement::Raw(format!("Error parsing URL: {e}"))),
                 }
             }
             (
@@ -91,7 +91,7 @@ fn handle_wiki_link_events<'a>(
 ) -> [Event<'a>; 3] {
     let scrap_link = &ScrapLink::from_path_str(dest_url);
     let file_stem = ScrapFileStem::from(scrap_link.clone());
-    let link = format!("{}scraps/{}.html", base_url, file_stem);
+    let link = format!("{base_url}scraps/{file_stem}.html");
     let start_link = Event::Start(Tag::Link {
         link_type: LinkType::WikiLink { has_pothole },
         dest_url: link.into(),

--- a/modules/libs/src/model/content.rs
+++ b/modules/libs/src/model/content.rs
@@ -16,7 +16,7 @@ impl Content {
 impl fmt::Display for Content {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for element in &self.elements {
-            write!(f, "{}", element)?;
+            write!(f, "{element}")?;
         }
         Ok(())
     }
@@ -31,8 +31,8 @@ pub enum ContentElement {
 impl fmt::Display for ContentElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ContentElement::Raw(text) => write!(f, "{}", text),
-            ContentElement::Autolink(url) => write!(f, "{}", url),
+            ContentElement::Raw(text) => write!(f, "{text}"),
+            ContentElement::Autolink(url) => write!(f, "{url}"),
         }
     }
 }

--- a/modules/libs/src/tests.rs
+++ b/modules/libs/src/tests.rs
@@ -84,6 +84,12 @@ pub struct TestResources {
     resources: Vec<Box<dyn TestResource>>,
 }
 
+impl Default for TestResources {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestResources {
     pub fn new() -> Self {
         TestResources {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -24,7 +24,7 @@ pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult
     let results = search_command.run(&base_url, query, num)?;
 
     if results.is_empty() {
-        println!("No results found for query: {}", query);
+        println!("No results found for query: {query}");
     } else {
         for result in results {
             println!("{} {}", result.title, result.url);

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -25,7 +25,7 @@ use scraps_libs::git::GitCommandImpl;
 pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     // set local environment
     let addr: SocketAddr = ([127, 0, 0, 1], 1112).into();
-    let base_url = Url::parse(&format!("http://{}", addr))?.join("").unwrap();
+    let base_url = Url::parse(&format!("http://{addr}"))?.join("").unwrap();
 
     // resolve paths
     let path_resolver = PathResolver::new(project_path)?;

--- a/src/cli/cmd/tag.rs
+++ b/src/cli/cmd/tag.rs
@@ -35,7 +35,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
             .sorted_by_key(|tag| tag.backlinks_count())
             .rev();
         for tag in sorted {
-            println!("{}", tag)
+            println!("{tag}")
         }
     })
 }

--- a/src/cli/cmd/template/list.rs
+++ b/src/cli/cmd/template/list.rs
@@ -13,7 +13,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let template_names = command.run()?;
 
     for template_name in template_names {
-        println!("{}", template_name);
+        println!("{template_name}");
     }
 
     Ok(())

--- a/src/cli/display/tag.rs
+++ b/src/cli/display/tag.rs
@@ -49,6 +49,6 @@ impl fmt::Display for DisplayTag {
             .collect_vec()
             .join(" ");
 
-        write!(f, "{}", tag_str)
+        write!(f, "{tag_str}")
     }
 }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -37,16 +37,16 @@ impl Progress for ProgressImpl {
     fn complete_stage(&self, stage: &Stage, count: &usize) {
         match stage {
             Stage::ReadScraps => {
-                println!("✔️ Find {} Scraps", count)
+                println!("✔️ Find {count} Scraps")
             }
             Stage::GenerateHtml => {
-                println!("✔️ Generated {} HTML files", count)
+                println!("✔️ Generated {count} HTML files")
             }
             Stage::GenerateCss => {
-                println!("✔️ Generated {} CSS files", count)
+                println!("✔️ Generated {count} CSS files")
             }
             Stage::GenerateJson => {
-                println!("✔️ Generated {} JSON files", count)
+                println!("✔️ Generated {count} JSON files")
             }
         }
     }

--- a/src/usecase/init/cmd.rs
+++ b/src/usecase/init/cmd.rs
@@ -1,8 +1,5 @@
 use crate::error::{anyhow::Context, InitError, ScrapsResult};
-use std::{
-    fs,
-    path::Path,
-};
+use std::{fs, path::Path};
 
 use scraps_libs::git::GitCommand;
 

--- a/src/usecase/init/cmd.rs
+++ b/src/usecase/init/cmd.rs
@@ -1,7 +1,7 @@
 use crate::error::{anyhow::Context, InitError, ScrapsResult};
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use scraps_libs::git::GitCommand;
@@ -35,6 +35,7 @@ impl<GC: GitCommand> InitCommand<GC> {
 #[cfg(test)]
 mod tests {
     use scraps_libs::git::GitCommandImpl;
+    use std::path::PathBuf;
 
     use super::*;
 

--- a/src/usecase/template/generate/cmd.rs
+++ b/src/usecase/template/generate/cmd.rs
@@ -50,7 +50,7 @@ mod tests {
         let timezone = chrono_tz::Asia::Tokyo;
 
         // template
-        let template_md_path = templates_dir_path.join(format!("{}.md", template_name));
+        let template_md_path = templates_dir_path.join(format!("{template_name}.md"));
 
         // scraps
 
@@ -89,7 +89,7 @@ mod tests {
         let timezone = chrono_tz::Asia::Tokyo;
 
         // template
-        let template_md_path = templates_dir_path.join(format!("{}.md", template_name));
+        let template_md_path = templates_dir_path.join(format!("{template_name}.md"));
 
         // scraps
 

--- a/src/usecase/template/markdown/render.rs
+++ b/src/usecase/template/markdown/render.rs
@@ -33,7 +33,7 @@ impl MarkdownRender {
     ) -> ScrapsResult<()> {
         let (tera, mut context) =
             markdown_tera::base(self.templates_dir_path.join("*.md").to_str().unwrap())?;
-        let template_file_name = format!("{}.md", template_name);
+        let template_file_name = format!("{template_name}.md");
         let template = if tera.get_template_names().any(|t| t == template_file_name) {
             Ok(template_file_name.as_str())
         } else {
@@ -58,7 +58,7 @@ impl MarkdownRender {
                     .map(|t| Ok(t.title))
                     .unwrap_or(Err(TemplateError::RequiredTitle))
             })?;
-        let scrap_file_name = format!("{}.md", scrap_title);
+        let scrap_file_name = format!("{scrap_title}.md");
         let ignored_metadata_text = frontmatter::ignore_metadata(&markdown_text);
 
         let mut wtr = File::create(self.scraps_dir_path.join(&scrap_file_name))


### PR DESCRIPTION
## Summary
- Fix `uninlined_format_args` warnings by using inline format strings
- Add `Default` implementation for `TestResources` to fix `new_without_default` warning
- Remove unused import `PathBuf` to fix `unused_imports` warning
- Keep `too_many_arguments` warning as-is (requires structural refactoring)

## Changes
- Replace `format\!("{}", var)` with `format\!("{var}")` across codebase
- Implement `Default` trait for `TestResources` struct
- Move `PathBuf` import to test module scope where it's actually used

## Test Plan
- [x] All existing tests pass (`cargo test --workspace`)
- [x] Code builds successfully (`cargo build --verbose --workspace`)
- [x] Code formatting is correct (`cargo fmt --all -- --check`)
- [x] Reduced clippy warnings from 9 to 1

🤖 Generated with [Claude Code](https://claude.ai/code)