### PR TITLE
feat: add colored display formatting to search command

### DIFF
--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use url::Url;
 
 use crate::cli::config::scrap_config::ScrapConfig;
+use crate::cli::display::search::DisplaySearch;
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::usecase::search::cmd::SearchCommand;
@@ -27,7 +28,8 @@ pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult
         println!("No results found for query: {query}");
     } else {
         for result in results {
-            println!("{} {}", result.title, result.url);
+            let display_search = DisplaySearch::new(&result);
+            println!("{display_search}");
         }
     }
 

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -1,1 +1,2 @@
+pub mod search;
 pub mod tag;

--- a/src/cli/display/search.rs
+++ b/src/cli/display/search.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use colored::Colorize;
-use itertools::Itertools;
 use scraps_libs::search::result::SearchResult;
 
 pub struct DisplaySearch {
@@ -23,11 +22,7 @@ impl fmt::Display for DisplaySearch {
         let title_str = self.title.bold();
         let url_str = self.url.blue();
 
-        let search_str = vec![title_str, url_str]
-            .into_iter()
-            .map(|c| c.to_string())
-            .collect_vec()
-            .join(" ");
+        let search_str = format!("{title_str} {url_str}");
 
         write!(f, "{search_str}")
     }

--- a/src/cli/display/search.rs
+++ b/src/cli/display/search.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+use colored::Colorize;
+use itertools::Itertools;
+use scraps_libs::search::result::SearchResult;
+
+pub struct DisplaySearch {
+    title: String,
+    url: String,
+}
+
+impl DisplaySearch {
+    pub fn new(search_result: &SearchResult) -> Self {
+        DisplaySearch {
+            title: search_result.title.clone(),
+            url: search_result.url.clone(),
+        }
+    }
+}
+
+impl fmt::Display for DisplaySearch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let title_str = self.title.bold();
+        let url_str = self.url.blue();
+
+        let search_str = vec![title_str, url_str]
+            .into_iter()
+            .map(|c| c.to_string())
+            .collect_vec()
+            .join(" ");
+
+        write!(f, "{search_str}")
+    }
+}


### PR DESCRIPTION
## Summary
• Update search command CLI output to match tag command styling with bold titles and blue URLs
• Add DisplaySearch struct using the `colored` crate for consistent formatting
• Maintain existing functionality while improving visual presentation

## Test plan
- [x] Build passes (`cargo build`)
- [x] All tests pass (`cargo test --workspace`)  
- [x] Code formatting is correct (`cargo fmt --all`)
- [x] Clippy warnings addressed (`cargo clippy`)
- [x] Search functionality works with new display formatting

🤖 Generated with [Claude Code](https://claude.ai/code)