### PR TITLE
refactor: rename usecase layer Command structs to Usecase

### DIFF
--- a/src/cli/cmd/build.rs
+++ b/src/cli/cmd/build.rs
@@ -9,13 +9,13 @@ use crate::cli::config::color_scheme::ColorSchemeConfig;
 use crate::cli::config::sort_key::SortKeyConfig;
 use crate::cli::progress::ProgressImpl;
 use crate::error::ScrapsResult;
-use crate::usecase::build::cmd::BuildCommand;
 use crate::usecase::build::model::color_scheme::ColorScheme;
 use crate::usecase::build::model::css::CssMetadata;
 use crate::usecase::build::model::html::HtmlMetadata;
 use crate::usecase::build::model::list_view_configs::ListViewConfigs;
 use crate::usecase::build::model::paging::Paging;
 use crate::usecase::build::model::sort::SortKey;
+use crate::usecase::build::usecase::BuildUsecase;
 
 use crate::cli::config::scrap_config::ScrapConfig;
 use crate::cli::path_resolver::PathResolver;
@@ -41,7 +41,7 @@ pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> Scraps
     let scraps_dir_path = path_resolver.scraps_dir();
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
-    let command = BuildCommand::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
+    let usecase = BuildUsecase::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
@@ -78,7 +78,7 @@ pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> Scraps
     };
     let list_view_configs = ListViewConfigs::new(&build_search_index, &sort_key, &paging);
 
-    command.run(
+    usecase.run(
         git_command,
         &progress,
         &base_url,

--- a/src/cli/cmd/init.rs
+++ b/src/cli/cmd/init.rs
@@ -1,6 +1,6 @@
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
-use crate::usecase::init::cmd::InitCommand;
+use crate::usecase::init::usecase::InitUsecase;
 use scraps_libs::git::GitCommandImpl;
 use std::path::Path;
 
@@ -9,5 +9,5 @@ pub fn run(project_name: &str, project_path: Option<&Path>) -> ScrapsResult<()> 
     let base_dir = path_resolver.project_root();
     let project_dir = base_dir.join(project_name);
     let git_command = GitCommandImpl::new();
-    InitCommand::new(git_command).run(&project_dir)
+    InitUsecase::new(git_command).run(&project_dir)
 }

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -5,7 +5,7 @@ use url::Url;
 use crate::cli::config::scrap_config::ScrapConfig;
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
-use crate::usecase::search::cmd::SearchCommand;
+use crate::usecase::search::usecase::SearchUsecase;
 
 pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
@@ -20,8 +20,8 @@ pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult
         Url::parse((config.base_url.to_string() + "/").as_str()).unwrap()
     };
 
-    let search_command = SearchCommand::new(&scraps_dir_path, &public_dir_path);
-    let results = search_command.run(&base_url, query, num)?;
+    let search_usecase = SearchUsecase::new(&scraps_dir_path, &public_dir_path);
+    let results = search_usecase.run(&base_url, query, num)?;
 
     if results.is_empty() {
         println!("No results found for query: {query}");

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -12,13 +12,13 @@ use crate::{
         color_scheme::ColorSchemeConfig, scrap_config::ScrapConfig, sort_key::SortKeyConfig,
     },
     usecase::build::{
-        cmd::BuildCommand,
         model::{
             color_scheme::ColorScheme, css::CssMetadata, html::HtmlMetadata, list_view_configs,
             paging::Paging, sort::SortKey,
         },
+        usecase::BuildUsecase,
     },
-    usecase::serve::cmd::ServeCommand,
+    usecase::serve::usecase::ServeUsecase,
 };
 use scraps_libs::git::GitCommandImpl;
 
@@ -32,7 +32,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let scraps_dir_path = path_resolver.scraps_dir();
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
-    let build_command = BuildCommand::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
+    let build_usecase = BuildUsecase::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
@@ -64,7 +64,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let list_view_configs =
         list_view_configs::ListViewConfigs::new(&build_search_index, &sort_key, &paging);
 
-    let build_result = build_command.run(
+    let build_result = build_usecase.run(
         git_command,
         &progress,
         &base_url,
@@ -76,8 +76,8 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     progress.end();
 
     // serve command
-    let serve_command = ServeCommand::new(&public_dir_path);
-    let serve_result = serve_command.run(&addr);
+    let serve_usecase = ServeUsecase::new(&public_dir_path);
+    let serve_result = serve_usecase.run(&addr);
 
     // merge result
     build_result.and(serve_result)

--- a/src/cli/cmd/tag.rs
+++ b/src/cli/cmd/tag.rs
@@ -8,12 +8,12 @@ use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 
 use crate::cli::config::scrap_config::ScrapConfig;
-use crate::usecase::tag::cmd::TagCommand;
+use crate::usecase::tag::usecase::TagUsecase;
 
 pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
     let scraps_dir_path = path_resolver.scraps_dir();
-    let command = TagCommand::new(&scraps_dir_path);
+    let usecase = TagUsecase::new(&scraps_dir_path);
 
     let config = ScrapConfig::from_path(project_path)?;
     // Automatically append a trailing slash to URLs
@@ -23,7 +23,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
         Url::parse((config.base_url.to_string() + "/").as_str()).unwrap()
     };
 
-    let (tags, backlinks_map) = command.run()?;
+    let (tags, backlinks_map) = usecase.run()?;
     let display_tags_result = tags
         .into_iter()
         .map(|tag| DisplayTag::new(&tag, &base_url, &backlinks_map))

--- a/src/cli/cmd/template/generate.rs
+++ b/src/cli/cmd/template/generate.rs
@@ -5,7 +5,7 @@ use crate::error::ScrapsResult;
 use scraps_libs::model::title::Title;
 
 use crate::{
-    cli::config::scrap_config::ScrapConfig, usecase::template::generate::cmd::GenerateCommand,
+    cli::config::scrap_config::ScrapConfig, usecase::template::generate::usecase::GenerateUsecase,
 };
 
 pub fn run(
@@ -17,11 +17,11 @@ pub fn run(
     let templates_dir_path = path_resolver.templates_dir();
     let scraps_dir_path = path_resolver.scraps_dir();
 
-    let command = GenerateCommand::new(&scraps_dir_path, &templates_dir_path);
+    let usecase = GenerateUsecase::new(&scraps_dir_path, &templates_dir_path);
 
     let config = ScrapConfig::from_path(project_path)?;
     let timezone = config.timezone.unwrap_or(chrono_tz::UTC);
-    command.run(template_name, scrap_title, &timezone)?;
+    usecase.run(template_name, scrap_title, &timezone)?;
 
     Ok(())
 }

--- a/src/cli/cmd/template/list.rs
+++ b/src/cli/cmd/template/list.rs
@@ -3,14 +3,14 @@ use std::path::Path;
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 
-use crate::usecase::template::list::cmd::ListCommand;
+use crate::usecase::template::list::usecase::ListUsecase;
 
 pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
     let templates_dir_path = path_resolver.templates_dir();
 
-    let command = ListCommand::new(&templates_dir_path);
-    let template_names = command.run()?;
+    let usecase = ListUsecase::new(&templates_dir_path);
+    let template_names = usecase.run()?;
 
     for template_name in template_names {
         println!("{template_name}");

--- a/src/usecase/build.rs
+++ b/src/usecase/build.rs
@@ -1,4 +1,4 @@
-pub mod cmd;
 mod css;
 mod html;
 pub mod model;
+pub mod usecase;

--- a/src/usecase/build/usecase.rs
+++ b/src/usecase/build/usecase.rs
@@ -37,19 +37,19 @@ use super::{
 };
 use crate::service::search::render::SearchIndexRender;
 
-pub struct BuildCommand {
+pub struct BuildUsecase {
     scraps_dir_path: PathBuf,
     static_dir_path: PathBuf,
     public_dir_path: PathBuf,
 }
 
-impl BuildCommand {
+impl BuildUsecase {
     pub fn new(
         scraps_dir_path: &Path,
         static_dir_path: &Path,
         public_dir_path: &Path,
-    ) -> BuildCommand {
-        BuildCommand {
+    ) -> BuildUsecase {
+        BuildUsecase {
             scraps_dir_path: scraps_dir_path.to_path_buf(),
             static_dir_path: static_dir_path.to_path_buf(),
             public_dir_path: public_dir_path.to_path_buf(),
@@ -198,18 +198,18 @@ mod tests {
     use super::*;
     use scraps_libs::{git::tests::GitCommandTest, lang::LangCode, tests::TestResources};
 
-    fn setup_command(test_resource_path: &Path) -> BuildCommand {
+    fn setup_usecase(test_resource_path: &Path) -> BuildUsecase {
         let scraps_dir_path = test_resource_path.join("scraps");
         let static_dir_path = test_resource_path.join("static");
         let public_dir_path = test_resource_path.join("public");
-        BuildCommand::new(&scraps_dir_path, &static_dir_path, &public_dir_path)
+        BuildUsecase::new(&scraps_dir_path, &static_dir_path, &public_dir_path)
     }
 
     #[test]
     fn it_run() {
         // fields
         let test_resource_path = PathBuf::from("tests/resource/build/cmd/it_run");
-        let command = setup_command(&test_resource_path);
+        let usecase = setup_usecase(&test_resource_path);
 
         // run args
         let git_command = GitCommandTest::new();
@@ -226,40 +226,40 @@ mod tests {
         let list_view_configs = ListViewConfigs::new(&true, &SortKey::LinkedCount, &Paging::Not);
 
         // scrap1
-        let md_path_1 = command.scraps_dir_path.join("test1.md");
-        let html_path_1 = command.public_dir_path.join("scraps/test1.html");
+        let md_path_1 = usecase.scraps_dir_path.join("test1.md");
+        let html_path_1 = usecase.public_dir_path.join("scraps/test1.html");
         let resource_bytes_1 = concat!("# header1\n", "## header2\n",).as_bytes();
 
         // scrap2
-        let md_path_2 = command.scraps_dir_path.join("test2.md");
-        let html_path_2 = command.public_dir_path.join("scraps/test2.html");
+        let md_path_2 = usecase.scraps_dir_path.join("test2.md");
+        let html_path_2 = usecase.public_dir_path.join("scraps/test2.html");
         let resource_bytes_2 = concat!("[[test1]]\n").as_bytes();
 
         // excluded not markdown file
-        let not_md_path = command.scraps_dir_path.join("test3.txt");
-        let not_exists_path = command.public_dir_path.join("scraps/test3.html");
+        let not_md_path = usecase.scraps_dir_path.join("test3.txt");
+        let not_exists_path = usecase.public_dir_path.join("scraps/test3.html");
         let resource_bytes_3 = concat!("# header1\n", "## header2\n",).as_bytes();
 
         // README.md
-        let readme_path = command.scraps_dir_path.join("README.md");
-        let readme_html_path = command.public_dir_path.join("README.html");
+        let readme_path = usecase.scraps_dir_path.join("README.md");
+        let readme_html_path = usecase.public_dir_path.join("README.html");
         let resource_bytes_4 = concat!("# README\n").as_bytes();
 
         // public
-        let html_path_3 = command.public_dir_path.join("index.html");
-        let css_path = command.public_dir_path.join("main.css");
-        let search_index_json_path = command.public_dir_path.join("search_index.json");
+        let html_path_3 = usecase.public_dir_path.join("index.html");
+        let css_path = usecase.public_dir_path.join("main.css");
+        let search_index_json_path = usecase.public_dir_path.join("search_index.json");
 
         let mut test_resources = TestResources::new();
         test_resources
-            .add_dir(&command.static_dir_path)
+            .add_dir(&usecase.static_dir_path)
             .add_file(&md_path_1, resource_bytes_1)
             .add_file(&md_path_2, resource_bytes_2)
             .add_file(&not_md_path, resource_bytes_3)
             .add_file(&readme_path, resource_bytes_4);
 
         test_resources.run(|| {
-            let result1 = command
+            let result1 = usecase
                 .run(
                     git_command,
                     &progress,
@@ -300,7 +300,7 @@ mod tests {
         // fields
         let test_resource_path =
             PathBuf::from("tests/resource/build/cmd/it_run_when_build_search_index_is_false");
-        let command = setup_command(&test_resource_path);
+        let usecase = setup_usecase(&test_resource_path);
 
         // run args
         let git_command = GitCommandTest::new();
@@ -317,24 +317,24 @@ mod tests {
         let list_view_configs = ListViewConfigs::new(&false, &SortKey::LinkedCount, &Paging::Not);
 
         // scrap1
-        let md_path_1 = command.scraps_dir_path.join("test1.md");
+        let md_path_1 = usecase.scraps_dir_path.join("test1.md");
         let resource_bytes_1 = concat!("# header1\n", "## header2\n",).as_bytes();
 
         // scrap2
-        let md_path_2 = command.scraps_dir_path.join("test2.md");
+        let md_path_2 = usecase.scraps_dir_path.join("test2.md");
         let resource_bytes_2 = concat!("[[test1]]\n").as_bytes();
 
         // public
-        let search_index_json_path = command.public_dir_path.join("search_index.json");
+        let search_index_json_path = usecase.public_dir_path.join("search_index.json");
 
         let mut test_resources = TestResources::new();
         test_resources
-            .add_dir(&command.static_dir_path)
+            .add_dir(&usecase.static_dir_path)
             .add_file(&md_path_1, resource_bytes_1)
             .add_file(&md_path_2, resource_bytes_2);
 
         test_resources.run(|| {
-            let result1 = command
+            let result1 = usecase
                 .run(
                     git_command,
                     &progress,

--- a/src/usecase/init.rs
+++ b/src/usecase/init.rs
@@ -1,1 +1,1 @@
-pub mod cmd;
+pub mod usecase;

--- a/src/usecase/init/usecase.rs
+++ b/src/usecase/init/usecase.rs
@@ -3,13 +3,13 @@ use std::{fs, path::Path};
 
 use scraps_libs::git::GitCommand;
 
-pub struct InitCommand<GC: GitCommand> {
+pub struct InitUsecase<GC: GitCommand> {
     git_command: GC,
 }
 
-impl<GC: GitCommand> InitCommand<GC> {
-    pub fn new(git_command: GC) -> InitCommand<GC> {
-        InitCommand { git_command }
+impl<GC: GitCommand> InitUsecase<GC> {
+    pub fn new(git_command: GC) -> InitUsecase<GC> {
+        InitUsecase { git_command }
     }
 
     pub fn run(&self, project_dir: &Path) -> ScrapsResult<()> {
@@ -41,9 +41,9 @@ mod tests {
         let git_command = GitCommandImpl::new();
         let project_path = PathBuf::from("tests/resource/init/cmd/it_run");
 
-        let command = InitCommand::new(git_command);
+        let usecase = InitUsecase::new(git_command);
 
-        command.run(&project_path).unwrap();
+        usecase.run(&project_path).unwrap();
 
         assert!(project_path.exists());
         assert!(project_path.join("scraps").exists());

--- a/src/usecase/search.rs
+++ b/src/usecase/search.rs
@@ -1,1 +1,1 @@
-pub mod cmd;
+pub mod usecase;

--- a/src/usecase/search/usecase.rs
+++ b/src/usecase/search/usecase.rs
@@ -8,14 +8,14 @@ use scraps_libs::search::fuzzy_engine::FuzzySearchEngine;
 use scraps_libs::search::result::SearchResult;
 use url::Url;
 
-pub struct SearchCommand {
+pub struct SearchUsecase {
     scraps_dir_path: PathBuf,
     public_dir_path: PathBuf,
 }
 
-impl SearchCommand {
-    pub fn new(scraps_dir_path: &PathBuf, public_dir_path: &PathBuf) -> SearchCommand {
-        SearchCommand {
+impl SearchUsecase {
+    pub fn new(scraps_dir_path: &PathBuf, public_dir_path: &PathBuf) -> SearchUsecase {
+        SearchUsecase {
             scraps_dir_path: scraps_dir_path.to_owned(),
             public_dir_path: public_dir_path.to_owned(),
         }
@@ -103,10 +103,10 @@ mod tests {
             .add_dir(&public_dir_path);
 
         test_resources.run(|| {
-            let command = SearchCommand::new(&scraps_dir_path, &public_dir_path);
+            let usecase = SearchUsecase::new(&scraps_dir_path, &public_dir_path);
             let base_url = Url::parse("http://localhost:1112/").unwrap();
 
-            let results = command.run(&base_url, "test", 100).unwrap();
+            let results = usecase.run(&base_url, "test", 100).unwrap();
 
             // Should find documents containing "test"
             assert!(!results.is_empty());

--- a/src/usecase/serve.rs
+++ b/src/usecase/serve.rs
@@ -1,2 +1,2 @@
-pub mod cmd;
 mod service;
+pub mod usecase;

--- a/src/usecase/serve/usecase.rs
+++ b/src/usecase/serve/usecase.rs
@@ -10,13 +10,13 @@ use tokio::net::TcpListener;
 
 use crate::error::ScrapsResult;
 
-pub struct ServeCommand {
+pub struct ServeUsecase {
     public_dir_path: PathBuf,
 }
 
-impl ServeCommand {
-    pub fn new(public_dir_path: &Path) -> ServeCommand {
-        ServeCommand {
+impl ServeUsecase {
+    pub fn new(public_dir_path: &Path) -> ServeUsecase {
+        ServeUsecase {
             public_dir_path: public_dir_path.to_path_buf(),
         }
     }

--- a/src/usecase/tag.rs
+++ b/src/usecase/tag.rs
@@ -1,1 +1,1 @@
-pub mod cmd;
+pub mod usecase;

--- a/src/usecase/tag/usecase.rs
+++ b/src/usecase/tag/usecase.rs
@@ -4,13 +4,13 @@ use std::path::PathBuf;
 
 use crate::usecase::build::model::backlinks_map::BacklinksMap;
 
-pub struct TagCommand {
+pub struct TagUsecase {
     scraps_dir_path: PathBuf,
 }
 
-impl TagCommand {
-    pub fn new(scraps_dir_path: &PathBuf) -> TagCommand {
-        TagCommand {
+impl TagUsecase {
+    pub fn new(scraps_dir_path: &PathBuf) -> TagUsecase {
+        TagUsecase {
             scraps_dir_path: scraps_dir_path.to_owned(),
         }
     }
@@ -58,9 +58,9 @@ mod tests {
             .add_file(&md_path_2, resource_bytes_2);
 
         test_resources.run(|| {
-            let command = TagCommand::new(&scraps_dir_path);
+            let usecase = TagUsecase::new(&scraps_dir_path);
 
-            let result = command.run().unwrap();
+            let result = usecase.run().unwrap();
 
             let (tags, backlinks_map) = result;
 

--- a/src/usecase/template/generate.rs
+++ b/src/usecase/template/generate.rs
@@ -1,1 +1,1 @@
-pub mod cmd;
+pub mod usecase;

--- a/src/usecase/template/generate/usecase.rs
+++ b/src/usecase/template/generate/usecase.rs
@@ -6,14 +6,14 @@ use scraps_libs::model::title::Title;
 
 use crate::usecase::template::markdown::render::MarkdownRender;
 
-pub struct GenerateCommand {
+pub struct GenerateUsecase {
     scraps_dir_path: PathBuf,
     templates_dir_path: PathBuf,
 }
 
-impl GenerateCommand {
-    pub fn new(scraps_dir_path: &Path, templates_dir_path: &Path) -> GenerateCommand {
-        GenerateCommand {
+impl GenerateUsecase {
+    pub fn new(scraps_dir_path: &Path, templates_dir_path: &Path) -> GenerateUsecase {
+        GenerateUsecase {
             scraps_dir_path: scraps_dir_path.to_path_buf(),
             templates_dir_path: templates_dir_path.to_path_buf(),
         }
@@ -65,8 +65,8 @@ mod tests {
 
         test_resources.run(|| {
             // run
-            let command = GenerateCommand::new(&scraps_dir_path, &templates_dir_path);
-            command
+            let usecase = GenerateUsecase::new(&scraps_dir_path, &templates_dir_path);
+            usecase
                 .run(template_name, template_title, &timezone)
                 .unwrap();
 
@@ -105,8 +105,8 @@ mod tests {
 
         test_resources.run(|| {
             // run
-            let command = GenerateCommand::new(&scraps_dir_path, &templates_dir_path);
-            command
+            let usecase = GenerateUsecase::new(&scraps_dir_path, &templates_dir_path);
+            usecase
                 .run(template_name, template_title, &timezone)
                 .unwrap();
 

--- a/src/usecase/template/list.rs
+++ b/src/usecase/template/list.rs
@@ -1,1 +1,1 @@
-pub mod cmd;
+pub mod usecase;

--- a/src/usecase/template/list/usecase.rs
+++ b/src/usecase/template/list/usecase.rs
@@ -4,13 +4,13 @@ use crate::error::{anyhow::Ok, ScrapsResult};
 
 use crate::usecase::template::markdown::markdown_tera;
 
-pub struct ListCommand {
+pub struct ListUsecase {
     templates_dir_path: PathBuf,
 }
 
-impl ListCommand {
-    pub fn new(templates_dir_path: &Path) -> ListCommand {
-        ListCommand {
+impl ListUsecase {
+    pub fn new(templates_dir_path: &Path) -> ListUsecase {
+        ListUsecase {
             templates_dir_path: templates_dir_path.to_path_buf(),
         }
     }


### PR DESCRIPTION
## Summary
- Rename cmd.rs files to usecase.rs in usecase directories
- Rename Command structs to Usecase (BuildCommand -> BuildUsecase, etc.)
- Update module declarations and imports throughout codebase
- Update CLI layer references to use new Usecase naming

## Motivation
This refactoring makes the usecase layer more semantically correct by removing CLI-specific naming conventions and clearly separating business logic from external interface concerns (CLI, future MCP Server, etc.).

## Test plan
- [x] All existing tests pass (28 tests in main crate, 58 in libs)
- [x] Code builds successfully
- [x] Code formatting is correct
- [x] Clippy linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)