### PR TITLE
feat: add Claude Code project hooks for Rust formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read file_path; if echo \"$file_path\" | grep -q '\\.rs$'; then cargo fmt --all; fi; }"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read file_path; if echo \"$file_path\" | grep -q '\\.rs$'; then cargo fmt --all; fi; }"
+            "command": "file_path=$(jq -r '.tool_input.file_path'); if echo \"$file_path\" | grep -q '\\.rs$'; then cargo fmt -- \"$file_path\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add PostToolUse hook for automatic `cargo fmt` execution on Rust files
- Configure hooks for Edit, MultiEdit, and Write tools in Claude Code
- Remove conflicting Git pre-commit hook to streamline development workflow

## Test plan
- [x] Verify hook triggers after editing .rs files with Claude Code
- [x] Confirm automatic formatting applies to modified Rust code
- [x] Test that non-Rust files are not affected by the hook

🤖 Generated with [Claude Code](https://claude.ai/code)