### PR TITLE
feat: Add MCP (Model Context Protocol) server with search functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ percent-encoding = "2.3.1"
 tracing = "0.1.0"
 tracing-subscriber = "0.3.0"
 clap-verbosity-flag = "3.0.0"
+rmcp = { version = "0.6.0", features = ["server"] }
+schemars = "1.0.4"
 
 [package]
 edition.workspace = true
@@ -83,6 +85,8 @@ percent-encoding.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap-verbosity-flag.workspace = true
+rmcp.workspace = true
+schemars.workspace = true
 
 [dev-dependencies]
 scraps_libs.workspace = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,12 @@ pub enum SubCommands {
         #[command(subcommand)]
         template_command: TemplateSubCommands,
     },
+
+    #[command(about = "MCP server commands")]
+    Mcp {
+        #[command(subcommand)]
+        mcp_command: McpSubCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -69,6 +75,12 @@ pub enum TemplateSubCommands {
 
     #[command(about = "List templates")]
     List,
+}
+
+#[derive(Subcommand)]
+pub enum McpSubCommands {
+    #[command(about = "Start MCP server with stdio transport")]
+    Serve,
 }
 
 #[derive(Args, Clone)]

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod init;
+pub mod mcp;
 pub mod search;
 pub mod serve;
 pub mod tag;

--- a/src/cli/cmd/mcp.rs
+++ b/src/cli/cmd/mcp.rs
@@ -1,0 +1,2 @@
+pub mod serve;
+pub mod server;

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use crate::{
+    cli::cmd::mcp::server::ScrapsServer,
+    error::{McpError, ScrapsResult},
+};
+use rmcp::ServiceExt;
+use tokio::io::{stdin, stdout};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
+    let _ = project_path;
+
+    // Initialize tracing
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|e| McpError::TracingSetup(e.to_string()))?;
+
+    info!("Starting Scraps MCP server...");
+
+    let service = ScrapsServer::new()
+        .serve((stdin(), stdout()))
+        .await
+        .inspect_err(|e| {
+            tracing::error!("Failed to start Scraps MCP server: {}", e);
+        })
+        .map_err(|e| McpError::ServiceError(e.to_string()))?;
+
+    service
+        .waiting()
+        .await
+        .map_err(|e| McpError::ServiceError(e.to_string()))?;
+    Ok(())
+}

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -2,16 +2,17 @@ use std::path::Path;
 
 use crate::{
     cli::cmd::mcp::server::ScrapsServer,
+    cli::config::scrap_config::ScrapConfig,
+    cli::path_resolver::PathResolver,
     error::{McpError, ScrapsResult},
 };
 use rmcp::ServiceExt;
 use tokio::io::{stdin, stdout};
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
+use url::Url;
 
 pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
-    let _ = project_path;
-
     // Initialize tracing
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::INFO)
@@ -21,7 +22,26 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
 
     info!("Starting Scraps MCP server...");
 
-    let service = ScrapsServer::new()
+    // Set up path resolver and config
+    let path_resolver = PathResolver::new(project_path)
+        .map_err(|e| McpError::ServiceError(format!("Failed to resolve paths: {e}")))?;
+
+    let scraps_dir = path_resolver.scraps_dir();
+    let public_dir = path_resolver.public_dir();
+
+    // Load config to get base_url
+    let config = ScrapConfig::from_path(project_path)
+        .map_err(|e| McpError::ServiceError(format!("Failed to load config: {e}")))?;
+
+    // Automatically append a trailing slash to URLs
+    let base_url = if config.base_url.path().ends_with('/') {
+        config.base_url
+    } else {
+        Url::parse((config.base_url.to_string() + "/").as_str())
+            .map_err(|e| McpError::ServiceError(format!("Invalid base URL: {e}")))?
+    };
+
+    let service = ScrapsServer::new(scraps_dir, public_dir, base_url)
         .serve((stdin(), stdout()))
         .await
         .inspect_err(|e| {

--- a/src/cli/cmd/mcp/server.rs
+++ b/src/cli/cmd/mcp/server.rs
@@ -1,0 +1,62 @@
+use std::future::Future;
+
+use rmcp::handler::server::tool::{Parameters, ToolRouter};
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::schemars::JsonSchema;
+use rmcp::service::RequestContext;
+use rmcp::{tool, tool_handler, tool_router, ErrorData, RoleServer};
+use serde::Deserialize;
+use serde_json::{json, Map};
+
+pub struct ScrapsServer {
+    tool_router: ToolRouter<ScrapsServer>,
+}
+
+impl ScrapsServer {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+impl Default for ScrapsServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HelloWorldRequest {
+    // Empty struct with proper object schema
+}
+
+#[tool_router]
+impl ScrapsServer {
+    #[tool(description = "Hello World")]
+    async fn hello_world(
+        &self,
+        _context: RequestContext<RoleServer>,
+        Parameters(_request): Parameters<HelloWorldRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut map = Map::new();
+        map.insert("message".into(), json!("Hello, World!"));
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{}",
+            json!(map)
+        ))]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ScrapsServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some("This is a Scraps MCP server".into()),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum ScrapsError {
     #[error("CLI error: {0}")]
     Cli(#[from] CliError),
 
+    #[error("MCP error: {0}")]
+    Mcp(#[from] McpError),
+
     #[error("Failed to read scrap: {0}")]
     ReadScrap(PathBuf),
 
@@ -94,4 +97,19 @@ pub enum CliError {
 
     #[error("Failed when load config")]
     ConfigLoad,
+}
+
+#[derive(Error, PartialEq, Debug)]
+pub enum McpError {
+    #[error("Failed to initialize MCP server")]
+    ServerInitialization,
+
+    #[error("Failed to setup tracing for MCP server: {0}")]
+    TracingSetup(String),
+
+    #[error("MCP service error: {0}")]
+    ServiceError(String),
+
+    #[error("Failed to create tokio runtime: {0}")]
+    RuntimeCreation(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,9 +101,6 @@ pub enum CliError {
 
 #[derive(Error, PartialEq, Debug)]
 pub enum McpError {
-    #[error("Failed to initialize MCP server")]
-    ServerInitialization,
-
     #[error("Failed to setup tracing for MCP server: {0}")]
     TracingSetup(String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod service;
 mod usecase;
 
 use clap::Parser;
+use error::McpError;
 
 fn main() -> error::ScrapsResult<()> {
     let cli = cli::Cli::parse();
@@ -27,6 +28,13 @@ fn main() -> error::ScrapsResult<()> {
                 cli.path.as_deref(),
             ),
             cli::TemplateSubCommands::List => cli::cmd::template::list::run(cli.path.as_deref()),
+        },
+        cli::SubCommands::Mcp { mcp_command } => match mcp_command {
+            cli::McpSubCommands::Serve => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|e| McpError::RuntimeCreation(e.to_string()))?;
+                runtime.block_on(cli::cmd::mcp::serve::run(cli.path.as_deref()))
+            }
         },
     }
 }


### PR DESCRIPTION
## Summary

This PR adds Model Context Protocol (MCP) server functionality to Scraps, enabling Claude Code to interact with Scraps projects directly. The implementation includes:

- Basic MCP server infrastructure with serve command
- Functional search tool that allows querying Scraps content
- Integration with existing Scraps search functionality

The MCP server provides a bridge between Claude Code and Scraps projects, allowing for enhanced developer workflows when working with documentation sites.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

This implementation follows the MCP specification and integrates with Scraps' existing search capabilities. The server exposes search functionality as a tool that can be called by MCP clients like Claude Code.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>