### PR TITLE
fix: correct Parameters import path in MCP server

### DIFF
--- a/src/cli/cmd/mcp/server.rs
+++ b/src/cli/cmd/mcp/server.rs
@@ -1,8 +1,8 @@
-use std::future::Future;
 use std::path::PathBuf;
 
 use crate::usecase::search::usecase::SearchUsecase;
-use rmcp::handler::server::tool::{Parameters, ToolRouter};
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::ErrorCode;
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};


### PR DESCRIPTION
## Summary

Fix compilation errors in the MCP server implementation by correcting the Parameters import path and removing unused imports.

This PR addresses build failures in the MCP server module by:
- Using the correct import path for Parameters: `rmcp::handler::server::wrapper::Parameters`
- Removing unused `std::future::Future` import
- Ensuring all tests pass and code formatting is maintained

## Related Issues

<!-- No specific issues linked - this is a build fix -->

## Additional Notes

The fix was necessary due to changes in the rmcp crate structure where Parameters is re-exported through the wrapper module. All quality checks (tests, formatting, clippy) pass successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)