### PR TITLE
refactor: optimize CLI search by eliminating JSON generation

### DIFF
--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -26,7 +26,6 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
         .map_err(|e| McpError::ServiceError(format!("Failed to resolve paths: {e}")))?;
 
     let scraps_dir = path_resolver.scraps_dir();
-    let public_dir = path_resolver.public_dir();
 
     // Load config to get base_url
     let config = ScrapConfig::from_path(project_path)
@@ -34,7 +33,7 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
 
     let base_url = config.base_url.into_base_url();
 
-    let service = ScrapsServer::new(scraps_dir, public_dir, base_url)
+    let service = ScrapsServer::new(scraps_dir, base_url)
         .serve((stdin(), stdout()))
         .await
         .inspect_err(|e| {

--- a/src/cli/cmd/mcp/server.rs
+++ b/src/cli/cmd/mcp/server.rs
@@ -16,16 +16,14 @@ use serde_json::json;
 pub struct ScrapsServer {
     tool_router: ToolRouter<ScrapsServer>,
     scraps_dir: PathBuf,
-    public_dir: PathBuf,
     base_url: BaseUrl,
 }
 
 impl ScrapsServer {
-    pub fn new(scraps_dir: PathBuf, public_dir: PathBuf, base_url: BaseUrl) -> Self {
+    pub fn new(scraps_dir: PathBuf, base_url: BaseUrl) -> Self {
         Self {
             tool_router: Self::tool_router(),
             scraps_dir,
-            public_dir,
             base_url,
         }
     }
@@ -49,7 +47,7 @@ impl ScrapsServer {
         Parameters(request): Parameters<SearchRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         // Create search usecase
-        let search_usecase = SearchUsecase::new(&self.scraps_dir, &self.public_dir);
+        let search_usecase = SearchUsecase::new(&self.scraps_dir);
 
         // Execute search
         let num = request.num.unwrap_or(100);

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -9,12 +9,11 @@ use crate::usecase::search::usecase::SearchUsecase;
 pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
     let scraps_dir_path = path_resolver.scraps_dir();
-    let public_dir_path = path_resolver.public_dir();
 
     let config = ScrapConfig::from_path(project_path)?;
     let base_url = config.base_url.into_base_url();
 
-    let search_usecase = SearchUsecase::new(&scraps_dir_path, &public_dir_path);
+    let search_usecase = SearchUsecase::new(&scraps_dir_path);
     let results = search_usecase.execute(&base_url, query, num)?;
 
     if results.is_empty() {


### PR DESCRIPTION
- Remove build_search_index method and JSON file generation
- Implement direct in-memory search for CLI commands
- Delete unused perform_search method and Serde structures
- Remove public_dir_path field from SearchUsecase struct
- Maintain backward compatibility for API consumers

This change improves CLI search performance by skipping unnecessary JSON file creation while preserving browser search functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

<!-- Brief description of what this PR does -->

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

<!-- Any additional information about the implementation or decisions made -->