### PR TITLE
feat: add md_text field to search results and rename SearchResultWithUrl to SearchResult

### DIFF
--- a/src/cli/cmd/mcp/server.rs
+++ b/src/cli/cmd/mcp/server.rs
@@ -61,7 +61,8 @@ impl ScrapsServer {
             .map(|result| {
                 json!({
                     "title": result.title,
-                    "url": result.url
+                    "url": result.url,
+                    "md_text": result.md_text
                 })
             })
             .collect::<Vec<_>>();

--- a/src/cli/display/search.rs
+++ b/src/cli/display/search.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::usecase::search::usecase::SearchResultWithUrl;
+use crate::usecase::search::usecase::SearchResult;
 use colored::Colorize;
 
 pub struct DisplaySearch {
@@ -9,7 +9,7 @@ pub struct DisplaySearch {
 }
 
 impl DisplaySearch {
-    pub fn new(search_result: &SearchResultWithUrl) -> Self {
+    pub fn new(search_result: &SearchResult) -> Self {
         DisplaySearch {
             title: search_result.title.clone(),
             url: search_result.url.clone(),


### PR DESCRIPTION
## Summary

This PR adds the `md_text` field from scraps to search results and renames `SearchResultWithUrl` to `SearchResult` for better naming consistency.

### Changes Made:
- **Renamed `SearchResultWithUrl` to `SearchResult`** - Updated struct name throughout codebase
- **Added `md_text` field** - Added `pub md_text: String` to store markdown content from scraps
- **Updated search usecase** - Modified `SearchUsecase::execute` to populate `md_text` from scrap data  
- **Enhanced MCP server response** - Updated JSON response to include `"md_text": result.md_text`
- **Fixed imports** - Updated all references in `src/cli/display/search.rs`
- **Updated tests** - Added assertion to verify `md_text` is properly populated

### Benefits:
- MCP search responses now include the full markdown content of each scrap
- More descriptive struct naming (`SearchResult` vs `SearchResultWithUrl`)
- Enhanced search functionality for clients consuming the MCP API

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

All tests pass and code quality checks (formatting, clippy) are clean. The changes are backward compatible for the search functionality while adding new data to MCP responses.

🤖 Generated with [Claude Code](https://claude.ai/code)