### PR TITLE
feat: rename MCP search tool to search_scraps

### DIFF
--- a/src/cli/cmd/mcp/server.rs
+++ b/src/cli/cmd/mcp/server.rs
@@ -41,7 +41,7 @@ struct SearchRequest {
 #[tool_router]
 impl ScrapsServer {
     #[tool(description = "Search scraps")]
-    async fn search(
+    async fn search_scraps(
         &self,
         _context: RequestContext<RoleServer>,
         Parameters(request): Parameters<SearchRequest>,


### PR DESCRIPTION
## Summary

Renames the MCP tool function from `search` to `search_scraps` to provide better clarity and naming consistency. This changes the tool's accessible name from `mcp__scraps__search` to `mcp__scraps__search_scraps`.

## Related Issues

<!-- No specific issues linked for this naming improvement -->

## Additional Notes

- Only changes the function name in the MCP server implementation
- No breaking changes to the underlying search functionality
- All existing tests continue to pass
- Improves tool naming consistency and clarity

🤖 Generated with [Claude Code](https://claude.ai/code)