### PR TITLE
feat: remove url field from search_scraps response

### DIFF
--- a/src/mcp/tools/search_scraps.rs
+++ b/src/mcp/tools/search_scraps.rs
@@ -40,7 +40,6 @@ pub async fn search_scraps(
         .map(|result| {
             json!({
                 "title": result.title,
-                "url": result.url,
                 "md_text": result.md_text
             })
         })


### PR DESCRIPTION
## Summary

Remove the `url` field from the JSON response in the `search_scraps` MCP tool to simplify the search results structure. The response now only includes `title` and `md_text` fields, making it more focused on the essential content for search operations.

## Related Issues

<!-- No specific issue linked for this cleanup -->

## Additional Notes

This change streamlines the search response format by removing the URL field that was not essential for the search functionality. The simplified response structure focuses on the core content (title and markdown text) that users need when searching through scraps.

🤖 Generated with [Claude Code](https://claude.ai/code)