### PR TITLE
feat: implement get_scrap_links MCP tool with shared JSON structures

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,2 +1,3 @@
+pub mod json;
 pub mod server;
 mod tools;

--- a/src/mcp/json.rs
+++ b/src/mcp/json.rs
@@ -1,0 +1,1 @@
+pub mod scrap;

--- a/src/mcp/json/scrap.rs
+++ b/src/mcp/json/scrap.rs
@@ -1,0 +1,8 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ScrapJson {
+    pub title: String,
+    pub ctx: Option<String>,
+    pub md_text: String,
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use super::tools::get_scrap_links::{get_scrap_links, GetScrapLinksRequest};
 use super::tools::list_tags::list_tags;
 use super::tools::search_scraps::{search_scraps, SearchRequest};
 use rmcp::handler::server::tool::ToolRouter;
@@ -35,6 +36,15 @@ impl ScrapsServer {
         parameters: Parameters<SearchRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         search_scraps(&self.scraps_dir, &self.base_url, context, parameters).await
+    }
+
+    #[tool(description = "Get scrap links")]
+    async fn get_scrap_links(
+        &self,
+        context: RequestContext<RoleServer>,
+        parameters: Parameters<GetScrapLinksRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        get_scrap_links(&self.scraps_dir, &self.base_url, context, parameters).await
     }
 
     #[tool(description = "List tags")]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,2 +1,3 @@
+pub mod get_scrap_links;
 pub mod list_tags;
 pub mod search_scraps;

--- a/src/mcp/tools/get_scrap_links.rs
+++ b/src/mcp/tools/get_scrap_links.rs
@@ -1,4 +1,4 @@
-use crate::mcp::tools::search_scraps::SearchResultResponse;
+use crate::mcp::json::scrap::ScrapJson;
 use crate::usecase::scrap::get_links::usecase::GetScrapLinksUsecase;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
@@ -21,7 +21,7 @@ pub struct GetScrapLinksRequest {
 
 #[derive(Debug, Serialize)]
 pub struct GetScrapLinksResponse {
-    pub results: Vec<SearchResultResponse>,
+    pub results: Vec<ScrapJson>,
     pub count: usize,
 }
 
@@ -52,18 +52,18 @@ pub async fn get_scrap_links(
         })?;
 
     // Convert results to structured response
-    let link_results: Vec<SearchResultResponse> = results
+    let scrap_jsons: Vec<ScrapJson> = results
         .into_iter()
-        .map(|result| SearchResultResponse {
+        .map(|result| ScrapJson {
             title: result.title.to_string(),
             ctx: result.ctx.map(|c| c.to_string()),
             md_text: result.md_text,
         })
         .collect();
 
-    let count = link_results.len();
+    let count = scrap_jsons.len();
     let response = GetScrapLinksResponse {
-        results: link_results,
+        results: scrap_jsons,
         count,
     };
 

--- a/src/mcp/tools/get_scrap_links.rs
+++ b/src/mcp/tools/get_scrap_links.rs
@@ -1,0 +1,79 @@
+use crate::mcp::tools::search_scraps::SearchResultResponse;
+use crate::usecase::scrap::get_links::usecase::GetScrapLinksUsecase;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::ErrorCode;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::schemars::JsonSchema;
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer};
+use scraps_libs::model::base_url::BaseUrl;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct GetScrapLinksRequest {
+    /// Title of the scrap to get links for
+    pub title: String,
+    /// Optional context if the scrap has one
+    pub ctx: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GetScrapLinksResponse {
+    pub results: Vec<SearchResultResponse>,
+    pub count: usize,
+}
+
+pub async fn get_scrap_links(
+    scraps_dir: &PathBuf,
+    base_url: &BaseUrl,
+    _context: RequestContext<RoleServer>,
+    Parameters(request): Parameters<GetScrapLinksRequest>,
+) -> Result<CallToolResult, ErrorData> {
+    // Create get scrap links usecase
+    let get_links_usecase = GetScrapLinksUsecase::new(scraps_dir);
+
+    // Execute get links
+    let title = scraps_libs::model::title::Title::from(request.title.as_str());
+    let ctx = request
+        .ctx
+        .as_ref()
+        .map(|c| scraps_libs::model::context::Ctx::from(c.as_str()));
+
+    let results = get_links_usecase
+        .execute(base_url, &title, &ctx)
+        .map_err(|e| {
+            ErrorData::new(
+                ErrorCode(-32004),
+                format!("Get scrap links failed: {e}"),
+                None,
+            )
+        })?;
+
+    // Convert results to structured response
+    let link_results: Vec<SearchResultResponse> = results
+        .into_iter()
+        .map(|result| SearchResultResponse {
+            title: result.title.to_string(),
+            ctx: result.ctx.map(|c| c.to_string()),
+            md_text: result.md_text,
+        })
+        .collect();
+
+    let count = link_results.len();
+    let response = GetScrapLinksResponse {
+        results: link_results,
+        count,
+    };
+
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string(&response).map_err(|e| {
+            ErrorData::new(
+                ErrorCode(-32005),
+                format!("JSON serialization failed: {e}"),
+                None,
+            )
+        })?,
+    )]))
+}

--- a/src/mcp/tools/search_scraps.rs
+++ b/src/mcp/tools/search_scraps.rs
@@ -1,3 +1,4 @@
+use crate::mcp::json::scrap::ScrapJson;
 use crate::usecase::search::usecase::SearchUsecase;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
@@ -19,15 +20,8 @@ pub struct SearchRequest {
 }
 
 #[derive(Debug, Serialize)]
-pub struct SearchResultResponse {
-    pub title: String,
-    pub ctx: Option<String>,
-    pub md_text: String,
-}
-
-#[derive(Debug, Serialize)]
 pub struct SearchResponse {
-    pub results: Vec<SearchResultResponse>,
+    pub results: Vec<ScrapJson>,
     pub count: usize,
 }
 
@@ -47,18 +41,18 @@ pub async fn search_scraps(
         .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("Search failed: {e}"), None))?;
 
     // Convert results to structured response
-    let search_results: Vec<SearchResultResponse> = results
+    let scrap_jsons: Vec<ScrapJson> = results
         .into_iter()
-        .map(|result| SearchResultResponse {
+        .map(|result| ScrapJson {
             title: result.title.to_string(),
             ctx: result.ctx.map(|c| c.to_string()),
             md_text: result.md_text,
         })
         .collect();
 
-    let count = search_results.len();
+    let count = scrap_jsons.len();
     let response = SearchResponse {
-        results: search_results,
+        results: scrap_jsons,
         count,
     };
 

--- a/src/usecase.rs
+++ b/src/usecase.rs
@@ -2,6 +2,7 @@ pub mod build;
 pub mod init;
 pub mod progress;
 mod read_scraps;
+pub mod scrap;
 pub mod search;
 pub mod serve;
 pub mod tag;

--- a/src/usecase/scrap.rs
+++ b/src/usecase/scrap.rs
@@ -1,0 +1,1 @@
+pub mod get_links;

--- a/src/usecase/scrap/get_links.rs
+++ b/src/usecase/scrap/get_links.rs
@@ -1,0 +1,1 @@
+pub mod usecase;

--- a/src/usecase/scrap/get_links/usecase.rs
+++ b/src/usecase/scrap/get_links/usecase.rs
@@ -1,0 +1,221 @@
+use crate::error::ScrapsResult;
+use crate::usecase::search::usecase::SearchResult;
+use scraps_libs::model::base_url::BaseUrl;
+use scraps_libs::model::context::Ctx;
+use scraps_libs::model::file::ScrapFileStem;
+use scraps_libs::model::key::ScrapKey;
+use scraps_libs::model::scrap::Scrap;
+use scraps_libs::model::title::Title;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub struct GetScrapLinksUsecase {
+    scraps_dir_path: PathBuf,
+}
+
+impl GetScrapLinksUsecase {
+    pub fn new(scraps_dir_path: &PathBuf) -> GetScrapLinksUsecase {
+        GetScrapLinksUsecase {
+            scraps_dir_path: scraps_dir_path.to_owned(),
+        }
+    }
+
+    pub fn execute(
+        &self,
+        base_url: &BaseUrl,
+        title: &Title,
+        ctx: &Option<Ctx>,
+    ) -> ScrapsResult<Vec<SearchResult>> {
+        // Load all scraps from directory
+        let scrap_paths = crate::usecase::read_scraps::to_scrap_paths(&self.scraps_dir_path)?;
+        let scraps = scrap_paths
+            .into_iter()
+            .map(|path| crate::usecase::read_scraps::to_scrap_by_path(&self.scraps_dir_path, &path))
+            .collect::<ScrapsResult<Vec<Scrap>>>()?;
+
+        // Create scrap key for the target scrap
+        let target_key = if let Some(ctx) = ctx {
+            ScrapKey::with_ctx(title, ctx)
+        } else {
+            ScrapKey::from(title.clone())
+        };
+
+        // Find the target scrap
+        let target_scrap = scraps
+            .iter()
+            .find(|scrap| scrap.self_key() == target_key)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Scrap not found: title='{}', ctx='{:?}'", title, ctx)
+            })?;
+
+        // Create scrap key-to-scrap mapping for efficient lookup
+        let scrap_map: HashMap<ScrapKey, &Scrap> = scraps
+            .iter()
+            .map(|scrap| (scrap.self_key(), scrap))
+            .collect();
+
+        // Convert each link to SearchResult
+        let results: Vec<SearchResult> = target_scrap
+            .links
+            .iter()
+            .filter_map(|link_key| {
+                // Find the linked scrap
+                scrap_map.get(link_key).map(|linked_scrap| {
+                    // Generate URL for the linked scrap
+                    let file_stem = ScrapFileStem::from(linked_scrap.self_key().clone());
+                    let url = format!("{}scraps/{}.html", base_url.as_url(), file_stem);
+
+                    let scrap_key = &linked_scrap.self_key();
+                    let title: Title = scrap_key.into();
+                    let ctx: Option<Ctx> = scrap_key.into();
+
+                    SearchResult {
+                        title,
+                        ctx,
+                        url,
+                        md_text: linked_scrap.md_text.clone(),
+                    }
+                })
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scraps_libs::tests::TestResources;
+    use std::path::PathBuf;
+    use url::Url;
+
+    #[test]
+    fn test_get_scrap_links_success() {
+        let test_resource_path =
+            PathBuf::from("tests/resource/scrap/get_links/test_get_scrap_links_success");
+        let scraps_dir_path = test_resource_path.join("scraps");
+
+        let md_path_1 = scraps_dir_path.join("scrap1.md");
+        let md_path_2 = scraps_dir_path.join("scrap2.md");
+        let md_path_3 = scraps_dir_path.join("scrap3.md");
+
+        let mut resources = TestResources::new();
+        resources
+            .add_dir(&scraps_dir_path)
+            .add_file(
+                &md_path_1,
+                b"# Scrap 1\n\nThis links to [[scrap2]] and [[scrap3]].",
+            )
+            .add_file(&md_path_2, b"# Scrap 2\n\nContent of scrap 2.")
+            .add_file(&md_path_3, b"# Scrap 3\n\nContent of scrap 3.");
+
+        resources.run(|| {
+            let usecase = GetScrapLinksUsecase::new(&scraps_dir_path);
+            let url = Url::parse("http://localhost:3000/").unwrap();
+            let base_url = BaseUrl::new(url).unwrap();
+
+            let results = usecase
+                .execute(&base_url, &Title::from("scrap1"), &None)
+                .expect("Should succeed");
+
+            assert_eq!(results.len(), 2);
+
+            // Check that we got the expected linked scraps
+            let titles: Vec<String> = results.iter().map(|r| r.title.to_string()).collect();
+            assert!(titles.contains(&"scrap2".to_string()));
+            assert!(titles.contains(&"scrap3".to_string()));
+
+            // Check URL format
+            for result in &results {
+                assert!(result.url.starts_with("http://localhost:3000/scraps/"));
+                assert!(result.url.ends_with(".html"));
+            }
+        });
+    }
+
+    #[test]
+    fn test_get_scrap_links_with_context() {
+        let test_resource_path =
+            PathBuf::from("tests/resource/scrap/get_links/test_get_scrap_links_with_context");
+        let scraps_dir_path = test_resource_path.join("scraps");
+        let context_dir_path = scraps_dir_path.join("Context");
+
+        let md_path_1 = context_dir_path.join("scrap1.md");
+        let md_path_2 = scraps_dir_path.join("scrap2.md");
+
+        let mut resources = TestResources::new();
+        resources
+            .add_dir(&context_dir_path)
+            .add_file(&md_path_1, b"# Scrap 1\n\nThis links to [[scrap2]].")
+            .add_file(&md_path_2, b"# Scrap 2\n\nContent of scrap 2.");
+
+        resources.run(|| {
+            let usecase = GetScrapLinksUsecase::new(&scraps_dir_path);
+            let url = Url::parse("http://localhost:3000/").unwrap();
+            let base_url = BaseUrl::new(url).unwrap();
+
+            let results = usecase
+                .execute(
+                    &base_url,
+                    &Title::from("scrap1"),
+                    &Some(Ctx::from("Context")),
+                )
+                .expect("Should succeed");
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].title.to_string(), "scrap2");
+        });
+    }
+
+    #[test]
+    fn test_get_scrap_links_not_found() {
+        let test_resource_path =
+            PathBuf::from("tests/resource/scrap/get_links/test_get_scrap_links_not_found");
+        let scraps_dir_path = test_resource_path.join("scraps");
+
+        let md_path_1 = scraps_dir_path.join("scrap1.md");
+
+        let mut resources = TestResources::new();
+        resources
+            .add_dir(&scraps_dir_path)
+            .add_file(&md_path_1, b"# Scrap 1\n\nContent.");
+
+        resources.run(|| {
+            let usecase = GetScrapLinksUsecase::new(&scraps_dir_path);
+            let url = Url::parse("http://localhost:3000/").unwrap();
+            let base_url = BaseUrl::new(url).unwrap();
+
+            let result = usecase.execute(&base_url, &Title::from("Nonexistent Scrap"), &None);
+
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Scrap not found"));
+        });
+    }
+
+    #[test]
+    fn test_get_scrap_links_no_links() {
+        let test_resource_path =
+            PathBuf::from("tests/resource/scrap/get_links/test_get_scrap_links_no_links");
+        let scraps_dir_path = test_resource_path.join("scraps");
+
+        let md_path_1 = scraps_dir_path.join("scrap1.md");
+
+        let mut resources = TestResources::new();
+        resources
+            .add_dir(&scraps_dir_path)
+            .add_file(&md_path_1, b"# Scrap 1\n\nThis scrap has no links.");
+
+        resources.run(|| {
+            let usecase = GetScrapLinksUsecase::new(&scraps_dir_path);
+            let url = Url::parse("http://localhost:3000/").unwrap();
+            let base_url = BaseUrl::new(url).unwrap();
+
+            let results = usecase
+                .execute(&base_url, &Title::from("scrap1"), &None)
+                .expect("Should succeed");
+
+            assert_eq!(results.len(), 0);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a new `get_scrap_links` MCP tool that retrieves links from a specified scrap and returns them in the same format as the search results. Additionally, it refactors the JSON response structures to eliminate code duplication between MCP tools.

### Key Changes:
- **New MCP Tool**: `get_scrap_links` tool that accepts title and optional context parameters
- **Usecase Layer**: Complete implementation of `GetScrapLinksUsecase` with comprehensive tests
- **Code Refactoring**: Extracted shared JSON structures to `src/mcp/json/` module
- **Improved Architecture**: Renamed `SearchResultResponse` to `ScrapJson` for better semantic clarity

### Implementation Details:
- Uses existing search infrastructure and `SearchResult` structure for consistency
- Follows established MCP tool patterns and error handling
- Includes proper TestResources-based testing with multiple test scenarios
- Maintains backward compatibility with existing search_scraps tool

## Test Plan

- [x] Unit tests for GetScrapLinksUsecase (4 test cases covering success, context, not found, and no links scenarios)
- [x] Integration with existing MCP server architecture
- [x] Code formatting and linting checks passed
- [x] Build and compilation successful

🤖 Generated with [Claude Code](https://claude.ai/code)