### PR TITLE
feat: enhance MCP tool descriptions with detailed functionality explanations

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -29,7 +29,9 @@ impl ScrapsServer {
 
 #[tool_router]
 impl ScrapsServer {
-    #[tool(description = "Search scraps")]
+    #[tool(
+        description = "Search for scraps by title and context (ctx) using fuzzy matching. Returns matching scraps with their titles, contexts, and full content."
+    )]
     async fn search_scraps(
         &self,
         context: RequestContext<RoleServer>,
@@ -38,7 +40,9 @@ impl ScrapsServer {
         search_scraps(&self.scraps_dir, &self.base_url, context, parameters).await
     }
 
-    #[tool(description = "Get scrap links")]
+    #[tool(
+        description = "Get outbound wiki links from a specific scrap. Returns all scraps that the specified scrap links to, with their full content."
+    )]
     async fn get_scrap_links(
         &self,
         context: RequestContext<RoleServer>,
@@ -47,7 +51,9 @@ impl ScrapsServer {
         get_scrap_links(&self.scraps_dir, &self.base_url, context, parameters).await
     }
 
-    #[tool(description = "List tags")]
+    #[tool(
+        description = "List all available tags used across scraps in the documentation site. Useful for discovering content categories and topics."
+    )]
     async fn list_tags(
         &self,
         context: RequestContext<RoleServer>,


### PR DESCRIPTION
## Summary

Enhanced the descriptions of MCP tools in `src/mcp/server.rs` to provide more detailed and accurate functionality explanations:

- **search_scraps**: Clarified that it searches by title and context (ctx) using fuzzy matching, not content
- **get_scrap_links**: Specified that it only returns outbound links (what the scrap links to), not inbound links  
- **list_tags**: Added context about discovering content categories and topics

## Related Issues

<!-- No specific issues linked -->

## Additional Notes

The enhanced descriptions will help MCP clients better understand what each tool does and when to use them. This improves the discoverability and usability of the Scraps MCP server.