### PR TITLE
fix: update E2E test to match new project description

### DIFF
--- a/tests/e2e/scraps-doc.spec.ts
+++ b/tests/e2e/scraps-doc.spec.ts
@@ -45,7 +45,7 @@ test('fetch OGP data', async ({ page }) => {
   const description = await ogpCard.locator('.ogp-description').textContent();
   
   expect(title).toContain('GitHub - boykush/scraps');
-  expect(description).toContain('Scraps is a static site generator');
+  expect(description).toContain('Scraps is a portable CLI knowledge hub');
 
   // Verify image is loaded
   const image = ogpCard.locator('.ogp-image');


### PR DESCRIPTION
## Summary

Updates the E2E test expectation for OGP data to align with the recent project description change. The GitHub repository description was updated from "Scraps is a static site generator" to "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation", causing the E2E test to fail.

This fix ensures the test correctly validates the new project description in the OGP metadata.

## Related Issues

This addresses failing E2E tests caused by the recent project description update in commit ede7387.

## Additional Notes

- Only the test expectation was updated - no functional changes to the application
- All E2E tests now pass across all browsers (Chromium, Firefox, WebKit)
- The change maintains the same test coverage while aligning with the current project messaging