### PR TITLE
refactor: improve dependency management by moving libs-specific dependencies to local scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,12 +1772,10 @@ dependencies = [
 name = "scraps_libs"
 version = "0.26.1"
 dependencies = [
- "anyhow",
  "fuzzy-matcher",
  "iso639_enum",
  "itertools",
  "pulldown-cmark",
- "thiserror",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,9 @@ anyhow = "=1.0.100"
 thiserror = "=2.0.16"
 url = { version = "=2.5.7", features = ["serde"] }
 itertools = "=0.14.0"
-pulldown-cmark = "=0.13.0"
 serde = { version = "=1.0.225", features = ["derive"] }
 serde_json = "=1.0.145"
 toml = "=0.9.7"
-iso639_enum = "=0.6.0"
 rayon = "=1.11.0"
 clap = { version = "=4.5.48", features = ["derive"] }
 config = { version = "=0.15.16", features = ["toml"] }

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -11,12 +11,10 @@ documentation.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
-thiserror.workspace = true
 url.workspace = true
 itertools.workspace = true
-pulldown-cmark.workspace = true
-iso639_enum.workspace = true
+pulldown-cmark = "=0.13.0"
+iso639_enum = "=0.6.0"
 fuzzy-matcher = { version = "=0.3.7", optional = true }
 
 [features]


### PR DESCRIPTION
## Summary

This PR improves dependency management by moving libraries that are only used within `modules/libs` from workspace-level dependencies to local dependencies within the `scraps_libs` crate.

### Changes Made
- Moved `pulldown-cmark` from workspace dependencies to `modules/libs` local dependencies  
- Moved `iso639_enum` from workspace dependencies to `modules/libs` local dependencies
- These libraries are only used within the `scraps_libs` crate and should not be exposed at the workspace level

### Benefits
- Better dependency encapsulation and hiding of implementation details
- Cleaner workspace-level dependency management  
- Follows Rust best practices for workspace organization
- Prevents accidental usage of libs-specific dependencies in other workspace members

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

The changes maintain the same functionality while improving the overall dependency architecture. All builds and tests continue to pass with these changes.

🤖 Generated with [Claude Code](https://claude.ai/code)