### PR TITLE
feat: add configurable scraps directory support

### DIFF
--- a/src/cli/cmd/build.rs
+++ b/src/cli/cmd/build.rs
@@ -37,15 +37,14 @@ pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> Scraps
     let span_run = span!(Level::INFO, "run").entered();
 
     let path_resolver = PathResolver::new(project_path)?;
-    let scraps_dir_path = path_resolver.scraps_dir();
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
     let usecase = BuildUsecase::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
-
-    let config = ScrapConfig::from_path(project_path)?;
     let base_url = config.base_url.into_base_url();
     let lang_code = config
         .lang_code

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -25,11 +25,11 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to resolve paths: {e}")))?;
 
-    let scraps_dir = path_resolver.scraps_dir();
-
     // Load config to get base_url
     let config = ScrapConfig::from_path(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to load config: {e}")))?;
+
+    let scraps_dir = path_resolver.scraps_dir(&config);
 
     let base_url = config.base_url.into_base_url();
 

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -8,9 +8,9 @@ use crate::usecase::search::usecase::SearchUsecase;
 
 pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
-    let scraps_dir_path = path_resolver.scraps_dir();
-
     let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
+
     let base_url = config.base_url.into_base_url();
 
     let search_usecase = SearchUsecase::new(&scraps_dir_path);

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -30,15 +30,14 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
 
     // resolve paths
     let path_resolver = PathResolver::new(project_path)?;
-    let scraps_dir_path = path_resolver.scraps_dir();
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
     let build_usecase = BuildUsecase::new(&scraps_dir_path, &static_dir_path, &public_dir_path);
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
-
-    let config = ScrapConfig::from_path(project_path)?;
     let lang_code = config
         .lang_code
         .map(|c| c.into_lang_code())

--- a/src/cli/cmd/tag.rs
+++ b/src/cli/cmd/tag.rs
@@ -11,10 +11,10 @@ use crate::usecase::tag::list::usecase::ListTagUsecase;
 
 pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
-    let scraps_dir_path = path_resolver.scraps_dir();
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
     let usecase = ListTagUsecase::new(&scraps_dir_path);
 
-    let config = ScrapConfig::from_path(project_path)?;
     let base_url = config.base_url.into_base_url();
 
     let (tags, backlinks_map) = usecase.execute()?;

--- a/src/cli/cmd/template/generate.rs
+++ b/src/cli/cmd/template/generate.rs
@@ -14,12 +14,11 @@ pub fn run(
     project_path: Option<&Path>,
 ) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
+    let config = ScrapConfig::from_path(project_path)?;
     let templates_dir_path = path_resolver.templates_dir();
-    let scraps_dir_path = path_resolver.scraps_dir();
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
 
     let usecase = GenerateUsecase::new(&scraps_dir_path, &templates_dir_path);
-
-    let config = ScrapConfig::from_path(project_path)?;
     let timezone = config.timezone.unwrap_or(chrono_tz::UTC);
     usecase.execute(template_name, scrap_title, &timezone)?;
 

--- a/src/cli/config/scrap_config.rs
+++ b/src/cli/config/scrap_config.rs
@@ -3,7 +3,7 @@ use crate::error::{anyhow::Context, CliError, ScrapsResult};
 use chrono_tz::Tz;
 use config::Config;
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use url::Url;
 
 use super::{
@@ -15,6 +15,7 @@ use super::{
 pub struct ScrapConfig {
     pub base_url: BaseUrlConfig,
     pub lang_code: Option<LangCodeConfig>,
+    pub scraps_dir: Option<PathBuf>,
     pub title: String,
     pub description: Option<String>,
     pub favicon: Option<Url>,

--- a/src/cli/config/scrap_config.rs
+++ b/src/cli/config/scrap_config.rs
@@ -14,9 +14,9 @@ use super::{
 #[derive(Debug, Deserialize)]
 pub struct ScrapConfig {
     pub base_url: BaseUrlConfig,
-    pub lang_code: Option<LangCodeConfig>,
-    pub scraps_dir: Option<PathBuf>,
     pub title: String,
+    pub scraps_dir: Option<PathBuf>,
+    pub lang_code: Option<LangCodeConfig>,
     pub description: Option<String>,
     pub favicon: Option<Url>,
     pub timezone: Option<Tz>,

--- a/src/usecase/init/builtins/Config.toml
+++ b/src/usecase/init/builtins/Config.toml
@@ -4,6 +4,9 @@ base_url = "https://username.github.io/repository-name/"
 # The site title
 title = ""
 
+# The scraps directory path (optional, default=scraps)
+# scraps_dir = "scraps"
+
 # The site language (compliant with iso639-1, default=en)
 # lang_code = "en"
 

--- a/src/usecase/init/builtins/Config.toml
+++ b/src/usecase/init/builtins/Config.toml
@@ -4,7 +4,7 @@ base_url = "https://username.github.io/repository-name/"
 # The site title
 title = ""
 
-# The scraps directory path (optional, default=scraps)
+# The scraps directory path relative to this Config.toml (optional, default=scraps)
 # scraps_dir = "scraps"
 
 # The site language (compliant with iso639-1, default=en)


### PR DESCRIPTION
## Summary

Add support for configurable scraps directory path via `Config.toml`. Users can now specify a custom directory for their markdown files instead of being limited to the default `scraps` directory.

This feature enables better project organization by allowing users to:
- Use custom directory names like `docs`, `content`, or `wiki`
- Align with existing project structures
- Support multiple documentation workflows

## Related Issues

Addresses the need for flexible project structure configuration.

## Changes

### Implementation
- Added `scraps_dir` field to `ScrapConfig` struct
- Implemented `scraps_dir()` method in `PathResolver` that accepts `ScrapConfig` parameter
- Default behavior: uses `"scraps"` directory when not configured
- Updated all command handlers to pass config to `scraps_dir()` method

### Configuration
- Added `scraps_dir` option to init command's Config.toml template
- Positioned after `title` and before `lang_code` for logical grouping
- Reordered `ScrapConfig` struct fields to match Config.toml layout

### Testing
- Added test for default directory path behavior
- Added test for custom directory path configuration
- All existing tests pass (104 tests)

## Additional Notes

The implementation maintains backward compatibility - projects without `scraps_dir` configuration will continue to use the default `scraps` directory. The change is purely additive and doesn't affect existing functionality.

All quality checks passed:
- ✅ Tests (104 passed)
- ✅ Format check
- ✅ Clippy
- ✅ Build successful