### PR TITLE
chore: enable commit-commands plugin in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "commit-commands@claude-code-plugins": true
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
Add commit-commands@claude-code-plugins to enabledPlugins in .claude/settings.json to enhance git workflow functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

<!-- Brief description of what this PR does -->

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

<!-- Any additional information about the implementation or decisions made -->