### PR TITLE
fix: properly escape special characters in search index JSON

### DIFF
--- a/src/service/search/builtins/search_index.json
+++ b/src/service/search/builtins/search_index.json
@@ -1,8 +1,8 @@
 [
   {% for scrap in scraps %}
     {
-      "title": "{{ scrap.link_title | addslashes }}",
-      "url": "{{ base_url }}scraps/{{ scrap.file_stem | addslashes }}.html"
+      "title": {{ scrap.link_title | json_encode() }},
+      "url": {{ base_url ~ "scraps/" ~ scrap.file_stem ~ ".html" | json_encode() }}
     }
     {% if not loop.last %},{% endif %}
   {% endfor %}


### PR DESCRIPTION
## Summary
- Fixed JSON escaping in search_index.json template by replacing `addslashes` with `json_encode()`
- This resolves a bug where titles containing apostrophes would break the search functionality

## Root Cause
The `addslashes` filter was escaping single quotes as `\'` which is invalid JSON syntax. This caused JSON parsing errors when the search index contained titles with apostrophes.

## Changes
- **src/service/search/builtins/search_index.json**: Replace `addslashes` filter with `json_encode()` for proper JSON escaping according to RFC 8259
- Concatenate URL components before applying `json_encode()` to avoid double-quoting

## Test Plan
- [x] Verify search_index.json generates valid JSON with special characters in titles
- [x] E2E tests should pass with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)