### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Pledge
+
+This project adheres to the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+We are committed to providing a welcoming and inclusive environment for all contributors, regardless of background or identity.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to:
+
+- **Email**: boykush315@gmail.com
+- **Language**: Reports can be made in English or Japanese (英語または日本語で報告可能)
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including:
+- GitHub Issues and Pull Requests
+- GitHub Discussions
+- Official project documentation and communications
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Welcome to the Scraps development community! 🎉
 
 Scraps is a static site generator that brings developer-friendly workflows to documentation, using Markdown files with simple Wiki-link notation.
 
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
 ## Quick Links
 
 - **Official Documentation:** https://boykush.github.io/scraps/


### PR DESCRIPTION
## Summary

- Add minimal CODE_OF_CONDUCT.md referencing Contributor Covenant 2.1
- Update CONTRIBUTING.md to reference the Code of Conduct
- Establish bilingual incident reporting support (English/Japanese)

## Details

This PR introduces a Code of Conduct for the Scraps project to establish community standards and create a welcoming environment for all contributors.

### Changes

1. **CODE_OF_CONDUCT.md** (new file)
   - Minimal implementation referencing Contributor Covenant 2.1
   - Clear reporting mechanism with bilingual support
   - Defined scope covering GitHub Issues, PRs, and Discussions

2. **CONTRIBUTING.md** (updated)
   - Added reference to Code of Conduct near the top
   - Ensures visibility for all contributors

### Approach

- Chose minimal reference-based approach for low maintenance
- Followed patterns from projects like Tokio and mdBook
- Added unique bilingual reporting support for international community

## Related Issues

N/A - Proactive community infrastructure improvement

## Test Plan

- [x] Verify CODE_OF_CONDUCT.md renders correctly on GitHub
- [x] Confirm CONTRIBUTING.md link works
- [x] Check GitHub Community Insights recognizes the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)