### PR TITLE
fix: Update Playwright test path for Autolink documentation

### DIFF
--- a/tests/e2e/scraps-doc.spec.ts
+++ b/tests/e2e/scraps-doc.spec.ts
@@ -25,7 +25,7 @@ test('search scraps', async ({ page }) => {
 });
 
 test('fetch OGP data', async ({ page }) => {
-  await page.goto('/scraps/autolink.html');
+  await page.goto('/scraps/autolink.reference.html');
 
   // Wait for OGP card to be present
   const ogpCard = page.locator('.ogp-card').first();


### PR DESCRIPTION
## Summary
- Fixed Playwright test failure by updating the path to the Autolink documentation page
- Changed from `/scraps/autolink.html` to `/scraps/autolink.reference.html` to match the new documentation structure

## Problem
The recent documentation restructure moved `Autolink.md` from the root to the `Reference/` directory. Scraps uses a flat naming convention for context-based documents (`{title}.{context}.html`), so the output path changed accordingly. The Playwright test was still using the old path, causing all browser tests to fail with "element not found" errors.

## Solution
Updated the test URL in `tests/e2e/scraps-doc.spec.ts` to use the correct path `autolink.reference.html`.

## Test Plan
- [x] All Playwright tests pass locally (9/9 tests across chromium, firefox, webkit)
- [x] The OGP card element is now properly found and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)