### PR TITLE
feat: group Rust toolchain updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,11 @@
         "dockerfile"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "groupName": "Rust toolchain",
+      "matchDatasources": ["docker", "mise"],
+      "matchPackagePatterns": ["^rust$"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add package grouping configuration to combine Rust version updates from `mise.toml` and `Dockerfile` into a single PR
- This prevents separate PRs for each file and makes Rust version updates more manageable

## Changes

- Added "Rust toolchain" package group in `.github/renovate.json`
- Group matches `docker` and `mise` datasources for the `rust` package

## Test plan

- [x] Renovate configuration syntax is valid
- [ ] Wait for next Renovate run to verify grouping works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)