### PR TITLE
fix: correct Renovate Rust toolchain grouping config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,8 +20,8 @@
     },
     {
       "groupName": "Rust toolchain",
-      "matchDatasources": ["docker", "mise"],
-      "matchPackagePatterns": ["^rust$"]
+      "matchManagers": ["dockerfile", "mise"],
+      "matchPackageNames": ["rust"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fix the Rust toolchain package grouping configuration to properly work with Renovate
- Previous config used incorrect options that prevented Docker Rust updates from being detected

## Changes

- **matchDatasources → matchManagers**: Use the correct option to target package managers
- **matchPackagePatterns → matchPackageNames**: Use exact package name matching
- Target both `dockerfile` and `mise` managers to group updates from:
  - `Dockerfile` (rust:1.90-slim-bookworm)
  - `mise.toml` (rust version 1.90.0)

## References

- [Renovate: Package Grouping](https://docs.renovatebot.com/noise-reduction/#package-grouping)
- [Renovate: matchManagers](https://docs.renovatebot.com/configuration-options/#matchmanagers)
- [Renovate: Supported Managers](https://docs.renovatebot.com/modules/manager/)

## Test plan

- [x] Renovate configuration syntax is valid
- [ ] Wait for next Renovate run to verify Dockerfile Rust updates are detected and grouped with mise.toml updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)