### PR TITLE
refactor: use dir parameter for e2e:test task in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,8 @@ run = "mise exec cargo:cargo-tarpaulin -- cargo tarpaulin --verbose --all-featur
 
 [tasks."e2e:test"]
 description = "Run E2E tests with Playwright"
-run = "cd tests/e2e && npm install && npx playwright test"
+dir = "tests/e2e"
+run = "npm install && npx playwright test"
 
 [tasks."docs:build"]
 description = "Build documentation with scraps"


### PR DESCRIPTION
## Summary
- Refactored the `e2e:test` task in mise.toml to use the `dir` parameter instead of `cd` command
- Follows mise best practices for TOML tasks as documented at https://mise.jdx.dev/tasks/toml-tasks.html

## Changes
- Added `dir = "tests/e2e"` to the e2e:test task
- Removed `cd tests/e2e &&` from the run command
- Improves readability and follows mise conventions

## Test plan
- [x] Verified e2e:test task runs successfully with the new configuration
- [x] All 9 E2E tests pass (Chromium, Firefox, WebKit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)