### PR TITLE
feat: increase scrap title font size to differentiate from markdown h1

### DIFF
--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -105,6 +105,10 @@ div.scrap .context::before {
     margin-right: 8px;
 }
 
+div.scrap h1.title {
+    font-size: 36px;
+}
+
 div.scrap .commited-date {
     font-size: 12.8px;
     color: var(--gray-color);

--- a/src/usecase/build/html/builtins/scrap.html
+++ b/src/usecase/build/html/builtins/scrap.html
@@ -14,7 +14,7 @@
         {% if scrap.ctx %}
           <h3 class="context">{{ scrap.ctx }}<span>&#47;</span></h2>
         {% endif %}
-        <h1>{{ scrap.title }}</h1>
+        <h1 class="title">{{ scrap.title }}</h1>
         {% if scrap.commited_ts %}
             <p class="commited-date">
                 commited date: {{ scrap.commited_ts | date(format="%Y-%m-%d", timezone=timezone) }}


### PR DESCRIPTION
## Summary
- Added `class="title"` to scrap page title in scrap.html
- Set font-size to 36px for scrap title to make it visually distinct from h1 elements in markdown content
- Tag page already had the title class, so it will also benefit from this styling

## Test plan
- [ ] Build the project with `mise run cargo:build`
- [ ] Run `scraps build` to generate static site
- [ ] Verify scrap page titles are larger than markdown h1 elements
- [ ] Verify tag page titles maintain consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)