### PR TITLE
feat: add Claude Code plugin configuration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "scraps",
+  "version": "1.0.0",
+  "description": "Claude Code plugin for Scraps - Manage interconnected Markdown documentation with Wiki-link notation",
+  "author": "boykush <boykush315@gmail.com>",
+  "homepage": "https://boykush.github.io/scraps",
+  "repository": "https://github.com/boykush/scraps",
+  "mcpServers": "./.mcp.json"
+}

--- a/docs/How-to/Install Claude Code Plugin.md
+++ b/docs/How-to/Install Claude Code Plugin.md
@@ -1,0 +1,21 @@
+#[[Integration]]
+
+This guide shows you how to install the Scraps Claude Code plugin, which provides MCP (Model Context Protocol) server integration for seamless AI assistant interaction with your Scraps knowledge base.
+
+## Installation
+
+Install the Scraps plugin using Claude Code:
+
+```bash
+claude plugin install boykush/scraps
+```
+
+That's it! The plugin will automatically use the current directory as your Scraps project path.
+
+## Custom Project Path (Optional)
+
+If you want to specify a different Scraps project path, set the `SCRAPS_PROJECT_PATH` environment variable:
+
+```bash
+export SCRAPS_PROJECT_PATH="/path/to/your/scraps/project"
+```


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/plugin.json` for Claude Code plugin metadata
- Add `.mcp.json` for MCP server configuration with `SCRAPS_PROJECT_PATH` environment variable support
- Add installation guide at `docs/How-to/Install Claude Code Plugin.md`

## Benefits

Users can now install Scraps as a Claude Code plugin with a single command:
```bash
claude plugin install boykush/scraps
```

The plugin automatically starts the MCP server using the current directory, with optional customization via the `SCRAPS_PROJECT_PATH` environment variable.

## Test plan

- [ ] Verify `.claude-plugin/plugin.json` has valid structure
- [ ] Verify `.mcp.json` MCP server configuration is correct
- [ ] Test plugin installation workflow
- [ ] Verify documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)