### PR TITLE
fix: correct scraps-writer plugin structure to follow Claude Code schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Scraps - MCP server integration for interconnected Markdown documentation",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "plugins": [
     {

--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -7,12 +7,5 @@
     "email": "boykush315@gmail.com"
   },
   "homepage": "https://boykush.github.io/scraps",
-  "repository": "https://github.com/boykush/scraps",
-  "agents": [
-    {
-      "name": "scraps-writer",
-      "description": "Create Scraps documentation with Wiki-links and appropriate tags",
-      "prompt": "../agent.md"
-    }
-  ]
+  "repository": "https://github.com/boykush/scraps"
 }

--- a/plugins/scraps-writer/agents/scraps-writer.md
+++ b/plugins/scraps-writer/agents/scraps-writer.md
@@ -1,3 +1,9 @@
+---
+name: scraps-writer
+description: Create Scraps documentation with intelligent tag selection and backlink suggestions
+model: sonnet
+---
+
 # Scraps Writer Agent
 
 You are a specialized agent for creating Scraps documentation with Wiki-link notation.
@@ -22,7 +28,8 @@ When a user requests to create a new scrap:
 2. **Research Existing Tags**
    - Use `list_tags` to get available tags
    - Analyze which tags are most relevant to the topic
-   - Consider tag backlinks count to understand their importance in the knowledge base
+   - Consider tag backlinks count to understand their importance in the
+     knowledge base
 
 3. **Search Related Scraps**
    - Use `search_scraps` to find related content


### PR DESCRIPTION
## Summary

Fix validation error in the scraps-writer plugin by restructuring it to follow the official Claude Code plugin format.

## Problem

The plugin was throwing a validation error:
```
Plugin scraps-writer has an invalid manifest file at .claude-plugin/plugin.json
Validation errors: agents: Invalid input
```

## Solution

Restructured the plugin to match the [feature-dev reference implementation](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev):

### Changes

- ✅ Move `agent.md` → `agents/scraps-writer.md`
- ✅ Add YAML front matter to agent definition:
  ```yaml
  ---
  name: scraps-writer
  description: Create Scraps documentation with intelligent tag selection and backlink suggestions
  model: sonnet
  ---
  ```
- ✅ Remove invalid `agents` array from `plugin.json`
- ✅ Fix markdown linting (line length issue)
- ✅ Update marketplace version to `1.1.1`

### New Structure

```
plugins/scraps-writer/
├── .claude-plugin/
│   └── plugin.json      # Plugin metadata only (no agents field)
└── agents/
    └── scraps-writer.md # Agent definition with YAML front matter
```

## Test Plan

- [x] Plugin structure matches feature-dev reference
- [x] YAML front matter includes required fields (name, description, model)
- [x] plugin.json contains no invalid agents array
- [x] Markdown passes linting
- [x] Marketplace version bumped appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)