### PR TITLE
feat: enable scraps-writer and mcp-server plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "enabledPlugins": {
-    "commit-commands@claude-code-plugins": true
+    "commit-commands@claude-code-plugins": true,
+    "mcp-server@scraps-claude-code-plugins": true,
+    "scraps-writer@scraps-claude-code-plugins": true
   },
   "hooks": {
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- Enabled `scraps-writer@scraps-claude-code-plugins` plugin for enhanced Scraps documentation authoring
- Enabled `mcp-server@scraps-claude-code-plugins` plugin for MCP server integration
- Updated `.claude/settings.json` to include both plugins in the enabled plugins list

## Test plan
- [ ] Verify Claude Code recognizes the enabled plugins
- [ ] Test scraps-writer plugin functionality
- [ ] Test mcp-server plugin functionality
- [ ] Confirm no conflicts with existing commit-commands plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)