### PR TITLE
feat: add MCP server integration to scraps-writer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Scraps - MCP server integration for interconnected Markdown documentation",
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "plugins": [
     {

--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "email": "boykush315@gmail.com"
   },
   "homepage": "https://boykush.github.io/scraps",
-  "repository": "https://github.com/boykush/scraps"
+  "repository": "https://github.com/boykush/scraps",
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/scraps-writer/.mcp.json
+++ b/plugins/scraps-writer/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "scraps": {
+      "command": "scraps",
+      "args": ["mcp", "serve", "--path", "${SCRAPS_PROJECT_PATH:-.}"],
+      "env": {
+        "SCRAPS_PROJECT_PATH": "${SCRAPS_PROJECT_PATH}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Added MCP server integration to scraps-writer plugin for independent operation
- Copied `.mcp.json` from mcp-server plugin to enable auto-start functionality
- Bumped marketplace version to 1.1.2

## Motivation

The scraps-writer plugin depends on the Scraps MCP server tools (search_scraps, list_tags, etc.) provided by the mcp-server plugin. Since Claude Code doesn't yet support native plugin dependencies ([issue #9444](https://github.com/anthropics/claude-code/issues/9444)), this change allows scraps-writer to function independently by bundling its own MCP server configuration.

## Changes

- **plugins/scraps-writer/.mcp.json**: Copied from mcp-server plugin
- **plugins/scraps-writer/.claude-plugin/plugin.json**: Added `"mcpServers": "./.mcp.json"`
- **.claude-plugin/marketplace.json**: Version bump 1.1.1 → 1.1.2

## MCP Server Duplication Handling

When both mcp-server and scraps-writer plugins are enabled, the same MCP server will be configured twice. This is safe because both use the same command and Claude Code handles lifecycle appropriately.

## Test Plan

- [x] Verify `.mcp.json` is correctly copied
- [x] Confirm `plugin.json` references `.mcp.json`
- [x] Validate marketplace version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)