### PR TITLE
refactor: encapsulate Content model fields with getters

### DIFF
--- a/modules/libs/src/model/content.rs
+++ b/modules/libs/src/model/content.rs
@@ -4,18 +4,22 @@ use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Content {
-    pub elements: Vec<ContentElement>,
+    elements: Vec<ContentElement>,
 }
 
 impl Content {
     pub fn new(elements: Vec<ContentElement>) -> Self {
         Self { elements }
     }
+
+    pub fn elements(&self) -> &[ContentElement] {
+        &self.elements
+    }
 }
 
 impl fmt::Display for Content {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for element in &self.elements {
+        for element in self.elements() {
             write!(f, "{element}")?;
         }
         Ok(())

--- a/src/usecase/build/html/serde/content.rs
+++ b/src/usecase/build/html/serde/content.rs
@@ -1,5 +1,6 @@
 use scraps_libs::model::content::{Content, ContentElement};
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use url::Url;
 
 fn serialize_content_element<S>(element: &ContentElement, serializer: S) -> Result<S::Ok, S::Error>
@@ -31,29 +32,25 @@ struct ContentElementAutolink {
 #[derive(Serialize)]
 struct ContentElementTera(#[serde(serialize_with = "serialize_content_element")] ContentElement);
 
-#[derive(Serialize)]
-#[serde(remote = "Content")]
-pub struct SerializeContent {
-    #[serde(serialize_with = "serialize_content_elements")]
-    elements: Vec<ContentElement>,
-}
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentTera(Content);
 
-fn serialize_content_elements<S>(
-    elements: &[ContentElement],
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    let serialized_elements: Vec<ContentElementTera> = elements
-        .iter()
-        .map(|element| ContentElementTera(element.clone()))
-        .collect();
-    serialized_elements.serialize(serializer)
+impl Serialize for ContentTera {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Content", 1)?;
+        let elements: Vec<ContentElementTera> = self
+            .0
+            .elements()
+            .iter()
+            .map(|element| ContentElementTera(element.clone()))
+            .collect();
+        state.serialize_field("elements", &elements)?;
+        state.end()
+    }
 }
-
-#[derive(Serialize, Clone, PartialEq, Debug)]
-pub struct ContentTera(#[serde(with = "SerializeContent")] Content);
 
 impl From<Content> for ContentTera {
     fn from(content: Content) -> Self {


### PR DESCRIPTION
## Summary

This PR implements proper encapsulation for the `Content` model by making the `elements` field private and adding an appropriate getter method, following the same pattern established in PR #291 for Scrap and Tag models.

## Changes

### Model Updates
- **Content model** (`modules/libs/src/model/content.rs`):
  - Made `elements` field private
  - Added `elements() -> &[ContentElement]` getter (returns slice, not Vec reference)
  - Updated Display impl to use `elements()` getter

### Serialization Updates
- **ContentTera** (`src/usecase/build/html/serde/content.rs`):
  - Replaced serde remote pattern with custom `Serialize` implementation
  - Uses `elements()` getter to access the private field
  - Maintains same serialization output format

## Design Decision: Minimal API Surface

Initially considered adding convenience methods (`len()`, `is_empty()`, `iter()`), but verification showed these methods were not being used anywhere in the codebase. Following the principle of minimal API surface, only the `elements()` getter was retained.

## Benefits

✅ **Encapsulation**: Prevents direct field access, enabling future internal changes without breaking APIs  
✅ **Type Safety**: Immutable references prevent accidental modifications  
✅ **Rust Idioms**: Returns slices (`&[T]`) instead of vector references (`&Vec<T>`)  
✅ **Consistency**: Aligns with existing `Scrap`, `Tag`, `Title` patterns from PR #291  
✅ **Minimal API**: Only exposes what's actually needed  
✅ **Performance**: Zero overhead - getter is inlined by the compiler  

## Testing

- ✅ All 104 tests passing (61 lib tests + 43 bin tests)
- ✅ Build successful
- ✅ `cargo fmt` clean
- ✅ `cargo clippy` clean (only pre-existing warnings)

## Pattern Consistency

This continues the encapsulation pattern from PR #291:
- **Scrap model**: `links() -> &[ScrapKey]`, `md_text() -> &str`, `title() -> &Title`
- **Tag model**: `title() -> &Title`
- **Content model**: `elements() -> &[ContentElement]`

## Notes

This is technically a breaking change for external users of `scraps_libs`, but since the library is workspace-internal only, there's no actual impact. The project is at version 0.27.2 (pre-1.0), so breaking changes are acceptable per semantic versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)