### PR TITLE
refactor: apply rstest fixtures to fuzzy_engine tests

### DIFF
--- a/modules/libs/src/search/fuzzy_engine.rs
+++ b/modules/libs/src/search/fuzzy_engine.rs
@@ -66,8 +66,10 @@ impl SearchEngine for FuzzySearchEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::{fixture, rstest};
 
-    fn create_test_items() -> Vec<SearchItem> {
+    #[fixture]
+    fn search_items() -> Vec<SearchItem> {
         vec![
             SearchItem::new("Test Document"),
             SearchItem::new("Another Document"),
@@ -78,90 +80,82 @@ mod tests {
         ]
     }
 
-    #[test]
-    fn test_fuzzy_search_engine_new() {
+    #[rstest]
+    fn test_fuzzy_search_engine_new(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
-        let results = engine.search(&items, "test", 100);
+        let results = engine.search(&search_items, "test", 100);
 
         assert!(!results.is_empty());
-        assert!(results.len() <= items.len());
+        assert!(results.len() <= search_items.len());
     }
 
-    #[test]
-    fn test_fuzzy_search_exact_match() {
+    #[rstest]
+    fn test_fuzzy_search_exact_match(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
-        let results = engine.search(&items, "Test Document", 100);
+        let results = engine.search(&search_items, "Test Document", 100);
 
         assert!(!results.is_empty());
         assert_eq!(results[0].title, "Test Document");
     }
 
-    #[test]
-    fn test_fuzzy_search_typo_tolerance() {
+    #[rstest]
+    fn test_fuzzy_search_typo_tolerance(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
         // Test with smaller typos that are more likely to match
-        let results = engine.search(&items, "tes", 100);
+        let results = engine.search(&search_items, "tes", 100);
         assert!(!results.is_empty());
 
-        let results = engine.search(&items, "doc", 100);
-        assert!(!results.is_empty());
-    }
-
-    #[test]
-    fn test_fuzzy_search_partial_match() {
-        let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
-
-        let results = engine.search(&items, "doc", 100);
-        assert!(!results.is_empty());
-
-        let results = engine.search(&items, "fram", 100);
+        let results = engine.search(&search_items, "doc", 100);
         assert!(!results.is_empty());
     }
 
-    #[test]
-    fn test_fuzzy_search_ordering() {
+    #[rstest]
+    fn test_fuzzy_search_partial_match(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
-        let results = engine.search(&items, "test", 100);
+        let results = engine.search(&search_items, "doc", 100);
+        assert!(!results.is_empty());
+
+        let results = engine.search(&search_items, "fram", 100);
+        assert!(!results.is_empty());
+    }
+
+    #[rstest]
+    fn test_fuzzy_search_ordering(search_items: Vec<SearchItem>) {
+        let engine = FuzzySearchEngine::new();
+
+        let results = engine.search(&search_items, "test", 100);
         assert!(!results.is_empty());
 
         let titles: Vec<&str> = results.iter().map(|r| r.title.as_str()).collect();
         assert!(titles.contains(&"Test Document") || titles.contains(&"Sample Test"));
     }
 
-    #[test]
-    fn test_fuzzy_search_empty_query() {
+    #[rstest]
+    fn test_fuzzy_search_empty_query(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
-        let results = engine.search(&items, "", 100);
-        assert_eq!(results.len(), items.len());
+        let results = engine.search(&search_items, "", 100);
+        assert_eq!(results.len(), search_items.len());
     }
 
-    #[test]
-    fn test_fuzzy_search_no_match() {
+    #[rstest]
+    fn test_fuzzy_search_no_match(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
-        let results = engine.search(&items, "xyzzyx", 100);
+        let results = engine.search(&search_items, "xyzzyx", 100);
         assert_eq!(results.len(), 0);
     }
 
-    #[test]
-    fn test_fuzzy_search_case_insensitive() {
+    #[rstest]
+    fn test_fuzzy_search_case_insensitive(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
         // Test with exact matches first
-        let results1 = engine.search(&items, "test", 100);
-        let results2 = engine.search(&items, "Test", 100);
-        let results3 = engine.search(&items, "doc", 100);
+        let results1 = engine.search(&search_items, "test", 100);
+        let results2 = engine.search(&search_items, "Test", 100);
+        let results3 = engine.search(&search_items, "doc", 100);
 
         // These should all return results since SkimMatcherV2 is case-insensitive by default
         assert!(!results1.is_empty());
@@ -169,17 +163,16 @@ mod tests {
         assert!(!results3.is_empty());
     }
 
-    #[test]
-    fn test_fuzzy_search_case_sensitive() {
+    #[rstest]
+    fn test_fuzzy_search_case_sensitive(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::with_case_sensitive(true);
-        let items = create_test_items();
 
         // Test with exact case matches
-        let results = engine.search(&items, "Test", 100);
+        let results = engine.search(&search_items, "Test", 100);
         assert!(!results.is_empty());
 
         // Even case sensitive should find some matches
-        let results = engine.search(&items, "Document", 100);
+        let results = engine.search(&search_items, "Document", 100);
         assert!(!results.is_empty());
     }
 
@@ -225,35 +218,32 @@ mod tests {
         assert_eq!(results.len(), 0);
     }
 
-    #[test]
-    fn test_fuzzy_search_num_larger_than_available() {
+    #[rstest]
+    fn test_fuzzy_search_num_larger_than_available(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items(); // 6 items
 
-        let results = engine.search(&items, "test", 10);
+        let results = engine.search(&search_items, "test", 10);
         // All items contain "test" in some form, so this should return all matching items
         assert!(results.len() <= 6);
         assert!(!results.is_empty());
     }
 
-    #[test]
-    fn test_fuzzy_search_empty_query_with_custom_num() {
+    #[rstest]
+    fn test_fuzzy_search_empty_query_with_custom_num(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items(); // 6 items
 
-        let results = engine.search(&items, "", 3);
+        let results = engine.search(&search_items, "", 3);
         assert_eq!(results.len(), 3);
 
-        let results = engine.search(&items, "", 10);
+        let results = engine.search(&search_items, "", 10);
         assert_eq!(results.len(), 6); // All items returned
     }
 
-    #[test]
-    fn test_fuzzy_search_results_content() {
+    #[rstest]
+    fn test_fuzzy_search_results_content(search_items: Vec<SearchItem>) {
         let engine = FuzzySearchEngine::new();
-        let items = create_test_items();
 
-        let results = engine.search(&items, "test", 100);
+        let results = engine.search(&search_items, "test", 100);
         assert!(!results.is_empty());
 
         for result in results {


### PR DESCRIPTION
## Summary

- Replace `create_test_items()` helper function with rstest `search_items` fixture
- Convert 13 tests from `#[test]` to `#[rstest]` using the fixture pattern
- Keep 2 tests with custom item creation as `#[test]` (appropriate for their use case)

## Changes

### Before
```rust
fn create_test_items() -> Vec<SearchItem> { ... }

#[test]
fn test_fuzzy_search_engine_new() {
    let items = create_test_items();
    let results = engine.search(&items, "test", 100);
    ...
}
```

### After
```rust
#[fixture]
fn search_items() -> Vec<SearchItem> { ... }

#[rstest]
fn test_fuzzy_search_engine_new(search_items: Vec<SearchItem>) {
    let results = engine.search(&search_items, "test", 100);
    ...
}
```

## Benefits

- **Code reduction**: Removed repetitive `create_test_items()` calls from each test
- **Consistency**: Unified test data provision using rstest fixture pattern
- **Maintainability**: Test data changes only need to be made in one place (the fixture)
- **Readability**: Test intent is clearer without setup noise

## Test Results

All 15 tests pass:
- 13 tests converted to use `search_items` fixture
- 2 tests kept as `#[test]` (they create custom items specific to their test cases)

```
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)