### PR TITLE
refactor: use public_path helper in test fixtures

### DIFF
--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -83,7 +83,7 @@ mod tests {
         let render = SearchIndexRender::new(&project.static_dir, &project.public_dir).unwrap();
         render.run(&base_url, &scraps).unwrap();
 
-        let result = fs::read_to_string(project.public_dir.join("search_index.json")).unwrap();
+        let result = fs::read_to_string(project.public_path("search_index.json")).unwrap();
         assert_eq!(
             result,
             "[{ \"title\": \"scrap1\", \"url\": \"http://localhost:1112/scraps/scrap1.html\" },{ \"title\": \"Context/scrap2\", \"url\": \"http://localhost:1112/scraps/scrap2.context.html\" }]");

--- a/src/usecase/build/css/render.rs
+++ b/src/usecase/build/css/render.rs
@@ -58,7 +58,7 @@ mod tests {
         let render = CSSRender::new(&project.static_dir, &project.public_dir);
         render.render_main(css_metadata).unwrap();
 
-        let result = fs::read_to_string(project.public_dir.join("main.css")).unwrap();
+        let result = fs::read_to_string(project.public_path("main.css")).unwrap();
         assert_eq!(result, ":root { color-scheme: light dark;}");
     }
 }

--- a/src/usecase/build/html/index_render.rs
+++ b/src/usecase/build/html/index_render.rs
@@ -209,7 +209,7 @@ mod tests {
             )
             .unwrap();
 
-        let result = fs::read_to_string(project.public_dir.join("index.html")).unwrap();
+        let result = fs::read_to_string(project.public_path("index.html")).unwrap();
         assert_eq!(
             result,
             "true<a href=\"./scrap1.html\">scrap1</a><a href=\"./scrap2.html\">scrap2</a>"
@@ -264,13 +264,13 @@ mod tests {
             )
             .unwrap();
 
-        let index_result = fs::read_to_string(project.public_dir.join("index.html")).unwrap();
+        let index_result = fs::read_to_string(project.public_path("index.html")).unwrap();
         assert_eq!(
             index_result,
             "true<a href=\"./scrap1.html\">scrap1</a><a href=\"./scrap2.html\">scrap2</a>"
         );
 
-        let page2_result = fs::read_to_string(project.public_dir.join("2.html")).unwrap();
+        let page2_result = fs::read_to_string(project.public_path("2.html")).unwrap();
         assert_eq!(
             page2_result,
             "true<a href=\"./scrap3.html\">scrap3</a><a href=\"./scrap4.html\">scrap4</a>"

--- a/src/usecase/build/html/tags_index_render.rs
+++ b/src/usecase/build/html/tags_index_render.rs
@@ -101,7 +101,7 @@ mod tests {
         let render = TagsIndexRender::new(&project.static_dir, &project.public_dir).unwrap();
         render.run(&base_url, &metadata, &scraps).unwrap();
 
-        let result1 = fs::read_to_string(project.public_dir.join("tags/index.html")).unwrap();
+        let result1 = fs::read_to_string(project.public_path("tags/index.html")).unwrap();
         assert_eq!(
             result1,
             "<a href=\"./tag1.html\">tag1</a><a href=\"./tag2.html\">tag2</a>"

--- a/src/usecase/build/usecase.rs
+++ b/src/usecase/build/usecase.rs
@@ -261,31 +261,31 @@ mod tests {
         assert_eq!(result1, 2);
 
         // Verify scrap1 HTML generated
-        let result2 = fs::read_to_string(project.public_dir.join("scraps/test1.html")).unwrap();
+        let result2 = fs::read_to_string(project.public_path("scraps/test1.html")).unwrap();
         assert!(!result2.is_empty());
 
         // Verify scrap2 HTML generated
-        let result3 = fs::read_to_string(project.public_dir.join("scraps/test2.html")).unwrap();
+        let result3 = fs::read_to_string(project.public_path("scraps/test2.html")).unwrap();
         assert!(!result3.is_empty());
 
         // Verify non-markdown file excluded
-        let result4 = fs::read_to_string(project.public_dir.join("scraps/test3.html"));
+        let result4 = fs::read_to_string(project.public_path("scraps/test3.html"));
         assert!(result4.is_err());
 
         // Verify README.html not generated
-        let result5 = fs::read_to_string(project.public_dir.join("README.html"));
+        let result5 = fs::read_to_string(project.public_path("README.html"));
         assert!(result5.is_err());
 
         // Verify index.html generated
-        let result6 = fs::read_to_string(project.public_dir.join("index.html")).unwrap();
+        let result6 = fs::read_to_string(project.public_path("index.html")).unwrap();
         assert!(!result6.is_empty());
 
         // Verify CSS generated
-        let result7 = fs::read_to_string(project.public_dir.join("main.css")).unwrap();
+        let result7 = fs::read_to_string(project.public_path("main.css")).unwrap();
         assert!(!result7.is_empty());
 
         // Verify search index JSON generated
-        let result8 = fs::read_to_string(project.public_dir.join("search_index.json")).unwrap();
+        let result8 = fs::read_to_string(project.public_path("search_index.json")).unwrap();
         assert!(!result8.is_empty());
     }
 
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(result1, 2);
 
         // Verify search index JSON not generated
-        let result2 = fs::read_to_string(project.public_dir.join("search_index.json"));
+        let result2 = fs::read_to_string(project.public_path("search_index.json"));
         assert!(result2.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Replaced 14 occurrences of `project.public_dir.join()` with `project.public_path()` across test files
- Improves code readability and consistency in test fixtures
- Demonstrates the utility of the `public_path` helper method in `TempScrapProject`

## Test plan

- [x] All existing tests pass (`mise run cargo:test`)
- [x] No functional changes, only refactoring for better code quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)