### PR TITLE
refactor: make base_url optional for MCP server

### DIFF
--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -25,15 +25,13 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to resolve paths: {e}")))?;
 
-    // Load config to get base_url
+    // Load config to get scraps_dir
     let config = ScrapConfig::from_path(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to load config: {e}")))?;
 
     let scraps_dir = path_resolver.scraps_dir(&config);
 
-    let base_url = config.base_url.into_base_url();
-
-    let service = ScrapsServer::new(scraps_dir, base_url)
+    let service = ScrapsServer::new(scraps_dir)
         .serve((stdin(), stdout()))
         .await
         .inspect_err(|e| {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -14,7 +14,7 @@ pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult
     let base_url = config.base_url.into_base_url();
 
     let search_usecase = SearchUsecase::new(&scraps_dir_path);
-    let results = search_usecase.execute(&base_url, query, num)?;
+    let results = search_usecase.execute(Some(&base_url), query, num)?;
 
     if results.is_empty() {
         println!("No results found for query: {query}");

--- a/src/cli/display/search.rs
+++ b/src/cli/display/search.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 
 pub struct DisplaySearch {
     title: String,
-    url: String,
+    url: Option<String>,
 }
 
 impl DisplaySearch {
@@ -20,9 +20,13 @@ impl DisplaySearch {
 impl fmt::Display for DisplaySearch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let title_str = self.title.bold();
-        let url_str = self.url.blue();
 
-        let search_str = format!("{title_str} {url_str}");
+        let search_str = if let Some(url) = &self.url {
+            let url_str = url.blue();
+            format!("{title_str} {url_str}")
+        } else {
+            format!("{title_str}")
+        };
 
         write!(f, "{search_str}")
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -11,20 +11,17 @@ use rmcp::handler::server::ServerHandler;
 use rmcp::model::{CallToolResult, ServerCapabilities, ServerInfo};
 use rmcp::service::RequestContext;
 use rmcp::{tool, tool_handler, tool_router, ErrorData, RoleServer};
-use scraps_libs::model::base_url::BaseUrl;
 
 pub struct ScrapsServer {
     tool_router: ToolRouter<ScrapsServer>,
     scraps_dir: PathBuf,
-    base_url: BaseUrl,
 }
 
 impl ScrapsServer {
-    pub fn new(scraps_dir: PathBuf, base_url: BaseUrl) -> Self {
+    pub fn new(scraps_dir: PathBuf) -> Self {
         Self {
             tool_router: Self::tool_router(),
             scraps_dir,
-            base_url,
         }
     }
 }
@@ -39,7 +36,7 @@ impl ScrapsServer {
         context: RequestContext<RoleServer>,
         parameters: Parameters<SearchRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        search_scraps(&self.scraps_dir, &self.base_url, context, parameters).await
+        search_scraps(&self.scraps_dir, context, parameters).await
     }
 
     #[tool(

--- a/src/mcp/tools/search_scraps.rs
+++ b/src/mcp/tools/search_scraps.rs
@@ -6,7 +6,6 @@ use rmcp::model::{CallToolResult, Content};
 use rmcp::schemars::JsonSchema;
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer};
-use scraps_libs::model::base_url::BaseUrl;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -27,17 +26,16 @@ pub struct SearchResponse {
 
 pub async fn search_scraps(
     scraps_dir: &PathBuf,
-    base_url: &BaseUrl,
     _context: RequestContext<RoleServer>,
     Parameters(request): Parameters<SearchRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     // Create search usecase
     let search_usecase = SearchUsecase::new(scraps_dir);
 
-    // Execute search
+    // Execute search without base_url (MCP server doesn't need URLs)
     let num = request.num.unwrap_or(100);
     let results = search_usecase
-        .execute(base_url, &request.query, num)
+        .execute(None, &request.query, num)
         .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("Search failed: {e}"), None))?;
 
     // Convert results to structured response


### PR DESCRIPTION
## Summary

Make `base_url` optional in `SearchUsecase` to support MCP server usage without requiring SSG-related URL generation.

## Changes

- Change `SearchResult.url` from `String` to `Option<String>`
- Make `base_url` parameter optional in `SearchUsecase::execute`
- Remove `base_url` dependency from MCP `ScrapsServer`
- MCP `search_scraps` now executes search without generating URLs
- `search` command continues to provide URLs for CLI output
- Update `DisplaySearch` to handle optional URLs

## Motivation

The MCP server should focus on providing document content to clients (like Claude Code) without coupling to SSG deployment URLs. 

**Note**: The MCP server response format (`ScrapJson`) has never included URL fields - this PR simply removes the unnecessary URL generation that was happening internally but never used in the response.

This change:

1. **Decouples MCP from SSG**: MCP server no longer needs SSG configuration (`base_url` in Config.toml)
2. **Removes unnecessary computation**: Stops generating URLs that were never included in MCP responses
3. **Simplifies configuration**: `mcp serve` can run with minimal config requirements
4. **Focuses on content**: MCP workflow now explicitly omits URL generation
5. **Maintains CLI functionality**: The `search` command still provides URLs for terminal usage

## Impact

- **No breaking changes**: MCP response format remains unchanged
- **Performance improvement**: Eliminates unnecessary URL generation for MCP workflows
- **Configuration simplification**: MCP server will eventually not require `base_url` in Config.toml (future work)

## Test plan

- [x] All existing tests pass
- [x] Updated tests to handle optional URLs
- [x] MCP server no longer generates unused URLs
- [x] CLI search command continues to show URLs
- [x] Quality checks (build, test, fmt, clippy) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)