### PR TITLE
refactor: make base_url optional for tag command display

### DIFF
--- a/src/cli/cmd/tag.rs
+++ b/src/cli/cmd/tag.rs
@@ -20,7 +20,7 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let (tags, backlinks_map) = usecase.execute()?;
     let display_tags_result = tags
         .into_iter()
-        .map(|tag| DisplayTag::new(&tag, &base_url, &backlinks_map))
+        .map(|tag| DisplayTag::new(&tag, Some(&base_url), &backlinks_map))
         .collect::<ScrapsResult<Vec<DisplayTag>>>();
 
     display_tags_result.map(|tags| {


### PR DESCRIPTION
## Summary

Make `base_url` optional in `DisplayTag` to support flexible URL generation for the tag command.

## Changes

- Change `DisplayTag.url` from `Url` to `Option<Url>`
- Make `base_url` parameter optional in `DisplayTag::new`
- Update `Display` implementation to handle optional URLs (shows only title+count when URL is absent)
- `tag` command continues to provide URLs for CLI output

## Motivation

This follows the same pattern as the search command refactoring (#306), preparing for:

1. **Future MCP server usage**: Tag listing functionality may be added to MCP server where URLs are not needed
2. **Consistency**: Matches the approach taken for search results
3. **Flexibility**: Allows tag display without requiring SSG configuration

## Relationship to Other Work

This PR builds on the pattern established in #306 (search command refactoring) and prepares the codebase for making `base_url` and `title` conditionally optional in Config.toml based on command type (SSG vs non-SSG commands).

## Test plan

- [x] All existing tests pass
- [x] Tag command continues to display URLs in CLI
- [x] Quality checks (build, test, fmt, clippy) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)