### PR TITLE
feat: display local file paths in search command

### DIFF
--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -11,16 +11,23 @@ pub fn run(query: &str, num: usize, project_path: Option<&Path>) -> ScrapsResult
     let config = ScrapConfig::from_path(project_path)?;
     let scraps_dir_path = path_resolver.scraps_dir(&config);
 
-    let base_url = config.base_url.into_base_url();
-
     let search_usecase = SearchUsecase::new(&scraps_dir_path);
-    let results = search_usecase.execute(Some(&base_url), query, num)?;
+    let results = search_usecase.execute(query, num)?;
 
     if results.is_empty() {
         println!("No results found for query: {query}");
     } else {
         for result in results {
-            let display_search = DisplaySearch::new(&result);
+            // Construct file path from title and ctx
+            let file_path = if let Some(ctx) = &result.ctx {
+                scraps_dir_path
+                    .join(ctx.to_string())
+                    .join(format!("{}.md", result.title))
+            } else {
+                scraps_dir_path.join(format!("{}.md", result.title))
+            };
+
+            let display_search = DisplaySearch::new_with_file_path(&result, &file_path);
             println!("{display_search}");
         }
     }

--- a/src/cli/display/search.rs
+++ b/src/cli/display/search.rs
@@ -1,18 +1,20 @@
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 use crate::usecase::search::usecase::SearchResult;
 use colored::Colorize;
+use url::Url;
 
 pub struct DisplaySearch {
     title: String,
-    url: Option<String>,
+    file_path: PathBuf,
 }
 
 impl DisplaySearch {
-    pub fn new(search_result: &SearchResult) -> Self {
+    pub fn new_with_file_path(search_result: &SearchResult, file_path: &Path) -> Self {
         DisplaySearch {
             title: search_result.title.to_string(),
-            url: search_result.url.clone(),
+            file_path: file_path.to_path_buf(),
         }
     }
 }
@@ -21,13 +23,15 @@ impl fmt::Display for DisplaySearch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let title_str = self.title.bold();
 
-        let search_str = if let Some(url) = &self.url {
-            let url_str = url.blue();
-            format!("{title_str} {url_str}")
+        // Convert file path to properly encoded file:// URL
+        // This handles spaces and special characters correctly
+        let file_url_str = if let Ok(url) = Url::from_file_path(&self.file_path) {
+            url.to_string().blue()
         } else {
-            format!("{title_str}")
+            // Fallback to display if URL conversion fails
+            self.file_path.display().to_string().blue()
         };
 
-        write!(f, "{search_str}")
+        write!(f, "{title_str} {file_url_str}")
     }
 }

--- a/src/mcp/tools/search_scraps.rs
+++ b/src/mcp/tools/search_scraps.rs
@@ -32,10 +32,10 @@ pub async fn search_scraps(
     // Create search usecase
     let search_usecase = SearchUsecase::new(scraps_dir);
 
-    // Execute search without base_url (MCP server doesn't need URLs)
+    // Execute search
     let num = request.num.unwrap_or(100);
     let results = search_usecase
-        .execute(None, &request.query, num)
+        .execute(&request.query, num)
         .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("Search failed: {e}"), None))?;
 
     // Convert results to structured response


### PR DESCRIPTION
## Summary

Change the search command to display local file paths with proper URL encoding instead of SSG URLs.

## Changes

- Remove `base_url` dependency from `SearchUsecase`
- `SearchResult` no longer includes `url` field
- `DisplaySearch` now uses `file_path` with proper URL encoding via `Url::from_file_path`
- Search command constructs file paths from title and ctx
- MCP server search simplified (no URL generation overhead)

## Benefits

- Search command shows clickable `file://` URLs for local files
- Spaces and special characters properly encoded (`%20`, etc.)
- Cross-platform file URL support (Windows/Unix paths)
- Cleaner separation: SSG URLs only needed for build/serve commands
- Simplified search usecase with no URL generation overhead

## Testing

All tests pass:
- Unit tests for SearchUsecase
- Integration tests for duplicate title handling
- Quality checks (build, test, fmt, clippy)

## Related

This change continues the work from #306 and #307 to make base_url optional for non-SSG commands.