### PR TITLE
feat: make title and base_url optional in Config.toml with command-le…

### DIFF
--- a/modules/libs/src/model/base_url.rs
+++ b/modules/libs/src/model/base_url.rs
@@ -1,7 +1,7 @@
 use url::Url;
 
 /// A wrapper around URL that ensures proper trailing slash normalization
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BaseUrl(Url);
 
 impl BaseUrl {

--- a/src/cli/cmd/build.rs
+++ b/src/cli/cmd/build.rs
@@ -45,18 +45,14 @@ pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> Scraps
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
-    let base_url = config.base_url.into_base_url();
+    let base_url = config.require_base_url()?;
+    let title = config.require_title()?;
     let lang_code = config
         .lang_code
         .map(|c| c.into_lang_code())
         .unwrap_or_default();
     let timezone = config.timezone.unwrap_or(chrono_tz::UTC);
-    let html_metadata = HtmlMetadata::new(
-        &lang_code,
-        &config.title,
-        &config.description,
-        &config.favicon,
-    );
+    let html_metadata = HtmlMetadata::new(&lang_code, &title, &config.description, &config.favicon);
     let css_metadata = CssMetadata::new(&config.color_scheme.map_or_else(
         || ColorScheme::OsSetting,
         ColorSchemeConfig::into_color_scheme,

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -38,17 +38,13 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
 
     let git_command = GitCommandImpl::new();
     let progress = ProgressImpl::init(Instant::now());
+    let title = config.require_title()?;
     let lang_code = config
         .lang_code
         .map(|c| c.into_lang_code())
         .unwrap_or_default();
     let timezone = config.timezone.unwrap_or(chrono_tz::UTC);
-    let html_metadata = HtmlMetadata::new(
-        &lang_code,
-        &config.title,
-        &config.description,
-        &config.favicon,
-    );
+    let html_metadata = HtmlMetadata::new(&lang_code, &title, &config.description, &config.favicon);
     let css_metadata = CssMetadata::new(&config.color_scheme.map_or_else(
         || ColorScheme::OsSetting,
         ColorSchemeConfig::into_color_scheme,

--- a/src/cli/cmd/tag.rs
+++ b/src/cli/cmd/tag.rs
@@ -15,12 +15,12 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let scraps_dir_path = path_resolver.scraps_dir(&config);
     let usecase = ListTagUsecase::new(&scraps_dir_path);
 
-    let base_url = config.base_url.into_base_url();
+    let base_url = config.get_base_url();
 
     let (tags, backlinks_map) = usecase.execute()?;
     let display_tags_result = tags
         .into_iter()
-        .map(|tag| DisplayTag::new(&tag, Some(&base_url), &backlinks_map))
+        .map(|tag| DisplayTag::new(&tag, base_url.as_ref(), &backlinks_map))
         .collect::<ScrapsResult<Vec<DisplayTag>>>();
 
     display_tags_result.map(|tags| {

--- a/src/cli/config/base_url.rs
+++ b/src/cli/config/base_url.rs
@@ -2,7 +2,7 @@ use scraps_libs::model::base_url::BaseUrl;
 use serde::de::{self, Deserialize, Deserializer};
 use url::Url;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BaseUrlConfig(BaseUrl);
 
 impl<'de> Deserialize<'de> for BaseUrlConfig {

--- a/src/cli/config/scrap_config.rs
+++ b/src/cli/config/scrap_config.rs
@@ -2,6 +2,7 @@ use crate::cli::path_resolver::PathResolver;
 use crate::error::{anyhow::Context, CliError, ScrapsResult};
 use chrono_tz::Tz;
 use config::Config;
+use scraps_libs::model::base_url::BaseUrl;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use url::Url;
@@ -13,8 +14,8 @@ use super::{
 
 #[derive(Debug, Deserialize)]
 pub struct ScrapConfig {
-    pub base_url: BaseUrlConfig,
-    pub title: String,
+    pub base_url: Option<BaseUrlConfig>,
+    pub title: Option<String>,
     pub scraps_dir: Option<PathBuf>,
     pub lang_code: Option<LangCodeConfig>,
     pub description: Option<String>,
@@ -39,5 +40,37 @@ impl ScrapConfig {
         config
             .try_deserialize::<ScrapConfig>()
             .context(CliError::ConfigLoad)
+    }
+
+    /// Validates that title is present and non-empty
+    pub fn require_title(&self) -> ScrapsResult<String> {
+        self.title
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                CliError::MissingRequiredConfig {
+                    field: "title".to_string(),
+                }
+                .into()
+            })
+    }
+
+    /// Validates that base_url is present
+    pub fn require_base_url(&self) -> ScrapsResult<BaseUrl> {
+        self.base_url
+            .as_ref()
+            .ok_or_else(|| {
+                CliError::MissingRequiredConfig {
+                    field: "base_url".to_string(),
+                }
+                .into()
+            })
+            .map(|config| config.clone().into_base_url())
+    }
+
+    /// Gets optional base_url if present
+    pub fn get_base_url(&self) -> Option<BaseUrl> {
+        self.base_url.as_ref().map(|c| c.clone().into_base_url())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,9 @@ pub enum CliError {
 
     #[error("Failed when load config")]
     ConfigLoad,
+
+    #[error("Missing required configuration field '{field}' in Config.toml. Please add '{field} = \"your-value\"' to your Config.toml file.")]
+    MissingRequiredConfig { field: String },
 }
 
 #[derive(Error, PartialEq, Debug)]

--- a/src/usecase/init/builtins/Config.toml
+++ b/src/usecase/init/builtins/Config.toml
@@ -1,8 +1,8 @@
-# The site base url
-base_url = "https://username.github.io/repository-name/"
+# The site base url (required for build and serve commands)
+# base_url = "https://username.github.io/repository-name/"
 
-# The site title
-title = ""
+# The site title (required for build and serve commands)
+# title = "My Site"
 
 # The scraps directory path relative to this Config.toml (optional, default=scraps)
 # scraps_dir = "scraps"


### PR DESCRIPTION
…vel validation

This change makes `title` and `base_url` optional fields in Config.toml, with validation performed at the command level based on each command's requirements.

Changes:
- Add Clone derive to BaseUrl and BaseUrlConfig
- Add MissingRequiredConfig error variant to CliError
- Make base_url and title optional in ScrapConfig
- Add validation helper methods (require_title, require_base_url, get_base_url)
- Update build command to validate both title and base_url
- Update serve command to validate title only (base_url is localhost)
- Update tag command to handle optional base_url gracefully
- Update default Config.toml template with clarified comments

Command requirements:
- build: requires both title and base_url
- serve: requires title only (base_url overridden to localhost)
- tag: base_url is optional (displays tags without URLs if missing)
- mcp: neither required
- template: neither required

<!-- 🙏 Thanks for your contribution! -->

## Summary

<!-- Brief description of what this PR does -->

## Related Issues

<!-- Optional: Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

<!-- Optional: Any additional information about the implementation or decisions made -->
<!-- 💡 Tip: You can attach screenshots by dragging & dropping them here -->