### PR TITLE
docs: update Config.toml requirements to SSG context

### DIFF
--- a/docs/Reference/Configuration.md
+++ b/docs/Reference/Configuration.md
@@ -6,13 +6,16 @@ See [[Tutorial/Configure Project]] for a quick setup guide.
 
 ## Configuration Variables
 
-Only the `base_url` and `title` variables are required. Everything else is optional. All configuration variables used by Scraps and their default values are listed below.
+The `base_url` and `title` variables are required when using Scraps as a static
+site generator (SSG). Other commands like `tag`, `mcp`, and `template` can work
+without these fields. All configuration variables used by Scraps and their
+default values are listed below.
 
 ```toml:Config.toml
-# The site base url
+# The site base url (required for SSG)
 base_url = "https://username.github.io/repository-name/"
 
-# The site title
+# The site title (required for SSG)
 title = ""
 
 # The scraps directory path relative to this Config.toml (optional, default=scraps)

--- a/docs/Tutorial/Configure Project.md
+++ b/docs/Tutorial/Configure Project.md
@@ -1,4 +1,5 @@
-To get started with your Scraps site, you need to edit at least two required fields in your `Config.toml` file.
+To use Scraps as a static site generator (SSG), you need to configure the
+`base_url` and `title` fields in your `Config.toml` file.
 
 ## Step 1: Edit base_url
 
@@ -18,6 +19,9 @@ title = "My Knowledge Base"
 
 ## Optional Configuration
 
-Only the `base_url` and `title` variables are required. Everything else is optional.
+The `base_url` and `title` variables are required when using Scraps as a static
+site generator (SSG). Other commands like `tag`, `mcp`, and `template` can work
+without these fields. All other configuration variables are optional.
 
-See [[Reference/Configuration]] for all available configuration variables and their default values.
+See [[Reference/Configuration]] for all available configuration variables and
+their default values.

--- a/docs/Tutorial/Getting Started.md
+++ b/docs/Tutorial/Getting Started.md
@@ -1,3 +1,5 @@
+This guide covers using Scraps as a static site generator (SSG).
+
 ## Setup
 
 1. **Install Scraps**


### PR DESCRIPTION
## Summary

- Updated documentation to clarify that `base_url` and `title` are required specifically for SSG usage (build/serve commands)
- Other commands (tag, mcp, template) can work without these fields
- Aligns documentation with recent code changes that made config fields optional with command-level validation

## Changes

- **Reference/Configuration.md**: Updated explanation to use SSG terminology instead of listing specific commands
- **Tutorial/Configure Project.md**: Clarified SSG context for required fields
- **Tutorial/Getting Started.md**: Added introductory note that guide covers SSG usage

## Context

This follows the implementation in #308 (assumed) that made `base_url` and `title` optional in `Config.toml` while adding validation at the command level. The documentation now accurately reflects this behavior and uses future-proof SSG terminology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)