### PR TITLE
chore: pin scraps-deploy-action to commit hash

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0 # For scraps git commited date
       - name: build_and_deploy
-        uses: boykush/scraps-deploy-action@v2
+        uses: boykush/scraps-deploy-action@fdcd6b2def03fa5e5a0b7b203a9c9fc69bbe1f6a # v2.1
         env:
           # Target branch
           PAGES_BRANCH: gh-pages


### PR DESCRIPTION
## Summary
- Pin `boykush/scraps-deploy-action` from tag reference (`v2`) to commit hash (`fdcd6b2def03fa5e5a0b7b203a9c9fc69bbe1f6a`)
- Add inline comment indicating v2.1 version for human readability

## Rationale
Using commit hashes instead of mutable tags improves security and ensures reproducible builds by preventing potential tag reassignment attacks.

## Test plan
- [ ] Verify GitHub Actions workflow syntax is valid
- [ ] Confirm workflow runs successfully on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)