### PR TITLE
chore: update scraps-deploy-action to v3

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -15,8 +15,7 @@ jobs:
         with:
           fetch-depth: 0 # For scraps git commited date
       - name: build_and_deploy
-        uses: boykush/scraps-deploy-action@7fd5a9ceeb34b46fd42ca20df8723297b9d659e9 # v2.2
-        env:
-          # Target branch
-          PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: boykush/scraps-deploy-action@75095c5e665928aa899ad45f60ecb4dbc295d05a # v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pages-branch: gh-pages

--- a/docs/How-to/Deploy to GitHub Pages.md
+++ b/docs/How-to/Deploy to GitHub Pages.md
@@ -2,7 +2,8 @@
 
 Custom actions are available to deploy Scraps to Github Pages.
 
-[scraps-deploy-action](https://github.com/boykush/scraps-deploy-action)
+- Repository: [scraps-deploy-action](https://github.com/boykush/scraps-deploy-action)
+- Marketplace: [Scraps Deploy to Pages](https://github.com/marketplace/actions/scraps-deploy-to-pages)
 
 ### YAML file
 
@@ -10,7 +11,7 @@ Prepare a yaml file under `.github/workflows/` like this
 
 ```yaml
 name: Deploy scraps github pages
-on: 
+on:
   push:
     branches:
       - main
@@ -21,15 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # For scraps git commited date
       - name: build_and_deploy
-        uses: boykush/scraps-deploy-action@v2
-        env:
-          # Target branch
-          PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: boykush/scraps-deploy-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pages-branch: gh-pages
 ```
 
 ### GitHub settings


### PR DESCRIPTION
## Summary
- Update scraps-deploy-action from v2.2 to v3
- Migrate from environment variables to action inputs
- Update actions/checkout from v5 to v6
- Add GitHub Marketplace link to documentation

## Changes
- `.github/workflows/deploy-scraps-github-pages.yml`: Updated to use v3 with new input format
- `docs/How-to/Deploy to GitHub Pages.md`: Updated example and added Marketplace link

## References
- https://github.com/marketplace/actions/scraps-deploy-to-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)