### PR TITLE
refactor: migrate tests to rstest fixture injection

### DIFF
--- a/src/cli/path_resolver.rs
+++ b/src/cli/path_resolver.rs
@@ -80,7 +80,8 @@ impl PathResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::SimpleTempDir;
+    use crate::test_fixtures::{simple_temp_dir, SimpleTempDir};
+    use rstest::rstest;
     use std::env;
 
     #[test]
@@ -91,9 +92,8 @@ mod tests {
         assert_eq!(resolver.project_root(), expected_root.as_path());
     }
 
-    #[test]
-    fn test_new_with_specified_path() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_new_with_specified_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_new");
 
         let test_project_path = temp_dir.path.join("test_project_new");
@@ -111,9 +111,8 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_scraps_dir_path_default() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_scraps_dir_path_default(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_scraps").add_file(
             "test_project_scraps/Config.toml",
             br#"
@@ -131,9 +130,8 @@ base_url = "http://example.com/"
         assert!(scraps_dir.starts_with(&test_project_path));
     }
 
-    #[test]
-    fn test_scraps_dir_path_custom() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_scraps_dir_path_custom(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_scraps_custom").add_file(
             "test_project_scraps_custom/Config.toml",
             br#"
@@ -152,9 +150,8 @@ scraps_dir = "custom_docs"
         assert!(scraps_dir.starts_with(&test_project_path));
     }
 
-    #[test]
-    fn test_static_dir_path() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_static_dir_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_static");
 
         let test_project_path = temp_dir.path.join("test_project_static");
@@ -164,9 +161,8 @@ scraps_dir = "custom_docs"
         assert!(static_dir.starts_with(&test_project_path));
     }
 
-    #[test]
-    fn test_public_dir_path() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_public_dir_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_public");
 
         let test_project_path = temp_dir.path.join("test_project_public");
@@ -176,9 +172,8 @@ scraps_dir = "custom_docs"
         assert!(public_dir.starts_with(&test_project_path));
     }
 
-    #[test]
-    fn test_templates_dir_path() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_templates_dir_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_templates");
 
         let test_project_path = temp_dir.path.join("test_project_templates");
@@ -188,9 +183,8 @@ scraps_dir = "custom_docs"
         assert!(templates_dir.starts_with(&test_project_path));
     }
 
-    #[test]
-    fn test_config_path() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn test_config_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         temp_dir.add_dir("test_project_config");
 
         let test_project_path = temp_dir.path.join("test_project_config");

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -56,17 +56,16 @@ impl SearchIndexRender {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
     use std::fs;
     use url::Url;
 
     use super::*;
     use scraps_libs::model::scrap::Scrap;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Add static search_index.json template
         project.add_static_file(
             "search_index.json",

--- a/src/usecase/build/css/render.rs
+++ b/src/usecase/build/css/render.rs
@@ -39,16 +39,15 @@ impl CSSRender {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
     use crate::usecase::build::model::color_scheme::ColorScheme;
+    use rstest::rstest;
 
     use super::*;
     use std::fs;
 
-    #[test]
-    fn test_render_main() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_render_main(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Add static CSS template
         project.add_static_file("main.css", b":root { color-scheme: {{ color_scheme }};}");
 

--- a/src/usecase/build/html/index_render.rs
+++ b/src/usecase/build/html/index_render.rs
@@ -160,7 +160,8 @@ impl IndexRender {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
     use std::fs;
     use url::Url;
 
@@ -171,10 +172,8 @@ mod tests {
     use scraps_libs::lang::LangCode;
     use scraps_libs::model::scrap::Scrap;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Add static index.html template
         project.add_static_file(
             "index.html",
@@ -216,10 +215,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn it_run_paging() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run_paging(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Add static index.html template
         project.add_static_file(
             "index.html",

--- a/src/usecase/build/html/tags_index_render.rs
+++ b/src/usecase/build/html/tags_index_render.rs
@@ -68,17 +68,16 @@ impl TagsIndexRender {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
     use scraps_libs::{lang::LangCode, model::base_url::BaseUrl};
     use std::fs;
     use url::Url;
 
     use super::*;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Add static tags_index.html template
         project.add_static_file(
             "tags_index.html",

--- a/src/usecase/build/usecase.rs
+++ b/src/usecase/build/usecase.rs
@@ -194,18 +194,17 @@ impl BuildUsecase {
 mod tests {
     use std::fs;
 
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
     use crate::usecase::build::model::{color_scheme::ColorScheme, paging::Paging, sort::SortKey};
     use crate::usecase::progress::tests::ProgressTest;
+    use rstest::rstest;
 
     use super::*;
     use scraps_libs::{git::tests::GitCommandTest, lang::LangCode};
     use url::Url;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Create scraps
         project
             .add_scrap(
@@ -289,10 +288,10 @@ mod tests {
         assert!(!result8.is_empty());
     }
 
-    #[test]
-    fn it_run_when_build_search_index_is_false() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run_when_build_search_index_is_false(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         // Create scraps
         project
             .add_scrap(

--- a/src/usecase/init/usecase.rs
+++ b/src/usecase/init/usecase.rs
@@ -31,14 +31,14 @@ impl<GC: GitCommand> InitUsecase<GC> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::SimpleTempDir;
+    use crate::test_fixtures::{simple_temp_dir, SimpleTempDir};
+    use rstest::rstest;
     use scraps_libs::git::GitCommandImpl;
 
     use super::*;
 
-    #[test]
-    fn it_run() {
-        let temp_dir = SimpleTempDir::new();
+    #[rstest]
+    fn it_run(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
         let project_path = temp_dir.path.join("project");
 
         let git_command = GitCommandImpl::new();

--- a/src/usecase/scrap/lookup_backlinks/usecase.rs
+++ b/src/usecase/scrap/lookup_backlinks/usecase.rs
@@ -79,12 +79,11 @@ impl LookupScrapBacklinksUsecase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
 
-    #[test]
-    fn test_lookup_scrap_backlinks_success() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_backlinks_success(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap("scrap1.md", b"# Scrap 1\n\nThis links to [[target_scrap]].")
             .add_scrap(
@@ -110,10 +109,10 @@ mod tests {
         assert!(titles.contains(&"scrap2".to_string()));
     }
 
-    #[test]
-    fn test_lookup_scrap_backlinks_with_context() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_backlinks_with_context(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project
             .add_scrap(
                 "scrap1.md",
@@ -135,10 +134,10 @@ mod tests {
         assert_eq!(results[0].title.to_string(), "scrap1");
     }
 
-    #[test]
-    fn test_lookup_scrap_backlinks_not_found() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_backlinks_not_found(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project.add_scrap("scrap1.md", b"# Scrap 1\n\nContent.");
 
         let usecase = LookupScrapBacklinksUsecase::new(&project.scraps_dir);
@@ -149,10 +148,10 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("Scrap not found"));
     }
 
-    #[test]
-    fn test_lookup_scrap_backlinks_no_backlinks() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_backlinks_no_backlinks(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project.add_scrap(
             "target_scrap.md",
             b"# Target Scrap\n\nThis scrap has no backlinks.",

--- a/src/usecase/scrap/lookup_links/usecase.rs
+++ b/src/usecase/scrap/lookup_links/usecase.rs
@@ -85,12 +85,11 @@ impl LookupScrapLinksUsecase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
 
-    #[test]
-    fn test_lookup_scrap_links_success() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_links_success(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap(
                 "scrap1.md",
@@ -113,10 +112,8 @@ mod tests {
         assert!(titles.contains(&"scrap3".to_string()));
     }
 
-    #[test]
-    fn test_lookup_scrap_links_with_context() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_links_with_context(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap_with_context(
                 "Context",
@@ -135,10 +132,8 @@ mod tests {
         assert_eq!(results[0].title.to_string(), "scrap2");
     }
 
-    #[test]
-    fn test_lookup_scrap_links_not_found() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_links_not_found(#[from(temp_scrap_project)] project: TempScrapProject) {
         project.add_scrap("scrap1.md", b"# Scrap 1\n\nContent.");
 
         let usecase = LookupScrapLinksUsecase::new(&project.scraps_dir);
@@ -149,10 +144,8 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("Scrap not found"));
     }
 
-    #[test]
-    fn test_lookup_scrap_links_no_links() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_scrap_links_no_links(#[from(temp_scrap_project)] project: TempScrapProject) {
         project.add_scrap("scrap1.md", b"# Scrap 1\n\nThis scrap has no links.");
 
         let usecase = LookupScrapLinksUsecase::new(&project.scraps_dir);

--- a/src/usecase/search/usecase.rs
+++ b/src/usecase/search/usecase.rs
@@ -77,14 +77,13 @@ impl SearchUsecase {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
 
     use super::*;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap("test1.md", b"# Test Document 1\nThis is a test document.")
             .add_scrap("test2.md", b"# Another Document\nAnother test content.");
@@ -100,10 +99,8 @@ mod tests {
         assert!(results.iter().all(|r| !r.md_text.is_empty()));
     }
 
-    #[test]
-    fn it_handles_duplicate_titles() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_handles_duplicate_titles(#[from(temp_scrap_project)] project: TempScrapProject) {
         // Two scraps with the same title but different contexts (ctx/ and root)
         project
             .add_scrap_with_context(

--- a/src/usecase/tag/list/usecase.rs
+++ b/src/usecase/tag/list/usecase.rs
@@ -31,16 +31,15 @@ impl ListTagUsecase {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
     use itertools::Itertools;
+    use rstest::rstest;
 
     use super::*;
     use scraps_libs::model::tag::Tag;
 
-    #[test]
-    fn it_run() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap("test1.md", b"#[[Tag1]] #[[Tag2]]")
             .add_scrap("test2.md", b"#[[Tag1]] #[[Tag3]]");

--- a/src/usecase/tag/lookup_backlinks/usecase.rs
+++ b/src/usecase/tag/lookup_backlinks/usecase.rs
@@ -73,12 +73,11 @@ impl LookupTagBacklinksUsecase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
 
-    #[test]
-    fn test_lookup_tag_backlinks_success() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_tag_backlinks_success(#[from(temp_scrap_project)] project: TempScrapProject) {
         project
             .add_scrap("scrap1.md", b"# Scrap 1\n\nThis links to [[test_tag]].")
             .add_scrap(
@@ -102,10 +101,10 @@ mod tests {
         assert!(!titles.contains(&"scrap3".to_string()));
     }
 
-    #[test]
-    fn test_lookup_tag_backlinks_with_context_scraps() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_tag_backlinks_with_context_scraps(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project
             .add_scrap("scrap1.md", b"# Scrap 1\n\nThis links to [[test_tag]].")
             .add_scrap_with_context(
@@ -132,10 +131,10 @@ mod tests {
         assert!(scrap_keys.contains(&("scrap2".to_string(), Some("Context".to_string()))));
     }
 
-    #[test]
-    fn test_lookup_tag_backlinks_no_backlinks() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_tag_backlinks_no_backlinks(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project.add_scrap(
             "scrap1.md",
             b"# Scrap 1\n\nThis scrap doesn't reference any tags.",
@@ -150,10 +149,10 @@ mod tests {
         assert_eq!(results.len(), 0);
     }
 
-    #[test]
-    fn test_lookup_tag_backlinks_invalid_tag() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_tag_backlinks_invalid_tag(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project
             .add_scrap("scrap1.md", b"# Scrap 1\n\nThis links to [[actual_tag]].")
             .add_scrap("scrap2.md", b"# Scrap 2\n\nThis links to [[actual_scrap]].")
@@ -189,10 +188,10 @@ mod tests {
         assert_eq!(tag_results[0].title.to_string(), "scrap1");
     }
 
-    #[test]
-    fn test_lookup_tag_backlinks_empty_scraps_directory() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn test_lookup_tag_backlinks_empty_scraps_directory(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         let usecase = LookupTagBacklinksUsecase::new(&project.scraps_dir);
 
         let results = usecase

--- a/src/usecase/template/generate/usecase.rs
+++ b/src/usecase/template/generate/usecase.rs
@@ -32,15 +32,14 @@ impl GenerateUsecase {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_fixtures::TempScrapProject;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
 
     use super::*;
     use std::fs;
 
-    #[test]
-    fn it_run_has_not_input_template_title() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run_has_not_input_template_title(#[from(temp_scrap_project)] project: TempScrapProject) {
         // run args
         let template_name = "it_render_from_template";
         let template_title = &None;
@@ -62,10 +61,8 @@ mod tests {
         assert_eq!(result.unwrap(), "\n2019-09-20")
     }
 
-    #[test]
-    fn it_run_has_input_template_title() {
-        let project = TempScrapProject::new();
-
+    #[rstest]
+    fn it_run_has_input_template_title(#[from(temp_scrap_project)] project: TempScrapProject) {
         // run args
         let template_name = "it_render_from_template";
         let template_title = &Some("override_title".into());


### PR DESCRIPTION
## Summary
- Replace direct `TempScrapProject::new()` and `SimpleTempDir::new()` calls with rstest `#[rstest]` + `#[fixture]` pattern
- Use `#[from(fixture)]` attribute to preserve existing variable names (`project`, `temp_dir`)
- 13 test files migrated, 33 tests updated

## Test plan
- [x] `mise run cargo:quality` passes
- [x] All 69 tests pass
- [x] No new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)