### PR TITLE
chore(renovate): apply global minimumReleaseAge of 1 day

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "matchManagers": [
@@ -10,13 +11,6 @@
       ],
       "enabled": true,
       "rangeStrategy": "pin"
-    },
-    {
-      "matchManagers": [
-        "github-actions",
-        "dockerfile"
-      ],
-      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "Rust toolchain",


### PR DESCRIPTION
## Summary
- Replace manager-specific 7-day stability period with global 1-day `minimumReleaseAge`
- Applies to all package managers instead of just github-actions and dockerfile
- Simplifies renovate configuration

## Test plan
- [ ] Verify renovate bot respects the new global setting on next dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)