### PR TITLE
test: add MCP server integration tests using rmcp client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -1795,6 +1796,7 @@ dependencies = [
  "clap-verbosity-flag",
  "colored",
  "config",
+ "futures",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1812,6 +1814,7 @@ dependencies = [
  "tera",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -2157,10 +2160,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.16"
+name = "tokio-stream"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ rmcp = { version = "=0.13.0", features = ["server"] }
 schemars = "=1.2.0"
 rstest = "=0.26.1"
 tempfile = "=3.24.0"
+tokio-util = "=0.7.15"
+futures = "=0.3.31"
 
 [package]
 edition.workspace = true
@@ -94,3 +96,6 @@ scraps_libs.workspace = true
 scraps_libs.features = ["git_test"]
 rstest.workspace = true
 tempfile.workspace = true
+rmcp = { workspace = true, features = ["client", "server", "transport-async-rw"] }
+tokio-util.workspace = true
+futures.workspace = true

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -93,3 +93,242 @@ impl ServerHandler for ScrapsServer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rmcp::model::CallToolRequestParam;
+    use rmcp::ServiceExt;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_server_info(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+        let info = server.get_info();
+
+        assert_eq!(
+            info.instructions,
+            Some("This is a Scraps MCP server".into())
+        );
+        assert!(info.capabilities.tools.is_some());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_list_tools(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let tools = client.list_tools(Default::default()).await.unwrap();
+
+        assert_eq!(tools.tools.len(), 5);
+
+        let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(tool_names.contains(&"search_scraps"));
+        assert!(tool_names.contains(&"lookup_scrap_links"));
+        assert!(tool_names.contains(&"lookup_scrap_backlinks"));
+        assert!(tool_names.contains(&"list_tags"));
+        assert!(tool_names.contains(&"lookup_tag_backlinks"));
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_search_scraps(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("test.md", b"# Test Scrap\n\nContent here");
+
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let result = client
+            .call_tool(CallToolRequestParam {
+                name: "search_scraps".into(),
+                arguments: Some(
+                    serde_json::json!({"query": "test"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+                task: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.is_error.unwrap_or(false));
+        assert!(!result.content.is_empty());
+
+        let content_text = result.content[0].as_text().unwrap();
+        assert!(content_text.text.contains("Test Scrap"));
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_list_tags(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("test.md", b"#[[rust]] #[[programming]]");
+
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let result = client
+            .call_tool(CallToolRequestParam {
+                name: "list_tags".into(),
+                arguments: None,
+                task: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.is_error.unwrap_or(false));
+        assert!(!result.content.is_empty());
+
+        let content_text = result.content[0].as_text().unwrap();
+        assert!(
+            content_text.text.contains("rust") || content_text.text.contains("programming"),
+            "Expected tags in response, got: {}",
+            content_text.text
+        );
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_lookup_scrap_links(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("source.md", b"# Source\n\n[[target]]");
+        project.add_scrap("target.md", b"# Target\n\nTarget content");
+
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let result = client
+            .call_tool(CallToolRequestParam {
+                name: "lookup_scrap_links".into(),
+                arguments: Some(
+                    serde_json::json!({"title": "source"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+                task: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.is_error.unwrap_or(false));
+        assert!(!result.content.is_empty());
+
+        let content_text = result.content[0].as_text().unwrap();
+        assert!(content_text.text.contains("target"));
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_lookup_scrap_backlinks(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("source.md", b"# Source\n\n[[target]]");
+        project.add_scrap("target.md", b"# Target\n\nTarget content");
+
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let result = client
+            .call_tool(CallToolRequestParam {
+                name: "lookup_scrap_backlinks".into(),
+                arguments: Some(
+                    serde_json::json!({"title": "target"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+                task: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.is_error.unwrap_or(false));
+        assert!(!result.content.is_empty());
+
+        let content_text = result.content[0].as_text().unwrap();
+        assert!(content_text.text.contains("source"));
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_lookup_tag_backlinks(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("test.md", b"# Test\n\n#[[rust]]");
+
+        let server = ScrapsServer::new(project.scraps_dir.clone());
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let result = client
+            .call_tool(CallToolRequestParam {
+                name: "lookup_tag_backlinks".into(),
+                arguments: Some(
+                    serde_json::json!({"tag": "rust"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+                task: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.is_error.unwrap_or(false));
+        assert!(!result.content.is_empty());
+
+        let content_text = result.content[0].as_text().unwrap();
+        assert!(
+            content_text.text.contains("Test") || content_text.text.contains("test"),
+            "Expected scrap with tag 'rust' in response, got: {}",
+            content_text.text
+        );
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive integration tests for MCP server using rmcp's client feature
- Use `tokio::io::duplex` for in-memory client-server communication
- Test all 5 MCP tools: search_scraps, list_tags, lookup_scrap_links, lookup_scrap_backlinks, lookup_tag_backlinks

## Test plan
- [x] Run `mise run cargo:test` - all 7 new tests pass
- [x] Run `mise run cargo:quality` - all quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)