### PR TITLE
refactor(scraps-writer): migrate from agents to skills

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scraps-writer",
-  "version": "1.0.2",
-  "description": "AI agent for creating Scraps documentation with intelligent tag selection and backlink suggestions",
+  "version": "1.1.0",
+  "description": "AI skill for creating Scraps documentation with intelligent tag selection and backlink suggestions",
   "author": {
     "name": "boykush",
     "email": "boykush315@gmail.com"

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: scraps-writer
-description: Create Scraps documentation with intelligent tag selection and backlink suggestions
+description: Create Scraps documentation with intelligent tag selection and backlink suggestions. Use when creating new scraps, writing documentation with Wiki-links, or when the user mentions scraps, wiki-links, or documentation.
 model: sonnet
-available_tools:
-  - mcp__plugin_scraps-writer_scraps__*
+allowed-tools: mcp__plugin_scraps-writer_scraps__*, Read, Write, Edit, Glob
+user-invocable: true
 ---
 
-# Scraps Writer Agent
+# Scraps Writer
 
-You are a specialized agent for creating Scraps documentation with Wiki-link notation.
+You are a specialized skill for creating Scraps documentation with Wiki-link notation.
 
 ## Your Role
 


### PR DESCRIPTION
## Summary

- Migrate scraps-writer plugin from Claude Code agents to skills format
- Skills provide better automatic discovery and user-invocable slash commands (`/scraps-writer`)
- Bump version to 1.1.0 (backward compatible feature change)

## Changes

- Convert `agents/scraps-writer.md` to `skills/scraps-writer/SKILL.md`
- Update frontmatter to skills format (`allowed-tools`, `user-invocable`)
- Add trigger keywords to description for automatic skill activation
- Update description from "AI agent" to "AI skill"

## Test plan

- [ ] Verify plugin loads correctly with Claude Code
- [ ] Test `/scraps-writer` slash command invocation
- [ ] Confirm MCP tools still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)