### PR TITLE
feat(cli): support SCRAPS_PROJECT_PATH environment variable for --path option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
 toml = "=0.9.11"
 rayon = "=1.11.0"
-clap = { version = "=4.5.54", features = ["derive"] }
+clap = { version = "=4.5.54", features = ["derive", "env"] }
 config = { version = "=0.15.19", features = ["toml"] }
 tera = "=1.20.1"
 once_cell = "=1.21.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ pub struct Cli {
         short = 'p',
         long = "path",
         global = true,
+        env = "SCRAPS_PROJECT_PATH",
         help = "Specify the project directory path"
     )]
     pub path: Option<PathBuf>,


### PR DESCRIPTION
## Summary
- Enable clap's `env` feature to read project path from `SCRAPS_PROJECT_PATH` environment variable
- The `--path` CLI option now falls back to reading from environment variable when not specified
- Improves MCP server integration where `.mcp.json` environment variable substitution is limited

## Test plan
- [ ] Verify `scraps --help` shows environment variable info for `--path` option
- [ ] Test that setting `SCRAPS_PROJECT_PATH` works as fallback when `--path` is not specified
- [ ] Verify `--path` option still takes priority over environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)