### PR TITLE
fix: update project Config.toml to new [ssg] section format

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -1,10 +1,12 @@
+scraps_dir = "docs"
+timezone = "Asia/Tokyo"
+
+[ssg]
 base_url = "https://boykush.github.io/scraps/"
 title = "Scraps Doc"
-scraps_dir = "docs"
 lang_code = "en"
 description = "A static site generator that makes it easy to write internal links (Wiki links) in Markdown files."
 favicon = "https://github.com/boykush/scraps/blob/main/assets/logo.png?raw=true"
-timezone = "Asia/Tokyo"
 build_search_index = true
 sort_key = "committed_date"
 paginate_by = 10


### PR DESCRIPTION
## Summary

- Update the project's own Config.toml to use the new [ssg] section format

## Problem

The breaking change in PR #328 introduced a new configuration format with the `[ssg]` section, but the project's own `Config.toml` was not updated. This causes E2E tests to fail because `cargo run serve` cannot parse the old format config.

## Solution

Update `Config.toml` to the new format:

```toml
scraps_dir = "docs"
timezone = "Asia/Tokyo"

[ssg]
base_url = "https://boykush.github.io/scraps/"
title = "Scraps Doc"
# ... other SSG settings
```

## Test plan

- [x] E2E tests should pass with the updated config format

🤖 Generated with [Claude Code](https://claude.com/claude-code)