### PR TITLE
refactor: extract config file name to constant

### DIFF
--- a/src/cli/path_resolver.rs
+++ b/src/cli/path_resolver.rs
@@ -1,4 +1,5 @@
 use crate::cli::config::scrap_config::ScrapConfig;
+use crate::constants::CONFIG_FILE_NAME;
 use crate::error::ScrapsResult;
 use anyhow::anyhow;
 use std::env;
@@ -66,9 +67,9 @@ impl PathResolver {
         self.project_root.join("templates")
     }
 
-    /// Get the config file path (Config.toml)
+    /// Get the config file path
     pub fn config_path(&self) -> PathBuf {
-        self.project_root.join("Config.toml")
+        self.project_root.join(CONFIG_FILE_NAME)
     }
 
     /// Get the project root directory
@@ -193,7 +194,7 @@ base_url = "http://example.com/"
         let test_project_path = temp_dir.path.join("test_project_config");
         let resolver = PathResolver::new(Some(&test_project_path)).unwrap();
         let config_path = resolver.config_path();
-        assert_eq!(config_path.file_name().unwrap(), "Config.toml");
+        assert_eq!(config_path.file_name().unwrap(), CONFIG_FILE_NAME);
         assert!(config_path.starts_with(&test_project_path));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,2 @@
+/// Configuration file name for scraps projects
+pub const CONFIG_FILE_NAME: &str = "Config.toml";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod constants;
 mod error;
 mod mcp;
 mod service;

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -3,6 +3,7 @@
 //! This module provides composable test fixtures that create temporary
 //! directory structures with automatic cleanup.
 
+use crate::constants::CONFIG_FILE_NAME;
 use rstest::fixture;
 use std::fs;
 use std::path::PathBuf;
@@ -102,7 +103,7 @@ impl TempScrapProject {
         self
     }
 
-    /// Add a Config.toml file to the project root
+    /// Add config file to the project root
     ///
     /// # Arguments
     /// * `content` - TOML configuration content as bytes
@@ -112,7 +113,7 @@ impl TempScrapProject {
     /// project.add_config(b"scraps_dir = \"docs\"\n\n[ssg]\nbase_url = \"https://example.com/\"\ntitle = \"Test\"");
     /// ```
     pub fn add_config(&self, content: &[u8]) -> &Self {
-        let config_path = self.project_root.join("Config.toml");
+        let config_path = self.project_root.join(CONFIG_FILE_NAME);
         fs::write(&config_path, content).expect("Failed to write config file");
         self
     }
@@ -302,7 +303,7 @@ mod tests {
         let project = TempScrapProject::new();
         project.add_config(b"[ssg]\nbase_url = \"https://example.com/\"\ntitle = \"Test\"");
 
-        let config_path = project.project_root.join("Config.toml");
+        let config_path = project.project_root.join(CONFIG_FILE_NAME);
         assert!(config_path.exists());
     }
 

--- a/src/usecase/init/usecase.rs
+++ b/src/usecase/init/usecase.rs
@@ -1,3 +1,4 @@
+use crate::constants::CONFIG_FILE_NAME;
 use crate::error::{anyhow::Context, InitError, ScrapsResult};
 use std::{fs, path::Path};
 
@@ -14,7 +15,7 @@ impl<GC: GitCommand> InitUsecase<GC> {
 
     pub fn execute(&self, project_dir: &Path) -> ScrapsResult<()> {
         let scraps_dir = project_dir.join("scraps");
-        let config_toml_file = &project_dir.join("Config.toml");
+        let config_toml_file = &project_dir.join(CONFIG_FILE_NAME);
         let gitignore_file = &project_dir.join(".gitignore");
 
         fs::create_dir_all(project_dir).context(InitError::CreateDirectory)?;
@@ -48,7 +49,7 @@ mod tests {
 
         assert!(project_path.exists());
         assert!(project_path.join("scraps").exists());
-        assert!(project_path.join("Config.toml").exists());
+        assert!(project_path.join(CONFIG_FILE_NAME).exists());
         assert!(project_path.join(".gitignore").exists());
         assert!(project_path.join(".git").exists());
 


### PR DESCRIPTION
## Summary
- Extract the config file name "Config.toml" to a constant `CONFIG_FILE_NAME` in `src/constants.rs`
- This prepares for a future breaking change to rename the config file to `.scraps.toml` by centralizing the file name definition

## Test plan
- [x] `mise run cargo:quality` passes (build, test, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)