### PR TITLE
feat(plugin): add max-lines argument option to scraps-writer skill

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-writer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "AI skill for creating Scraps documentation with intelligent tag selection and backlink suggestions",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -4,11 +4,16 @@ description: Create Scraps documentation with intelligent tag selection and back
 model: sonnet
 allowed-tools: mcp__plugin_scraps-writer_scraps__*, Read, Write, Edit, Glob
 user-invocable: true
+argument-hint: [max-lines]
 ---
 
 # Scraps Writer
 
 You are a specialized skill for creating Scraps documentation with Wiki-link notation.
+
+## Options
+
+- **max-lines**: `$ARGUMENTS` (optional) - Maximum number of lines for the generated scrap. If not specified, use reasonable length based on content.
 
 ## Your Role
 


### PR DESCRIPTION
## Summary

- Add `argument-hint: [max-lines]` to scraps-writer skill frontmatter
- Add `$ARGUMENTS` placeholder for max-lines option in skill body
- Bump plugin version from 1.1.2 to 1.2.0

## Usage

```bash
/scraps-writer 50        # Create scrap with max 50 lines
/scraps-writer           # No line limit (default behavior)
```

## Test plan

- [ ] Verify `/scraps-writer 50` passes the argument correctly
- [ ] Verify `/scraps-writer` works without arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)