### PR TITLE
feat(plugin): restructure scraps-writer plugin to v2.0.0 with workflow skills

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scraps-writer",
-  "version": "1.2.0",
-  "description": "AI skill for creating Scraps documentation with intelligent tag selection and backlink suggestions",
+  "version": "2.0.0",
+  "description": "AI skills for creating Scraps documentation with add-scrap and web-to-scrap workflows",
   "author": {
     "name": "boykush",
     "email": "boykush315@gmail.com"

--- a/plugins/scraps-writer/skills/add-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/add-scrap/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: add-scrap
+description: Create a new scrap with intelligent tag selection and backlink suggestions.
+allowed-tools: mcp__plugin_scraps-writer_scraps__*, Read, Write, Edit, Glob, WebSearch, Skill
+user-invocable: true
+argument-hint: [title] [max-lines]
+---
+
+# Add Scrap
+
+Create a new scrap by calling `scraps-writer` skill.
+
+## Arguments
+
+- **title**: `$ARGUMENTS` - Title of the scrap to create
+- **max-lines**: (optional) - Maximum number of lines for the generated scrap
+
+## Workflow
+
+1. **Understand the Request**
+   - Ask clarifying questions if the content is unclear
+   - Identify the context folder if applicable
+
+2. **Research the Topic**
+   - Use `WebSearch` to gather information about the topic
+
+3. **Research Existing Tags**
+   - Use `list_tags` to get available tags
+   - Identify tags relevant to the topic
+
+4. **Search Related Scraps**
+   - Use `search_scraps` to find related content
+   - Identify scraps that should link to the new scrap
+
+5. **Create the Scrap**
+   - Call `scraps-writer` skill with max-lines argument
+   - Write well-structured Markdown content
+
+6. **Suggest Backlinks**
+   - List existing scraps that should add links to this new scrap

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -1,86 +1,60 @@
 ---
 name: scraps-writer
-description: Create Scraps documentation with intelligent tag selection and backlink suggestions. Use when creating new scraps, writing documentation with Wiki-links, or when the user mentions scraps, wiki-links, or documentation.
-model: sonnet
+description: Knowledge base for Scraps documentation conventions including Wiki-link syntax, Markdown features, and MCP tools usage.
 allowed-tools: mcp__plugin_scraps-writer_scraps__*, Read, Write, Edit, Glob
-user-invocable: true
+user-invocable: false
 argument-hint: [max-lines]
 ---
 
 # Scraps Writer
 
-You are a specialized skill for creating Scraps documentation with Wiki-link notation.
+Knowledge base for creating Scraps documentation with Wiki-link notation.
 
 ## Options
 
-- **max-lines**: `$ARGUMENTS` (optional) - Maximum number of lines for the generated scrap. If not specified, use reasonable length based on content.
+- **max-lines**: `$ARGUMENTS` (optional) - Maximum number of lines for the generated scrap.
 
-## Your Role
+## MCP Tools Usage
 
-Help users create high-quality Markdown documentation scraps that:
+- `list_tags` → Identify tags for a scrap. Returns all tags sorted by backlinks count.
+- `search_scraps` → Find related scraps by keyword with fuzzy matching.
+- `lookup_tag_backlinks` → Check which scraps are using a specific tag.
+- `lookup_scrap_links` → Get all scraps that a scrap links to.
+- `lookup_scrap_backlinks` → Get all scraps that link to a scrap.
 
-- Follow Scraps conventions (CommonMark, GitHub-flavored Markdown, Wiki-links)
-- Use appropriate tags from the existing knowledge base
-- Connect well with existing scraps through backlinks
+## Wiki-Link Syntax
 
-## Workflow
+### Normal Link
 
-When a user requests to create a new scrap:
+`[[Page Name]]` - Links to an existing scrap with the specified title.
 
-1. **Understand the Request**
-   - Ask clarifying questions if the topic or content type is unclear
-   - Identify the context (folder) if applicable
-   - Understand the target audience and purpose
+### Alias Link
 
-2. **Research Existing Tags**
-   - Use `list_tags` to get available tags
-   - Analyze which tags are most relevant to the topic
-   - Consider tag backlinks count to understand their importance in the
-     knowledge base
+`[[Page Name|Display Text]]` - Links to a scrap with custom display text.
 
-3. **Search Related Scraps**
-   - Use `search_scraps` to find related content
-   - Use `lookup_tag_backlinks` for specific tags
-   - Identify scraps that should link to the new scrap
+### Context Link
 
-4. **Generate the Scrap**
-   - Create well-structured Markdown content
-   - Add appropriate tags using `#[[Tag]]` notation
-   - Include Wiki-links to related scraps using `[[Title]]` or `[[Context/Title]]`
-   - Organize content with clear headings and sections
+`[[Context/Page Name]]` - Links to a scrap in a specific context folder.
 
-5. **Suggest Backlinks**
-   - Provide a list of existing scraps that should add links to this new scrap
-   - Explain why each backlink makes sense
-   - Format suggestions clearly for easy implementation
+### Tag
 
-## Scraps Conventions
+`#[[Tag Name]]` - Creates a tag when no scrap with that title exists. Tags group scraps by category and generate an index page listing all scraps using that tag.
 
-### Wiki-Link Syntax
-
-- Normal link: `[[Page Name]]` - See [Normal Link](https://boykush.github.io/scraps/scraps/normal-link.reference.html)
-- Alias link: `[[Page Name|Display Text]]` - See [Alias Link](https://boykush.github.io/scraps/scraps/alias-link.reference.html)
-- Context link: `[[Context/Page Name]]` - See [Context Link](https://boykush.github.io/scraps/scraps/context-link.reference.html)
-- Tag: `#[[Tag Name]]` - See [Tag Link](https://boykush.github.io/scraps/scraps/tag-link.reference.html)
-
-### Markdown Features
+## Markdown Features
 
 - CommonMark specification
 - GitHub-flavored Markdown (tables, task lists, strikethrough)
 - Mermaid diagrams with `mermaid` code blocks
 - Autolinks for OGP cards: `<https://example.com>`
 
-### File Organization
+## File Organization
 
 - Scraps directory is configurable in `.scraps.toml`
 - Use folders for context when titles overlap
 - Keep folder structure flat (avoid deep nesting)
-- Context appears in the static site as metadata
 
 ## Best Practices
 
-- Always research and prefer existing tags over creating new ones
+- Prefer existing tags over creating new ones
 - Keep content focused and concise
-- Follow the single-responsibility principle for scraps
-- Ensure context folders are used only when necessary
-- Adapt to the user's project style and conventions
+- Follow single-responsibility principle for scraps

--- a/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: web-to-scrap
+description: Summarize a web article and create a scrap with source link and tags.
+allowed-tools: mcp__plugin_scraps-writer_scraps__*, Read, Write, Edit, Glob, WebFetch, Skill
+user-invocable: true
+argument-hint: [url] [max-lines]
+---
+
+# Web to Scrap
+
+Summarize a web article and create a scrap by calling `scraps-writer` skill.
+
+## Arguments
+
+- **url**: `$ARGUMENTS` - URL of the web article to summarize
+- **max-lines**: (optional) - Maximum number of lines for the generated scrap
+
+## Workflow
+
+1. **Fetch the Article**
+   - Use `WebFetch` to retrieve the web article content
+   - Extract the title and main content
+
+2. **Research Existing Tags**
+   - Use `list_tags` to get available tags
+   - Identify tags relevant to the article topic
+
+3. **Search Related Scraps**
+   - Use `search_scraps` to find related content
+
+4. **Create the Scrap**
+   - Call `scraps-writer` skill with max-lines argument
+   - Generate a concise summary of the article
+   - Include the source URL as autolink: `<https://...>`


### PR DESCRIPTION
## Summary

- Refactor `scraps-writer` to knowledge base skill (`user-invocable: false`)
- Add `add-scrap` workflow skill for creating new scraps with WebSearch
- Add `web-to-scrap` workflow skill for summarizing web articles
- Workflow skills call `scraps-writer` skill with max-lines argument
- Remove `model: sonnet` restriction to allow user's active model
- Bump plugin version to 2.0.0

## New Skills Structure

| Skill | Role | user-invocable |
|-------|------|----------------|
| `scraps-writer` | Knowledge base (Wiki-link syntax, MCP tools, best practices) | `false` |
| `add-scrap` | Create new scrap workflow | `true` |
| `web-to-scrap` | Summarize web article workflow | `true` |

## Usage

```bash
/scraps-writer:add-scrap "Title" 50
/scraps-writer:web-to-scrap https://example.com/article 30
```

## Test plan

- [ ] Verify `/scraps-writer:add-scrap` creates scrap with tags and links
- [ ] Verify `/scraps-writer:web-to-scrap` fetches and summarizes article
- [ ] Verify max-lines argument is passed to scraps-writer skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)