### PR TITLE
feat(plugin): enforce MCP-validated links and tags in scraps-writer skills

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-writer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "AI skills for creating Scraps documentation with add-scrap and web-to-scrap workflows",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-writer/skills/add-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/add-scrap/SKILL.md
@@ -30,6 +30,7 @@ Create a new scrap by calling `scraps-writer` skill.
 
 4. **Search Related Scraps**
    - Use `search_scraps` to find related content
+   - Only use `title` and `ctx` from results as link targets (ensures links point to existing scraps)
    - Identify scraps that should link to the new scrap
 
 5. **Create the Scrap**

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -17,7 +17,7 @@ Knowledge base for creating Scraps documentation with Wiki-link notation.
 ## MCP Tools Usage
 
 - `list_tags` → Identify tags for a scrap. Returns all tags sorted by backlinks count.
-- `search_scraps` → Find related scraps by keyword with fuzzy matching.
+- `search_scraps` → Find related scraps by keyword with fuzzy matching. Returns `title` and `ctx` for each result.
 - `lookup_tag_backlinks` → Check which scraps are using a specific tag.
 - `lookup_scrap_links` → Get all scraps that a scrap links to.
 - `lookup_scrap_backlinks` → Get all scraps that link to a scrap.
@@ -26,19 +26,19 @@ Knowledge base for creating Scraps documentation with Wiki-link notation.
 
 ### Normal Link
 
-`[[Page Name]]` - Links to an existing scrap with the specified title.
+`[[Page Name]]` - Links to an existing scrap with the specified title. Use `title` from `search_scraps` results as the Page Name.
 
 ### Alias Link
 
-`[[Page Name|Display Text]]` - Links to a scrap with custom display text.
+`[[Page Name|Display Text]]` - Links to a scrap with custom display text. Use `title` (and `ctx` if applicable) from `search_scraps` results as the Page Name.
 
 ### Context Link
 
-`[[Context/Page Name]]` - Links to a scrap in a specific context folder.
+`[[Context/Page Name]]` - Links to a scrap in a specific context folder. Use `ctx` from `search_scraps` results as the Context.
 
 ### Tag
 
-`#[[Tag Name]]` - Creates a tag when no scrap with that title exists. Tags group scraps by category and generate an index page listing all scraps using that tag.
+`#[[Tag Name]]` - Creates a tag when no scrap with that title exists. Tags group scraps by category and generate an index page listing all scraps using that tag. Use tags from `list_tags` results only.
 
 ## Markdown Features
 

--- a/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
@@ -27,6 +27,7 @@ Summarize a web article and create a scrap by calling `scraps-writer` skill.
 
 3. **Search Related Scraps**
    - Use `search_scraps` to find related content
+   - Only use `title` and `ctx` from results as link targets (ensures links point to existing scraps)
 
 4. **Create the Scrap**
    - Call `scraps-writer` skill with max-lines argument


### PR DESCRIPTION
## Summary
- Ensure wiki-links and tags only reference existing scraps/tags by requiring MCP tool results
- Add instruction to use `title`/`ctx` from `search_scraps` for link targets
- Require tags from `list_tags` results only
- Bump version to 2.0.1

## Test plan
- [ ] Verify add-scrap skill uses search_scraps results for links
- [ ] Verify web-to-scrap skill uses search_scraps results for links
- [ ] Verify scraps-writer skill documentation is clear about MCP tool usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)