### PR TITLE
docs: add README files for plugins

### DIFF
--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -1,0 +1,19 @@
+# MCP Server Plugin
+
+MCP server for browsing and searching Scraps documentation with Wiki-link notation.
+
+## Overview
+
+This plugin provides an MCP (Model Context Protocol) server that enables AI assistants to browse, search, and navigate your Scraps documentation.
+
+## Features
+
+- Fuzzy search across scrap titles and content
+- Tag listing and lookup
+- Wiki-link navigation (outbound links and backlinks)
+
+## Documentation
+
+- [Install Claude Code Plugin](https://boykush.github.io/scraps/scraps/install-claude-code-plugin.how-to.html) - Setup instructions
+- [MCP Tools Reference](https://boykush.github.io/scraps/scraps/mcp-tools.reference.html) - Available tools and parameters
+- [Integrate with AI Assistants](https://boykush.github.io/scraps/scraps/integrate-with-ai-assistants.how-to.html) - General MCP integration

--- a/plugins/scraps-writer/README.md
+++ b/plugins/scraps-writer/README.md
@@ -1,0 +1,19 @@
+# Scraps Writer Plugin
+
+AI skills for creating Scraps documentation with intelligent tag selection and backlink suggestions.
+
+## Overview
+
+This plugin provides AI-powered skills for creating and managing Scraps documentation. It combines the MCP server tools with structured workflows to ensure consistent, well-linked documentation that follows Scraps conventions.
+
+The skills automatically research existing tags and related scraps, ensuring new content integrates naturally into your knowledge graph with proper Wiki-links and tag assignments.
+
+## Skills
+
+### `/add-scrap [title] [max-lines]`
+
+Create a new scrap on any topic. The skill researches the topic via web search, identifies relevant existing tags, finds related scraps for Wiki-linking, and suggests which existing scraps should add backlinks to the new content.
+
+### `/web-to-scrap [url] [max-lines]`
+
+Convert a web article into a scrap. The skill fetches the article, generates a concise summary, adds a source autolink for OGP card display, and connects the content to your existing knowledge base through tags and Wiki-links.


### PR DESCRIPTION
## Summary
- Add README for mcp-server plugin with MCP tools overview and links to official docs
- Add README for scraps-writer plugin with AI skills description for `/add-scrap` and `/web-to-scrap`

## Test plan
- [ ] Verify README content is accurate
- [ ] Verify documentation links are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)