### PR TITLE
feat: add multi-platform binary build support

### DIFF
--- a/.github/workflows/build-binary-and-update-homebrew.yml
+++ b/.github/workflows/build-binary-and-update-homebrew.yml
@@ -8,12 +8,23 @@ jobs:
   build:
     name: Build
     strategy:
-        matrix:
-          include:
-            - target: aarch64-apple-darwin
-              os: macos-latest
-            - target: x86_64-apple-darwin
-              os: macos-latest
+      matrix:
+        include:
+          # macOS
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          # Linux
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          # Windows
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add Linux and Windows targets to release workflow for aqua-registry compatibility
- New targets: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-unknown-linux-musl, x86_64-pc-windows-msvc
- Enables broader distribution via package managers requiring multi-platform binaries

## Test plan
- [ ] Verify workflow syntax passes CI checks
- [ ] Create a test release to confirm all 6 binaries are built and uploaded
- [ ] Validate binaries execute correctly on each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)