### PR TITLE
docs: add Linux support and GitHub Releases installation guide

### DIFF
--- a/docs/Tutorial/Installation.md
+++ b/docs/Tutorial/Installation.md
@@ -10,8 +10,32 @@ The `git` command is required for features.
 ❯ cargo install scraps
 ```
 
-### macOS
+### macOS / Linux (Homebrew)
 
 ```bash
 ❯ brew install boykush/tap/scraps
+```
+
+### GitHub Releases
+
+Download the binary for your platform and place it in your PATH:
+
+```bash
+# macOS (Apple Silicon)
+❯ curl -sL https://github.com/boykush/scraps/releases/latest/download/scraps-aarch64-apple-darwin.tar.gz | tar xz
+
+# macOS (Intel)
+❯ curl -sL https://github.com/boykush/scraps/releases/latest/download/scraps-x86_64-apple-darwin.tar.gz | tar xz
+
+# Linux (x86_64)
+❯ curl -sL https://github.com/boykush/scraps/releases/latest/download/scraps-x86_64-unknown-linux-gnu.tar.gz | tar xz
+
+# Linux (ARM64)
+❯ curl -sL https://github.com/boykush/scraps/releases/latest/download/scraps-aarch64-unknown-linux-gnu.tar.gz | tar xz
+```
+
+Then move the binary to a directory in your PATH:
+
+```bash
+❯ sudo mv scraps /usr/local/bin/
 ```


### PR DESCRIPTION
## Summary
- Update Homebrew section to include Linux support (macOS / Linux)
- Add GitHub Releases section with manual installation instructions for all supported platforms

## Test plan
- [ ] Verify Markdown renders correctly on GitHub
- [ ] Confirm documented commands work as expected (already tested via Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)