### PR TITLE
chore: exclude self-maintained packages from minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,11 @@
       "groupName": "CDN dependencies",
       "matchManagers": ["regex"],
       "matchPackageNames": ["highlight.js", "mermaid", "nord-highlightjs", "fuse.js"]
+    },
+    {
+      "description": "Self-maintained packages: skip minimumReleaseAge",
+      "matchPackageNames": ["scraps", "boykush/scraps-deploy-action"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Add packageRules to exclude `scraps` and `scraps-deploy-action` from `minimumReleaseAge` (1 day)
- These are self-maintained packages, so update PRs should be created immediately when new releases are published

## Test plan
- [ ] Verify renovate.json is valid JSON
- [ ] Confirm correct behavior on next Renovate scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)