### PR TITLE
fix: add 7-day stability delay for GitHub Actions and Dockerfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,13 @@
       "rangeStrategy": "pin"
     },
     {
+      "matchManagers": [
+        "github-actions",
+        "dockerfile"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "groupName": "Rust toolchain",
       "matchManagers": ["dockerfile", "mise"],
       "matchPackageNames": ["rust"]


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "7 days"` package rule for GitHub Actions and Dockerfile dependency updates
- This helps avoid issues with newly released versions by waiting 7 days before updating
- Improves CI stability by giving time for potential bugs or yanked releases to be discovered

## Test plan
- [ ] Verify Renovate validates the configuration successfully
- [ ] Confirm PRs for GitHub Actions and Dockerfile updates are delayed by 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)