### PR TITLE
docs: clarify search_scraps returns existing scraps only

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-writer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "AI skills for creating Scraps documentation with add-scrap and web-to-scrap workflows",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -17,7 +17,7 @@ Knowledge base for creating Scraps documentation with Wiki-link notation.
 ## MCP Tools Usage
 
 - `list_tags` → Identify tags for a scrap. Returns all tags sorted by backlinks count.
-- `search_scraps` → Find related scraps by keyword with fuzzy matching. Returns `title` and `ctx` for each result. Use `logic: "and"` to match all keywords, or `logic: "or"` (default) to match any keyword.
+- `search_scraps` → Find related scraps by keyword with fuzzy matching against title and body content. Returns `title` and `ctx` for each result. **IMPORTANT: Each result represents an existing scrap. Only use the returned `title` and `ctx` values when creating Wiki-links.** Use `logic: "and"` to match all keywords, or `logic: "or"` (default) to match any keyword.
 - `lookup_tag_backlinks` → Check which scraps are using a specific tag.
 - `lookup_scrap_links` → Get all scraps that a scrap links to.
 - `lookup_scrap_backlinks` → Get all scraps that link to a scrap.


### PR DESCRIPTION
## Summary
- Clarify that `search_scraps` matches against title and body content
- Emphasize that each result represents an existing scrap to prevent creating non-existent Wiki-links
- Bump scraps-writer plugin version to 2.0.2

## Test plan
- [ ] Verify SKILL.md changes are correctly documented
- [ ] Test add-scrap and web-to-scrap skills to confirm Wiki-links are created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)