### PR TITLE
ci: add semver comments to docker actions for renovate stability-days

### DIFF
--- a/.github/workflows/publish-docker-package.yml
+++ b/.github/workflows/publish-docker-package.yml
@@ -37,13 +37,13 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@c7c4c00f3eef127be487a50899a220e44c6bcc87
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@0567fa5ae8c9a197cb207537dc5cbb43ca3d803f
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@ed95091677497158a9ff38b314264cd965388d5e
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -75,7 +75,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@64c9b141502b80dbbd71e008a0130ad330f480f8
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
- Add semver version comments to Docker actions in `publish-docker-package.yml`
- Update to latest tagged releases (previously using untagged commits)

## Background
Renovate's `stability-days` check was showing yellow because the Docker actions were pinned to untagged commits (hash only, no semver comment). This prevented Renovate from properly evaluating the release age.

## Changes
| Action | Version |
|--------|---------|
| docker/setup-buildx-action | v3.12.0 |
| docker/login-action | v3.7.0 |
| docker/metadata-action | v5.10.0 |
| docker/build-push-action | v6.18.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)