### PR TITLE
fix: strengthen Wiki-link validation instructions

### DIFF
--- a/plugins/scraps-writer/.claude-plugin/plugin.json
+++ b/plugins/scraps-writer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-writer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "AI skills for creating Scraps documentation with add-scrap and web-to-scrap workflows",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-writer/skills/add-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/add-scrap/SKILL.md
@@ -30,10 +30,11 @@ Create a new scrap with Wiki-link notation.
 
 4. **Search Related Scraps**
    - Use `search_scraps` to find related content
-   - **IMPORTANT: You MUST use ONLY the exact `title` and `ctx` values returned from search results when creating Wiki-links. Never invent or guess link targets.**
+   - **NEVER create Wiki-links that were not returned by `search_scraps`. If a scrap is not in the results, it does not exist.**
    - Identify scraps that should link to the new scrap
 
 5. **Create the Scrap**
+   - **Only use Wiki-links to scraps found in step 4. Do not link to anything else.**
    - Write well-structured Markdown content following the syntax below
 
 6. **Suggest Backlinks**

--- a/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
+++ b/plugins/scraps-writer/skills/web-to-scrap/SKILL.md
@@ -27,9 +27,10 @@ Summarize a web article and create a scrap with Wiki-link notation.
 
 3. **Search Related Scraps**
    - Use `search_scraps` to find related content
-   - **IMPORTANT: You MUST use ONLY the exact `title` and `ctx` values returned from search results when creating Wiki-links. Never invent or guess link targets.**
+   - **NEVER create Wiki-links that were not returned by `search_scraps`. If a scrap is not in the results, it does not exist.**
 
 4. **Create the Scrap**
+   - **Only use Wiki-links to scraps found in step 3. Do not link to anything else.**
    - Generate a concise summary of the article
    - Include the source URL as autolink: `<https://...>`
    - Write well-structured Markdown content following the syntax below


### PR DESCRIPTION
## Summary
- Use direct prohibition instead of positive instruction for Wiki-link validation
- Add constraint reminder in "Create the Scrap" step

## Changes
- `add-scrap`: "NEVER create Wiki-links that were not returned by search_scraps"
- `web-to-scrap`: Same change
- Both: Add "Only use Wiki-links to scraps found in step N" in Create step
- Bump plugin version to 2.0.4

## Background
Even with IMPORTANT instruction, LLM sometimes creates links to scraps that were not in search results. This change uses prohibition language and reinforces the constraint at the point of content creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)