### PR TITLE
Add get command to retrieve scrap content by title

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,17 @@ pub enum SubCommands {
         verbose: Verbosity<WarnLevel>,
     },
 
+    #[command(about = "Get the markdown body of a scrap by title")]
+    Get {
+        title: String,
+
+        #[arg(long, help = "Disambiguate title across contexts")]
+        ctx: Option<String>,
+
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
     #[command(about = "Init scraps project")]
     Init { project_name: String },
 

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod get;
 pub mod init;
 pub mod lint;
 pub mod mcp;

--- a/src/cli/cmd/get.rs
+++ b/src/cli/cmd/get.rs
@@ -1,0 +1,194 @@
+use std::io::Write;
+use std::path::Path;
+
+use crate::cli::config::scrap_config::ScrapConfig;
+use crate::cli::json::scrap::ScrapJson;
+use crate::cli::path_resolver::PathResolver;
+use crate::error::ScrapsResult;
+use crate::input::file::read_scraps;
+use crate::usecase::scrap::get::usecase::GetScrapUsecase;
+use scraps_libs::model::context::Ctx;
+use scraps_libs::model::scrap::Scrap;
+use scraps_libs::model::title::Title;
+
+pub fn run(
+    title: &str,
+    ctx: Option<&str>,
+    json: bool,
+    project_path: Option<&Path>,
+    writer: &mut impl Write,
+) -> ScrapsResult<()> {
+    let path_resolver = PathResolver::new(project_path)?;
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
+
+    let scraps = read_scraps::to_all_scraps(&scraps_dir_path)?;
+    let target_title = Title::from(title);
+    let resolved_ctx = resolve_ctx(&scraps, &target_title, ctx)?;
+
+    let usecase = GetScrapUsecase::new();
+    let result = usecase.execute(&scraps, &target_title, &resolved_ctx)?;
+
+    if json {
+        let scrap_json = ScrapJson {
+            title: result.title.to_string(),
+            ctx: result.ctx.map(|c| c.to_string()),
+            md_text: result.md_text,
+        };
+        writeln!(writer, "{}", serde_json::to_string(&scrap_json)?)?;
+    } else {
+        write!(writer, "{}", result.md_text)?;
+    }
+    Ok(())
+}
+
+fn resolve_ctx(scraps: &[Scrap], title: &Title, ctx: Option<&str>) -> ScrapsResult<Option<Ctx>> {
+    if let Some(c) = ctx {
+        return Ok(Some(Ctx::from(c)));
+    }
+
+    let candidates: Vec<&Scrap> = scraps.iter().filter(|s| s.title() == title).collect();
+
+    match candidates.as_slice() {
+        [] => Ok(None),
+        [only] => Ok(Option::<Ctx>::from(&only.self_key())),
+        many => {
+            let mut listed: Vec<String> = many.iter().map(|s| s.self_key().to_string()).collect();
+            listed.sort();
+            let joined = listed
+                .into_iter()
+                .map(|k| format!("  - {k}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(anyhow::anyhow!(
+                "multiple scraps found for \"{title}\". Specify --ctx:\n{joined}"
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
+
+    #[rstest]
+    fn run_text_outputs_md_body(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nBody");
+
+        let mut buf = Vec::new();
+        run(
+            "rust",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("# Rust"));
+        assert!(output.contains("Body"));
+    }
+
+    #[rstest]
+    fn run_json_outputs_scrap(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("Backend/Auth.md", b"# Auth\n\nBody");
+
+        let mut buf = Vec::new();
+        run(
+            "Auth",
+            Some("Backend"),
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(scrap.title, "Auth");
+        assert_eq!(scrap.ctx.as_deref(), Some("Backend"));
+        assert!(scrap.md_text.contains("# Auth"));
+    }
+
+    #[rstest]
+    fn run_resolves_unique_title_without_ctx(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("Backend/Auth.md", b"# Auth\n\nFrom Backend");
+
+        let mut buf = Vec::new();
+        run(
+            "Auth",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(scrap.title, "Auth");
+        assert_eq!(scrap.ctx.as_deref(), Some("Backend"));
+    }
+
+    #[rstest]
+    fn run_errors_on_ambiguous_title(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("Backend/Auth.md", b"# Auth\n\nBackend body")
+            .add_scrap("Frontend/Auth.md", b"# Auth\n\nFrontend body");
+
+        let mut buf = Vec::new();
+        let result = run(
+            "Auth",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("multiple scraps found"));
+        assert!(msg.contains("Backend/Auth"));
+        assert!(msg.contains("Frontend/Auth"));
+    }
+
+    #[rstest]
+    fn run_errors_on_missing_title(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_config(b"").add_scrap("rust.md", b"# Rust");
+
+        let mut buf = Vec::new();
+        let result = run(
+            "nonexistent",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn run_fails_without_config(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let mut buf = Vec::new();
+        let result = run(
+            "rust",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/cli/json/scrap.rs
+++ b/src/cli/json/scrap.rs
@@ -5,3 +5,10 @@ pub struct ScrapKeyJson {
     pub title: String,
     pub ctx: Option<String>,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScrapJson {
+    pub title: String,
+    pub ctx: Option<String>,
+    pub md_text: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ fn main() -> error::ScrapsResult<()> {
             cli::cmd::init::run(&project_name, cli.path.as_deref())
         }
         cli::SubCommands::Build { verbose } => cli::cmd::build::run(verbose, cli.path.as_deref()),
+        cli::SubCommands::Get { title, ctx, json } => cli::cmd::get::run(
+            &title,
+            ctx.as_deref(),
+            json,
+            cli.path.as_deref(),
+            &mut std::io::stdout(),
+        ),
         cli::SubCommands::Lint { rules } => {
             let rule_names: Vec<_> = rules.into_iter().map(Into::into).collect();
             cli::cmd::lint::run(cli.path.as_deref(), &rule_names)


### PR DESCRIPTION
## Summary

Adds a new `get` subcommand that retrieves and displays the markdown content of a scrap by its title. The command supports:
- Retrieving scraps by title with optional context disambiguation
- Automatic context resolution when a title is unique
- Output in both plain text (markdown) and JSON formats
- Proper error handling for ambiguous or missing titles

## Implementation Details

- **New `get` command module** (`src/cli/cmd/get.rs`): Implements the core logic for retrieving scraps, including context resolution that automatically infers the context when a title is unique across the project
- **CLI integration**: Added `Get` subcommand variant with `--ctx` and `--json` flags
- **JSON schema**: Extended `ScrapJson` struct to include the full markdown body (`md_text`) for JSON output
- **Comprehensive tests**: Covers text output, JSON output, automatic context resolution, ambiguous title detection, missing titles, and missing configuration

## Related Issues

<!-- Optional: Link any related issues using "Fixes #123" or "Addresses #123" -->

## Additional Notes

The context resolution logic intelligently handles three cases:
1. Explicit context provided via `--ctx` flag
2. Single matching scrap - automatically uses its context
3. Multiple matching scraps - returns an error listing all candidates to guide the user

All changes are covered by unit tests using the test fixture framework.

https://claude.ai/code/session_01CnTRg5KegxHRQ8FRGwo9UP