### PR TITLE
Add optional --git flag to build and serve commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,12 @@ pub enum SubCommands {
     Build {
         #[command(flatten)]
         verbose: Verbosity<WarnLevel>,
+
+        #[arg(
+            long,
+            help = "Include git-derived metadata (commited_ts) in HTML output and template variables"
+        )]
+        git: bool,
     },
 
     #[command(about = "Init scraps project")]
@@ -50,7 +56,13 @@ pub enum SubCommands {
     },
 
     #[command(about = "Serve the site with build scraps")]
-    Serve,
+    Serve {
+        #[arg(
+            long,
+            help = "Include git-derived metadata (commited_ts) in HTML output and template variables"
+        )]
+        git: bool,
+    },
 
     #[command(about = "Tag commands")]
     Tag {

--- a/src/cli/cmd/build.rs
+++ b/src/cli/cmd/build.rs
@@ -21,7 +21,11 @@ use crate::cli::path_resolver::PathResolver;
 use crate::usecase::progress::Progress;
 use scraps_libs::git::GitCommandImpl;
 
-pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> ScrapsResult<()> {
+pub fn run(
+    verbose: Verbosity<WarnLevel>,
+    git: bool,
+    project_path: Option<&Path>,
+) -> ScrapsResult<()> {
     let log_level = match verbose.log_level() {
         Some(log::Level::Error) => Level::ERROR,
         Some(log::Level::Warn) => Level::WARN,
@@ -35,12 +39,12 @@ pub fn run(verbose: Verbosity<WarnLevel>, project_path: Option<&Path>) -> Scraps
         .with_max_level(log_level)
         .init();
     let span_run = span!(Level::INFO, "run").entered();
-    let result = execute(project_path);
+    let result = execute(git, project_path);
     span_run.exit();
     result
 }
 
-fn execute(project_path: Option<&Path>) -> ScrapsResult<()> {
+fn execute(git: bool, project_path: Option<&Path>) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
     let config = ScrapConfig::from_path(project_path)?;
     let ssg = config.require_ssg()?;
@@ -48,8 +52,8 @@ fn execute(project_path: Option<&Path>) -> ScrapsResult<()> {
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
 
-    // Input: read scraps with git timestamps and README
-    let git_command = GitCommandImpl::new();
+    // Input: read scraps (with git timestamps if --git is set) and README
+    let git_command = git.then(GitCommandImpl::new);
     let (scraps_with_ts, readme_text) =
         read_scraps::to_all_scraps_with_timestamps(&scraps_dir_path, git_command)?;
 
@@ -116,7 +120,7 @@ mod tests {
             .add_scrap("test1.md", b"# header1\n## header2\n")
             .add_scrap("test2.md", b"[[test1]]\n");
 
-        let result = execute(Some(project.project_root.as_path()));
+        let result = execute(false, Some(project.project_root.as_path()));
         assert!(result.is_ok());
 
         // Verify scrap HTMLs generated
@@ -147,11 +151,28 @@ mod tests {
             .add_scrap("test1.md", b"# header1\n")
             .add_scrap("test2.md", b"[[test1]]\n");
 
-        let result = execute(Some(project.project_root.as_path()));
+        let result = execute(false, Some(project.project_root.as_path()));
         assert!(result.is_ok());
 
         // Verify search index JSON not generated
         let json = fs::read_to_string(project.public_path("search_index.json"));
         assert!(json.is_err());
+    }
+
+    #[rstest]
+    fn run_with_git_flag_includes_commited_date_block(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"[ssg]\nbase_url = \"http://localhost:1112/\"\ntitle = \"Test\"")
+            .add_scrap("test1.md", b"# header1\n");
+
+        let result = execute(true, Some(project.project_root.as_path()));
+        assert!(result.is_ok());
+
+        // Outside a git repo `commited_ts` is None so the conditional block
+        // is omitted; this test just asserts that --git does not error out.
+        let html = fs::read_to_string(project.public_path("scraps/test1.html")).unwrap();
+        assert!(!html.is_empty());
     }
 }

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use scraps_libs::git::GitCommandImpl;
 
-pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
+pub fn run(git: bool, project_path: Option<&Path>) -> ScrapsResult<()> {
     // set local environment
     let addr: SocketAddr = ([127, 0, 0, 1], 1112).into();
     let base_url = BaseUrl::new(Url::parse(&format!("http://{addr}"))?.join("").unwrap()).unwrap();
@@ -37,8 +37,8 @@ pub fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
     let static_dir_path = path_resolver.static_dir();
     let public_dir_path = path_resolver.public_dir();
 
-    // Input: read scraps with git timestamps and README
-    let git_command = GitCommandImpl::new();
+    // Input: read scraps (with git timestamps if --git is set) and README
+    let git_command = git.then(GitCommandImpl::new);
     let (scraps_with_ts, readme_text) =
         read_scraps::to_all_scraps_with_timestamps(&scraps_dir_path, git_command)?;
 

--- a/src/input/file/read_scraps.rs
+++ b/src/input/file/read_scraps.rs
@@ -64,15 +64,18 @@ pub(crate) fn to_all_scraps(scraps_dir_path: &Path) -> ScrapsResult<Vec<Scrap>> 
         .collect()
 }
 
-/// Read all scraps with git commit timestamps, and README text separately.
+/// Read all scraps with optional git commit timestamps, and README text separately.
 /// Used by build/serve commands that need both scraps+timestamps and README.
+///
+/// When `git_command` is `None`, no git subprocess is spawned and every scrap's
+/// `commited_ts` is returned as `None`. When `Some`, a `git not installed`
+/// failure is downgraded to `None` with a warning rather than an error.
 pub(crate) fn to_all_scraps_with_timestamps<
     GC: scraps_libs::git::GitCommand + Send + Sync + Copy,
 >(
     scraps_dir_path: &Path,
-    git_command: GC,
+    git_command: Option<GC>,
 ) -> ScrapsResult<(Vec<(Scrap, Option<i64>)>, Option<String>)> {
-    use crate::error::BuildError;
     use rayon::prelude::*;
 
     let paths = to_scrap_paths(scraps_dir_path)?;
@@ -85,17 +88,32 @@ pub(crate) fn to_all_scraps_with_timestamps<
     // Read README text
     let readme_text = readme_paths
         .first()
-        .map(|path| fs::read_to_string(path).context(BuildError::ReadREADMEFile))
+        .map(|path| fs::read_to_string(path).context(crate::error::BuildError::ReadREADMEFile))
         .transpose()?;
 
-    // Read scraps with git timestamps in parallel
+    // Read scraps (with git timestamps if enabled) in parallel
     let scraps_with_ts = scrap_paths
         .into_par_iter()
         .map(|path| {
             let scrap = to_scrap_by_path(scraps_dir_path, &path)?;
-            let commited_ts = git_command
-                .commited_ts(&path)
-                .context(BuildError::GitCommitedTs)?;
+            let commited_ts = match git_command {
+                Some(gc) => match gc.commited_ts(&path) {
+                    Ok(ts) => ts,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        tracing::warn!(
+                            "git binary not found; skipping commited_ts for {}",
+                            path.display()
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        return Err(
+                            anyhow::Error::new(e).context(crate::error::BuildError::GitCommitedTs)
+                        );
+                    }
+                },
+                None => None,
+            };
             Ok((scrap, commited_ts))
         })
         .collect::<ScrapsResult<Vec<(Scrap, Option<i64>)>>>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,14 @@ fn main() -> error::ScrapsResult<()> {
         cli::SubCommands::Init { project_name } => {
             cli::cmd::init::run(&project_name, cli.path.as_deref())
         }
-        cli::SubCommands::Build { verbose } => cli::cmd::build::run(verbose, cli.path.as_deref()),
+        cli::SubCommands::Build { verbose, git } => {
+            cli::cmd::build::run(verbose, git, cli.path.as_deref())
+        }
         cli::SubCommands::Lint { rules } => {
             let rule_names: Vec<_> = rules.into_iter().map(Into::into).collect();
             cli::cmd::lint::run(cli.path.as_deref(), &rule_names)
         }
-        cli::SubCommands::Serve => cli::cmd::serve::run(cli.path.as_deref()),
+        cli::SubCommands::Serve { git } => cli::cmd::serve::run(git, cli.path.as_deref()),
         cli::SubCommands::Tag { tag_command } => match tag_command {
             cli::TagSubCommands::List { json } => {
                 cli::cmd::tag::list::run(json, cli.path.as_deref(), &mut std::io::stdout())


### PR DESCRIPTION
## Summary

Add an optional `--git` flag to the `build` and `serve` commands that controls whether git-derived metadata (specifically `commited_ts`) is included in the HTML output and template variables.

### Changes

- **CLI**: Added `--git` boolean flag to both `Build` and `Serve` subcommands
- **build.rs**: Updated `run()` and `execute()` functions to accept and pass through the `git` parameter
- **serve.rs**: Updated `run()` function to accept and pass through the `git` parameter
- **read_scraps.rs**: Modified `to_all_scraps_with_timestamps()` to accept `Option<GC>` instead of `GC`, allowing git functionality to be optional:
  - When `None`, no git subprocess is spawned and all `commited_ts` values are `None`
  - When `Some`, gracefully downgrades "git not installed" errors to warnings instead of failing
- **main.rs**: Updated command handlers to pass the `git` flag through the call chain

### Behavior

- By default (without `--git` flag), the build/serve commands skip git operations entirely
- With `--git` flag enabled, git metadata is collected if available
- If git is not installed when `--git` is used, a warning is logged but the build continues (rather than erroring)

### Testing

Added a new test `run_with_git_flag_includes_commited_date_block()` that verifies the `--git` flag doesn't cause errors. Updated existing tests to pass `false` for the new `git` parameter.

https://claude.ai/code/session_01DtnnFN5hDMLu7gRt2y7hWK