### PR TITLE
Add max-depth validation for Ctx parsing (#474)

### DIFF
--- a/modules/libs/src/model/context.rs
+++ b/modules/libs/src/model/context.rs
@@ -10,6 +10,9 @@ pub struct Ctx {
 }
 
 impl Ctx {
+    /// Maximum number of nested ctx segments accepted by `try_parse`.
+    pub const MAX_DEPTH: usize = 3;
+
     pub fn depth(&self) -> usize {
         self.segments.len()
     }
@@ -17,7 +20,38 @@ impl Ctx {
     pub fn segments(&self) -> &[String] {
         &self.segments
     }
+
+    /// Parse a `/`-separated string and reject ctx whose depth exceeds
+    /// [`Ctx::MAX_DEPTH`]. Empty / collapsed segments are dropped before
+    /// the depth check, matching `From<&str>` semantics.
+    pub fn try_parse(s: &str) -> Result<Self, CtxParseError> {
+        let ctx = Ctx::from(s);
+        if ctx.depth() > Self::MAX_DEPTH {
+            return Err(CtxParseError::DepthExceeded {
+                actual: ctx.depth(),
+                max: Self::MAX_DEPTH,
+            });
+        }
+        Ok(ctx)
+    }
 }
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CtxParseError {
+    DepthExceeded { actual: usize, max: usize },
+}
+
+impl Display for CtxParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DepthExceeded { actual, max } => {
+                write!(f, "ctx depth {actual} exceeds maximum {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CtxParseError {}
 
 /// Parses a `/`-separated string. Empty segments (from leading, trailing, or
 /// repeated `/`) are dropped. An entirely empty input yields a `Ctx` with no
@@ -103,5 +137,40 @@ mod tests {
         v.sort();
         let displayed: Vec<String> = v.iter().map(|c| format!("{}", c)).collect();
         assert_eq!(displayed, vec!["a", "a/a", "a/b", "b"]);
+    }
+
+    #[rstest]
+    #[case::single_segment("a", 1)]
+    #[case::two_segments("a/b", 2)]
+    #[case::at_max_depth("a/b/c", 3)]
+    fn it_try_parse_accepts_within_max_depth(#[case] input: &str, #[case] expected_depth: usize) {
+        let ctx = Ctx::try_parse(input).expect("within max depth");
+        assert_eq!(ctx.depth(), expected_depth);
+    }
+
+    #[rstest]
+    #[case::four("a/b/c/d", 4)]
+    #[case::five("a/b/c/d/e", 5)]
+    fn it_try_parse_rejects_over_max_depth(#[case] input: &str, #[case] actual: usize) {
+        let err = Ctx::try_parse(input).expect_err("exceeds max depth");
+        assert_eq!(
+            err,
+            CtxParseError::DepthExceeded {
+                actual,
+                max: Ctx::MAX_DEPTH,
+            }
+        );
+    }
+
+    #[test]
+    fn it_try_parse_collapses_empty_segments_before_depth_check() {
+        // double slash collapses to 3 segments — under the limit
+        let ctx = Ctx::try_parse("a//b/c").expect("double-slash collapses");
+        assert_eq!(ctx.depth(), 3);
+    }
+
+    #[test]
+    fn it_max_depth_default_is_three() {
+        assert_eq!(Ctx::MAX_DEPTH, 3);
     }
 }


### PR DESCRIPTION
## Summary

#474 のサブタスク「Add max-depth validation at parse time」のうち、model 層の基盤を追加します。

- `Ctx::MAX_DEPTH: usize = 3`(default) を公開定数として追加
- `Ctx::try_parse(&str) -> Result<Ctx, CtxParseError>` を追加。depth が `MAX_DEPTH` を超えると `CtxParseError::DepthExceeded { actual, max }` を返す
- 既存の infallible な `From<&str>` は内部利用 / 検証済み入力向けにそのまま残置
- empty/double-slash の collapse 後に depth チェックを行う（`From<&str>` の挙動と一致）

## Test plan

TDD で実装。`modules/libs/src/model/context.rs` のテストモジュールに以下を追加:

- [x] `it_try_parse_accepts_within_max_depth` (1〜3 segments)
- [x] `it_try_parse_rejects_over_max_depth` (4, 5 segments で `DepthExceeded`)
- [x] `it_try_parse_collapses_empty_segments_before_depth_check`(`a//b/c` → depth 3)
- [x] `it_max_depth_default_is_three`（デフォルト値 3 の tripwire）
- [x] `mise run cargo:quality` 全件パス（test 288 ok）

## Out of scope (follow-up)

- 呼び出し箇所への統合（`read_scraps`, `cli/cmd/get.rs --ctx`, MCP tool ctx 引数）
- `.scraps.toml` での `MAX_DEPTH` 設定可能化

https://claude.ai/code/session_0141FKyC2AHSuFKcAacNFfy7

---
_Generated by [Claude Code](https://claude.ai/code/session_0141FKyC2AHSuFKcAacNFfy7)_