### PR TITLE
Add broken-heading-ref lint rule for [[name#heading]]

### DIFF
--- a/docs/Reference/Lint.md
+++ b/docs/Reference/Lint.md
@@ -26,16 +26,6 @@ Detects the same `[[link]]` appearing multiple times within a single scrap. Repe
 
 `[[Page|alias]]` and `[[Page]]` are treated as the same link.
 
-### broken-link
-
-Detects `[[wikilink]]` references that don't resolve to any existing scrap. An unresolved scrap link is a real bug — usually a typo or a stale reference left behind after a rename.
-
-### broken-heading-ref
-
-Detects `[[name#heading]]` references whose `#heading` part doesn't match any heading in the target scrap. Headings are compared after slug normalization (lowercased, whitespace and special characters mapped to dashes), so `[[Topic#My Section]]` and `## my-section` resolve to the same anchor.
-
-If the target scrap itself doesn't exist, `broken-link` fires instead — `broken-heading-ref` only reports cases where the scrap was found but the heading inside it wasn't.
-
 ### singleton-tag
 
 Detects tags referenced by only 1 scrap. Tags used by a single scrap provide no grouping value and may indicate a tag that should be removed or consolidated.

--- a/docs/Reference/Lint.md
+++ b/docs/Reference/Lint.md
@@ -26,6 +26,16 @@ Detects the same `[[link]]` appearing multiple times within a single scrap. Repe
 
 `[[Page|alias]]` and `[[Page]]` are treated as the same link.
 
+### broken-link
+
+Detects `[[wikilink]]` references that don't resolve to any existing scrap. An unresolved scrap link is a real bug — usually a typo or a stale reference left behind after a rename.
+
+### broken-heading-ref
+
+Detects `[[name#heading]]` references whose `#heading` part doesn't match any heading in the target scrap. Headings are compared after slug normalization (lowercased, whitespace and special characters mapped to dashes), so `[[Topic#My Section]]` and `## my-section` resolve to the same anchor.
+
+If the target scrap itself doesn't exist, `broken-link` fires instead — `broken-heading-ref` only reports cases where the scrap was found but the heading inside it wasn't.
+
 ### singleton-tag
 
 Detects tags referenced by only 1 scrap. Tags used by a single scrap provide no grouping value and may indicate a tag that should be removed or consolidated.

--- a/modules/libs/src/markdown/query.rs
+++ b/modules/libs/src/markdown/query.rs
@@ -1,5 +1,6 @@
 mod common;
 mod embeds;
+mod headings;
 mod images;
 mod section;
 mod tags;
@@ -8,6 +9,7 @@ mod wiki_ref;
 mod wikilinks;
 
 pub use embeds::{embeds, EmbedRef};
+pub use headings::headings;
 pub use images::images;
 pub use section::section;
 pub use tags::{tags, TagRef};

--- a/modules/libs/src/markdown/query/headings.rs
+++ b/modules/libs/src/markdown/query/headings.rs
@@ -1,0 +1,78 @@
+use comrak::{nodes::NodeValue, parse_document, Arena};
+
+use super::common::{collect_text, options};
+
+/// Extract heading text strings from a markdown document, in occurrence order.
+///
+/// Returns the visible label of every ATX/Setext heading. Levels and structural
+/// information are not preserved — callers that need them should parse the
+/// document themselves. Wiki-link / inline markup inside a heading is collapsed
+/// to its plain-text label, mirroring how `section()` identifies headings.
+pub fn headings(text: &str) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let arena = Arena::new();
+    let opts = options();
+    let root = parse_document(&arena, text, &opts);
+
+    let mut out = Vec::new();
+    for n in root.descendants() {
+        if let NodeValue::Heading(_) = &n.data().value {
+            out.push(collect_text(n));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_headings_basic() {
+        let input = "# H1\n\n## H2\n\n### H3\n";
+        assert_eq!(headings(input), vec!["H1", "H2", "H3"]);
+    }
+
+    #[test]
+    fn it_headings_setext() {
+        let input = "Title\n=====\n\nSub\n---\n";
+        assert_eq!(headings(input), vec!["Title", "Sub"]);
+    }
+
+    #[test]
+    fn it_headings_with_inline_markup() {
+        let input = "## Hello **bold** world\n";
+        assert_eq!(headings(input), vec!["Hello bold world"]);
+    }
+
+    #[test]
+    fn it_headings_with_wikilink() {
+        let input = "## see [[topic]]\n";
+        assert_eq!(headings(input), vec!["see topic"]);
+    }
+
+    #[test]
+    fn it_headings_empty_input() {
+        assert!(headings("").is_empty());
+    }
+
+    #[test]
+    fn it_headings_no_headings() {
+        let input = "just a paragraph\n\nanother paragraph\n";
+        assert!(headings(input).is_empty());
+    }
+
+    #[test]
+    fn it_headings_preserves_order_and_duplicates() {
+        let input = "## same\n\nbody\n\n## same\n\nmore\n";
+        assert_eq!(headings(input), vec!["same", "same"]);
+    }
+
+    #[test]
+    fn it_headings_japanese() {
+        let input = "## 見出し\n\n本文\n";
+        assert_eq!(headings(input), vec!["見出し"]);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,6 +122,8 @@ pub enum CliLintRuleName {
     Overlinking,
     #[value(name = "broken-link")]
     BrokenLink,
+    #[value(name = "broken-heading-ref")]
+    BrokenHeadingRef,
 }
 
 impl From<CliLintRuleName> for LintRuleName {
@@ -132,6 +134,7 @@ impl From<CliLintRuleName> for LintRuleName {
             CliLintRuleName::SelfLink => LintRuleName::SelfLink,
             CliLintRuleName::Overlinking => LintRuleName::Overlinking,
             CliLintRuleName::BrokenLink => LintRuleName::BrokenLink,
+            CliLintRuleName::BrokenHeadingRef => LintRuleName::BrokenHeadingRef,
         }
     }
 }

--- a/src/usecase/lint/rule.rs
+++ b/src/usecase/lint/rule.rs
@@ -9,6 +9,7 @@ pub enum LintRuleName {
     SelfLink,
     Overlinking,
     BrokenLink,
+    BrokenHeadingRef,
 }
 
 impl LintRuleName {
@@ -19,6 +20,7 @@ impl LintRuleName {
             Self::SelfLink => "self-link",
             Self::Overlinking => "overlinking",
             Self::BrokenLink => "broken-link",
+            Self::BrokenHeadingRef => "broken-heading-ref",
         }
     }
 }

--- a/src/usecase/lint/rules.rs
+++ b/src/usecase/lint/rules.rs
@@ -1,3 +1,4 @@
+pub mod broken_heading_ref;
 pub mod broken_link;
 pub mod dead_end;
 pub mod lonely;

--- a/src/usecase/lint/rules/broken_heading_ref.rs
+++ b/src/usecase/lint/rules/broken_heading_ref.rs
@@ -1,0 +1,189 @@
+use std::collections::{HashMap, HashSet};
+
+use scraps_libs::{
+    markdown,
+    model::{key::ScrapKey, scrap::Scrap, tags::Tags},
+    slugify,
+};
+
+use crate::usecase::build::model::backlinks_map::BacklinksMap;
+use crate::usecase::lint::rule::{scrap_relative_path, LintRule, LintRuleName, LintWarning};
+
+/// Detect `[[name#heading]]` references whose `#heading` part doesn't match any
+/// heading in the target scrap.
+///
+/// Heading resolution (v1): the referenced heading and each candidate heading
+/// in the target scrap are normalized with `slugify::by_dash` before comparison.
+/// The same slugifier feeds the URL fragment that HTML rendering emits, so
+/// "no warning" means the rendered `target.html#fragment` lines up with a
+/// heading slug in the target document.
+///
+/// Missing-target-scrap is the `broken-link` rule's territory; this rule stays
+/// silent in that case to keep one warning per real cause.
+pub struct BrokenHeadingRefRule;
+
+impl LintRule for BrokenHeadingRefRule {
+    fn name(&self) -> LintRuleName {
+        LintRuleName::BrokenHeadingRef
+    }
+
+    fn check(
+        &self,
+        scraps: &[Scrap],
+        _backlinks_map: &BacklinksMap,
+        _tags: &Tags,
+    ) -> Vec<LintWarning> {
+        let scrap_by_key: HashMap<ScrapKey, &Scrap> =
+            scraps.iter().map(|s| (s.self_key(), s)).collect();
+
+        let heading_slugs_cache: HashMap<ScrapKey, HashSet<String>> = scrap_by_key
+            .iter()
+            .map(|(key, scrap)| {
+                let slugs = markdown::query::headings(scrap.md_text())
+                    .into_iter()
+                    .map(|h| slugify::by_dash(&h))
+                    .collect();
+                (key.clone(), slugs)
+            })
+            .collect();
+
+        let mut warnings = Vec::new();
+        for scrap in scraps {
+            let path = scrap_relative_path(scrap);
+            for link in markdown::query::wikilinks(scrap.md_text()) {
+                let Some(heading) = link.heading.as_ref() else {
+                    continue;
+                };
+                let target_key = ScrapKey::from(&link);
+                let Some(target_slugs) = heading_slugs_cache.get(&target_key) else {
+                    continue;
+                };
+                let ref_slug = slugify::by_dash(heading);
+                if ref_slug.is_empty() || target_slugs.contains(&ref_slug) {
+                    continue;
+                }
+                warnings.push(LintWarning {
+                    rule_name: LintRuleName::BrokenHeadingRef,
+                    scrap_path: path.clone(),
+                    message: format!(
+                        "broken heading reference: [[{}#{}]] (heading not found in target scrap)",
+                        target_key, heading
+                    ),
+                    source: None,
+                    span: None,
+                });
+            }
+        }
+        warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_broken_heading_ref() {
+        let target = Scrap::new("target", &None, "## present\n\nbody\n");
+        let referrer = Scrap::new("a", &None, "see [[target#missing]]");
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].rule_name, LintRuleName::BrokenHeadingRef);
+        assert_eq!(warnings[0].scrap_path, "a.md");
+        assert!(warnings[0].message.contains("target"));
+        assert!(warnings[0].message.contains("missing"));
+    }
+
+    #[test]
+    fn skip_resolved_heading_ref() {
+        let target = Scrap::new("target", &None, "## present\n\nbody\n");
+        let referrer = Scrap::new("a", &None, "see [[target#present]]");
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn skip_link_without_heading() {
+        let target = Scrap::new("target", &None, "no headings here");
+        let referrer = Scrap::new("a", &None, "see [[target]]");
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn skip_when_target_scrap_missing() {
+        // Missing-target-scrap is broken-link's job. broken-heading-ref must
+        // not double-report that case.
+        let referrer = Scrap::new("a", &None, "see [[ghost#whatever]]");
+        let scraps = vec![referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn detect_with_alias_and_context() {
+        let target = Scrap::new("Eric Evans", &Some("Person".into()), "## Bio\n\ntext\n");
+        let referrer = Scrap::new("a", &None, "[[Person/Eric Evans#missing|Eric]]");
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn case_insensitive_heading_match() {
+        // slugify::by_dash lowercases, so "Section" and "section" align.
+        let target = Scrap::new("target", &None, "## Section\n\nbody\n");
+        let referrer = Scrap::new("a", &None, "see [[target#section]]");
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn detect_self_referencing_broken_heading() {
+        let scrap = Scrap::new("a", &None, "## present\n\n[[a#missing]]");
+        let scraps = vec![scrap];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn detect_multiple_broken_heading_refs_within_one_scrap() {
+        let target = Scrap::new("target", &None, "## one\n\nbody\n");
+        let referrer = Scrap::new(
+            "a",
+            &None,
+            "[[target#missing1]] and [[target#missing2]] and [[target#one]]",
+        );
+        let scraps = vec![target, referrer];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = BrokenHeadingRefRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 2);
+    }
+}

--- a/src/usecase/lint/usecase.rs
+++ b/src/usecase/lint/usecase.rs
@@ -6,8 +6,9 @@ use crate::{error::ScrapsResult, usecase::build::model::backlinks_map::Backlinks
 use super::{
     rule::{LintRule, LintRuleName, LintWarning},
     rules::{
-        broken_link::BrokenLinkRule, dead_end::DeadEndRule, lonely::LonelyRule,
-        overlinking::OverlinkingRule, self_link::SelfLinkRule,
+        broken_heading_ref::BrokenHeadingRefRule, broken_link::BrokenLinkRule,
+        dead_end::DeadEndRule, lonely::LonelyRule, overlinking::OverlinkingRule,
+        self_link::SelfLinkRule,
     },
 };
 
@@ -32,6 +33,7 @@ impl LintUsecase {
             Box::new(SelfLinkRule),
             Box::new(OverlinkingRule),
             Box::new(BrokenLinkRule),
+            Box::new(BrokenHeadingRefRule),
         ];
 
         let rules: Vec<Box<dyn LintRule>> = if rule_names.is_empty() {
@@ -63,11 +65,14 @@ mod tests {
         // - self_linker: self_link
         // - overlinker: overlinking (duplicate refs to no_links)
         // - linker_to_unknown: broken_link ([[unknown]] doesn't resolve)
+        // - heading_referrer: broken_heading_ref ([[no_links#missing]] - target
+        //   exists but heading doesn't)
         let scraps = vec![
             Scrap::new("no_links", &None, "plain text"),
             Scrap::new("self_linker", &None, "[[self_linker]] [[no_links]]"),
             Scrap::new("overlinker", &None, "[[no_links]] [[no_links]]"),
             Scrap::new("linker_to_unknown", &None, "[[unknown]]"),
+            Scrap::new("heading_referrer", &None, "[[no_links#missing]]"),
         ];
 
         let usecase = LintUsecase::new();
@@ -79,6 +84,7 @@ mod tests {
         assert!(rule_names.contains(&&LintRuleName::SelfLink));
         assert!(rule_names.contains(&&LintRuleName::Overlinking));
         assert!(rule_names.contains(&&LintRuleName::BrokenLink));
+        assert!(rule_names.contains(&&LintRuleName::BrokenHeadingRef));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #472.

`[[name#heading]]` syntax was already wired through the parser and HTML URL-fragment generation, so the missing piece for v1 was validation: a typo in the heading slug silently produced a dead anchor. This PR adds a `broken-heading-ref` lint rule that fires when the target scrap exists but the referenced heading slug doesn't match any heading in it.

### Heading resolution

- Both sides are normalized with `slugify::by_dash` — the same slugifier `transform_wiki_refs` uses to build URL fragments — so "no warning" means the rendered `target.html#fragment` aligns with a real heading slug in the target.
- Missing-target-scrap stays with `broken-link`; `broken-heading-ref` deliberately stays silent in that case so each cause maps to one warning.

### Changes

- New `markdown::query::headings()` returns the visible text of every ATX/Setext heading in document order. Reusable for future MCP / tooling needs.
- New `LintRuleName::BrokenHeadingRef` variant + `--rule broken-heading-ref` CLI value.
- `BrokenHeadingRefRule` implementation + tests covering: matched / mismatched slug, alias, context path, case-insensitive match, self-reference, missing target scrap (deferred to broken-link), and multi-warning aggregation.
- Updates `docs/Reference/Lint.md` with `broken-link` and `broken-heading-ref` entries.

### Out of scope

- HTML build emitting `id="..."` on heading elements: the URL fragment is generated, but the target heading currently has no anchor id. Listed as "to be decided" in the issue and worth a separate PR since slugifier choice (`slugify::by_dash` vs Comrak's GitHub-style) affects what id format to emit.
- MCP `lookup_scrap_links` heading exposure — also "to be decided"; can layer on later using the new `headings()` query.
- `![[name#heading]]` / block refs — explicitly out of scope per the issue.

## Test plan

- [x] `mise run cargo:quality` passes (build + test + fmt + clippy)
- [x] New unit tests in `headings.rs` and `broken_heading_ref.rs` all green
- [x] Aggregator test in `usecase.rs` updated to assert `BrokenHeadingRef` is produced
- [ ] Manual: run `scraps lint --rule broken-heading-ref` against a sample project with a known broken `[[topic#missing]]` and confirm the warning surfaces

https://claude.ai/code/session_01CMMfJ8gKaR1Ah68F3LbYz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMMfJ8gKaR1Ah68F3LbYz7)_