### PR TITLE
Add `scraps backlinks` command with --json support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,17 @@ pub enum SubCommands {
         json: bool,
     },
 
+    #[command(about = "List inbound wiki-links (backlinks) to a scrap")]
+    Backlinks {
+        title: String,
+
+        #[arg(long, help = "Disambiguate title across contexts")]
+        ctx: Option<String>,
+
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
     #[command(about = "Serve the site with build scraps")]
     Serve {
         #[arg(

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,3 +1,4 @@
+pub mod backlinks;
 pub mod build;
 pub mod get;
 pub mod init;

--- a/src/cli/cmd/backlinks.rs
+++ b/src/cli/cmd/backlinks.rs
@@ -1,0 +1,239 @@
+use std::io::Write;
+use std::path::Path;
+
+use colored::Colorize;
+use comfy_table::presets::NOTHING;
+use comfy_table::{Cell, Table};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::config::scrap_config::ScrapConfig;
+use crate::cli::json::scrap::ScrapKeyJson;
+use crate::cli::path_resolver::PathResolver;
+use crate::error::ScrapsResult;
+use crate::input::file::read_scraps;
+use crate::usecase::scrap::lookup_backlinks::usecase::LookupScrapBacklinksUsecase;
+use scraps_libs::model::context::Ctx;
+use scraps_libs::model::title::Title;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BacklinksResponse {
+    results: Vec<ScrapKeyJson>,
+    count: usize,
+}
+
+pub fn run(
+    title: &str,
+    ctx: Option<&str>,
+    json: bool,
+    project_path: Option<&Path>,
+    writer: &mut impl Write,
+) -> ScrapsResult<()> {
+    let path_resolver = PathResolver::new(project_path)?;
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir(&config);
+
+    let scraps = read_scraps::to_all_scraps(&scraps_dir_path)?;
+    let target_title = Title::from(title);
+    let target_ctx = ctx.map(Ctx::from);
+
+    let usecase = LookupScrapBacklinksUsecase::new();
+    let results = usecase.execute(&scraps, &target_title, &target_ctx)?;
+
+    let scrap_keys: Vec<ScrapKeyJson> = results
+        .into_iter()
+        .map(|r| ScrapKeyJson {
+            title: r.title.to_string(),
+            ctx: r.ctx.map(|c| c.to_string()),
+        })
+        .collect();
+
+    if json {
+        let count = scrap_keys.len();
+        let response = BacklinksResponse {
+            results: scrap_keys,
+            count,
+        };
+        writeln!(writer, "{}", serde_json::to_string(&response)?)?;
+    } else {
+        if scrap_keys.is_empty() {
+            return Ok(());
+        }
+
+        let mut table = Table::new();
+        table.load_preset(NOTHING);
+        table.set_header(vec![Cell::new("Title".bold()), Cell::new("Context".bold())]);
+
+        for key in &scrap_keys {
+            table.add_row(vec![
+                Cell::new(&key.title),
+                Cell::new(key.ctx.as_deref().unwrap_or("")),
+            ]);
+        }
+        writeln!(writer, "{table}")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
+
+    #[rstest]
+    fn run_text_outputs_backlinks(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nLinks to [[cargo]].")
+            .add_scrap("clippy.md", b"# Clippy\n\nAlso uses [[cargo]].")
+            .add_scrap("cargo.md", b"# Cargo");
+
+        let mut buf = Vec::new();
+        run(
+            "cargo",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("rust"));
+        assert!(output.contains("clippy"));
+    }
+
+    #[rstest]
+    fn run_json_outputs_backlinks(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nLinks to [[cargo]].")
+            .add_scrap("clippy.md", b"# Clippy\n\nAlso uses [[cargo]].")
+            .add_scrap("cargo.md", b"# Cargo");
+
+        let mut buf = Vec::new();
+        run(
+            "cargo",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: BacklinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 2);
+        assert_eq!(response.results.len(), 2);
+
+        let titles: Vec<&str> = response.results.iter().map(|r| r.title.as_str()).collect();
+        assert!(titles.contains(&"rust"));
+        assert!(titles.contains(&"clippy"));
+    }
+
+    #[rstest]
+    fn run_json_outputs_empty_for_no_backlinks(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("cargo.md", b"# Cargo\n\nNo one links here.");
+
+        let mut buf = Vec::new();
+        run(
+            "cargo",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: BacklinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 0);
+        assert!(response.results.is_empty());
+    }
+
+    #[rstest]
+    fn run_with_ctx_resolves_target(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap(
+                "Backend/Server.md",
+                b"# Server\n\nLinks to [[Backend/Auth]].",
+            )
+            .add_scrap(
+                "Frontend/Login.md",
+                b"# Login\n\nLinks to [[Frontend/Auth]].",
+            )
+            .add_scrap("Backend/Auth.md", b"# Auth\n\nBackend auth")
+            .add_scrap("Frontend/Auth.md", b"# Auth\n\nFrontend auth");
+
+        let mut buf = Vec::new();
+        run(
+            "Auth",
+            Some("Backend"),
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: BacklinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 1);
+        assert_eq!(response.results[0].title, "Server");
+    }
+
+    #[rstest]
+    fn run_errors_when_ctx_is_omitted_for_ctx_scoped_scrap(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap(
+                "Backend/Server.md",
+                b"# Server\n\nLinks to [[Backend/Auth]].",
+            )
+            .add_scrap("Backend/Auth.md", b"# Auth");
+
+        let mut buf = Vec::new();
+        let result = run(
+            "Auth",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn run_errors_on_missing_title(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_config(b"").add_scrap("rust.md", b"# Rust");
+
+        let mut buf = Vec::new();
+        let result = run(
+            "nonexistent",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn run_fails_without_config(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let mut buf = Vec::new();
+        let result = run(
+            "rust",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,13 @@ fn main() -> error::ScrapsResult<()> {
             cli.path.as_deref(),
             &mut std::io::stdout(),
         ),
+        cli::SubCommands::Backlinks { title, ctx, json } => cli::cmd::backlinks::run(
+            &title,
+            ctx.as_deref(),
+            json,
+            cli.path.as_deref(),
+            &mut std::io::stdout(),
+        ),
         cli::SubCommands::Serve { git } => cli::cmd::serve::run(git, cli.path.as_deref()),
         cli::SubCommands::Tag { tag_command } => match tag_command {
             cli::TagSubCommands::List { json } => {


### PR DESCRIPTION
## Summary

Adds a new `scraps backlinks <title>` CLI command that lists inbound wiki-links (backlinks) to the specified scrap. Reuses `LookupScrapBacklinksUsecase` (the same usecase backing the MCP `lookup_scrap_backlinks` tool).

## Behavior

- `--ctx <ctx>`: disambiguate the target scrap when the same title appears in multiple contexts (passed through to the usecase, matching the post-#502 `links`/`get` behavior).
- `--json`: outputs `{ "results": [{ "title", "ctx" }], "count" }`.
- Default text output: a `Title` / `Context` table (empty when there are no backlinks).

## Changes

- `src/cli.rs`: add `SubCommands::Backlinks { title, ctx, json }`.
- `src/cli/cmd.rs`: register `backlinks` module.
- `src/cli/cmd/backlinks.rs`: new command implementation, modeled on `links.rs`.
- `src/main.rs`: dispatch `Backlinks` to `cli::cmd::backlinks::run`.

## Test plan

- [x] `mise run cargo:test` (7 new tests in `cli::cmd::backlinks::tests` pass; full suite green)
- [x] `mise run cargo:quality` (build + test + fmt + clippy all pass)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)