### PR TITLE
Add `stale_by_git` lint rule for detecting scraps untouched over a threshold

### DIFF
--- a/modules/libs/src/git.rs
+++ b/modules/libs/src/git.rs
@@ -7,6 +7,12 @@ use std::{
 pub trait GitCommand {
     fn init(&self, path: &Path) -> io::Result<()>;
     fn commited_ts(&self, path: &Path) -> io::Result<Option<i64>>;
+    /// Whether `path` lives inside a git working tree.
+    ///
+    /// Returns `Ok(false)` when git reports the path is not inside a working
+    /// tree. A missing `git` binary is also reported as `Ok(false)` so that
+    /// callers can degrade gracefully without distinguishing the two cases.
+    fn is_git_repository(&self, path: &Path) -> io::Result<bool>;
 }
 
 #[derive(Clone, Copy)]
@@ -46,6 +52,25 @@ impl GitCommand for GitCommandImpl {
         let commited_ts = output_str.trim().parse::<i64>().ok();
         Ok(commited_ts)
     }
+
+    fn is_git_repository(&self, path: &Path) -> io::Result<bool> {
+        let result = Command::new("git")
+            .current_dir(path)
+            .arg("rev-parse")
+            .arg("--is-inside-work-tree")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+
+        match result {
+            Ok(output) => {
+                Ok(output.status.success()
+                    && String::from_utf8_lossy(&output.stdout).trim() == "true")
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 #[cfg(feature = "git_test")]
@@ -67,6 +92,9 @@ pub mod tests {
         }
         fn commited_ts(&self, _path: &Path) -> io::Result<Option<i64>> {
             Ok(Some(0))
+        }
+        fn is_git_repository(&self, _path: &Path) -> io::Result<bool> {
+            Ok(true)
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,8 @@ pub enum CliLintRuleName {
     BrokenLink,
     #[value(name = "broken-heading-ref")]
     BrokenHeadingRef,
+    #[value(name = "stale-by-git")]
+    StaleByGit,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -194,6 +196,7 @@ impl From<CliLintRuleName> for LintRuleName {
             CliLintRuleName::Overlinking => LintRuleName::Overlinking,
             CliLintRuleName::BrokenLink => LintRuleName::BrokenLink,
             CliLintRuleName::BrokenHeadingRef => LintRuleName::BrokenHeadingRef,
+            CliLintRuleName::StaleByGit => LintRuleName::StaleByGit,
         }
     }
 }

--- a/src/cli/cmd/lint.rs
+++ b/src/cli/cmd/lint.rs
@@ -1,14 +1,19 @@
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use colored::Colorize;
+use scraps_libs::git::GitCommandImpl;
 
-use crate::cli::config::scrap_config::ScrapConfig;
+use crate::cli::config::scrap_config::{ScrapConfig, StaleByGitConfig};
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
-use crate::usecase::lint::rule::{LintRuleName, LintWarning};
+use crate::usecase::lint::rule::{LintRule, LintRuleName, LintWarning};
+use crate::usecase::lint::rules::stale_by_git::StaleByGitRule;
 use crate::usecase::lint::usecase::LintUsecase;
+
+const DEFAULT_STALE_THRESHOLD_DAYS: u64 = 180;
 
 pub fn run(project_path: Option<&Path>, rule_names: &[LintRuleName]) -> ScrapsResult<()> {
     let path_resolver = PathResolver::new(project_path)?;
@@ -17,8 +22,14 @@ pub fn run(project_path: Option<&Path>, rule_names: &[LintRuleName]) -> ScrapsRe
     let scraps_dir_name = config.scraps_dir.as_deref().unwrap_or(Path::new("scraps"));
 
     let scraps = read_scraps::to_all_scraps(&scraps_dir_path)?;
+
+    let stale_config = config.lint.as_ref().and_then(|l| l.stale_by_git.as_ref());
+    let effective_rules = resolve_effective_rules(rule_names, stale_config);
+
+    let extra_rules = build_extra_rules(&effective_rules, stale_config, &scraps_dir_path);
+
     let usecase = LintUsecase::new();
-    let warnings = usecase.execute(&scraps, rule_names)?;
+    let warnings = usecase.execute(&scraps, &effective_rules, extra_rules)?;
 
     if warnings.is_empty() {
         return Ok(());
@@ -41,11 +52,79 @@ pub fn run(project_path: Option<&Path>, rule_names: &[LintRuleName]) -> ScrapsRe
     Ok(())
 }
 
+/// Decide which rules will actually run.
+///
+/// CLI selection (`--rule X`) wins outright when given. Otherwise the default
+/// rules run, plus any opt-in rules whose config section says they should
+/// (e.g. `[lint.stale_by_git]` with `enabled = true`).
+fn resolve_effective_rules(
+    cli_rule_names: &[LintRuleName],
+    stale_config: Option<&StaleByGitConfig>,
+) -> Vec<LintRuleName> {
+    if !cli_rule_names.is_empty() {
+        return cli_rule_names.to_vec();
+    }
+
+    let mut rules = LintRuleName::default_rules();
+    if stale_config.is_some_and(|c| c.enabled) {
+        rules.push(LintRuleName::StaleByGit);
+    }
+    rules
+}
+
+fn build_extra_rules(
+    effective_rules: &[LintRuleName],
+    stale_config: Option<&StaleByGitConfig>,
+    scraps_dir: &Path,
+) -> Vec<Box<dyn LintRule>> {
+    let mut extras: Vec<Box<dyn LintRule>> = Vec::new();
+    if effective_rules.contains(&LintRuleName::StaleByGit) {
+        let threshold_days = stale_config
+            .and_then(|c| c.threshold_days)
+            .unwrap_or(DEFAULT_STALE_THRESHOLD_DAYS);
+        let now_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        extras.push(Box::new(StaleByGitRule {
+            git_command: GitCommandImpl::new(),
+            scraps_dir: scraps_dir.to_path_buf(),
+            threshold_days,
+            now_ts,
+        }));
+    }
+    extras
+}
+
+fn print_warning(warning: &LintWarning, scraps_dir: &Path, renderer: &Renderer) {
+    let file_path = scraps_dir.join(&warning.scrap_path);
+    let file_path_str = file_path.to_string_lossy();
+    let title = format!("{}: {}", warning.rule_name.as_str(), warning.message);
+
+    match (warning.source.as_ref(), warning.span) {
+        (Some(source), Some((start, end))) => {
+            let message = Level::Warning.title(&title).snippet(
+                Snippet::source(source)
+                    .line_start(1)
+                    .origin(&file_path_str)
+                    .fold(true)
+                    .annotation(Level::Warning.span(start..end)),
+            );
+            eprintln!("{}", renderer.render(message));
+        }
+        _ => {
+            let message = Level::Warning.title(&title);
+            eprintln!("{}", renderer.render(message));
+            eprintln!(" {} {}", "-->".blue().bold(), file_path_str);
+            eprintln!();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
-    use crate::usecase::lint::rule::LintRuleName;
     use rstest::rstest;
 
     #[rstest]
@@ -95,29 +174,66 @@ mod tests {
         let result = run(Some(project.project_root.as_path()), &[]);
         assert!(result.is_ok());
     }
-}
 
-fn print_warning(warning: &LintWarning, scraps_dir: &Path, renderer: &Renderer) {
-    let file_path = scraps_dir.join(&warning.scrap_path);
-    let file_path_str = file_path.to_string_lossy();
-    let title = format!("{}: {}", warning.rule_name.as_str(), warning.message);
+    #[rstest]
+    fn run_succeeds_with_stale_by_git_section(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"[lint.stale_by_git]\nthreshold_days = 30\n")
+            .add_scrap("a.md", b"[[b]]")
+            .add_scrap("b.md", b"[[a]]");
 
-    match (warning.source.as_ref(), warning.span) {
-        (Some(source), Some((start, end))) => {
-            let message = Level::Warning.title(&title).snippet(
-                Snippet::source(source)
-                    .line_start(1)
-                    .origin(&file_path_str)
-                    .fold(true)
-                    .annotation(Level::Warning.span(start..end)),
-            );
-            eprintln!("{}", renderer.render(message));
-        }
-        _ => {
-            let message = Level::Warning.title(&title);
-            eprintln!("{}", renderer.render(message));
-            eprintln!(" {} {}", "-->".blue().bold(), file_path_str);
-            eprintln!();
-        }
+        // Without --rule, presence of [lint.stale_by_git] enables the opt-in
+        // rule; outside a git repo it gracefully skips.
+        let result = run(Some(project.project_root.as_path()), &[]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn resolve_uses_cli_when_given() {
+        let cli = vec![LintRuleName::DeadEnd];
+        let resolved = resolve_effective_rules(&cli, None);
+        assert_eq!(resolved, vec![LintRuleName::DeadEnd]);
+    }
+
+    #[test]
+    fn resolve_omits_stale_when_section_absent() {
+        let resolved = resolve_effective_rules(&[], None);
+        assert!(!resolved.contains(&LintRuleName::StaleByGit));
+        // sanity: at least one default rule is included
+        assert!(resolved.contains(&LintRuleName::DeadEnd));
+    }
+
+    #[test]
+    fn resolve_includes_stale_when_section_present_and_enabled() {
+        let stale = StaleByGitConfig {
+            enabled: true,
+            threshold_days: Some(90),
+        };
+        let resolved = resolve_effective_rules(&[], Some(&stale));
+        assert!(resolved.contains(&LintRuleName::StaleByGit));
+    }
+
+    #[test]
+    fn resolve_omits_stale_when_section_present_but_disabled() {
+        let stale = StaleByGitConfig {
+            enabled: false,
+            threshold_days: Some(90),
+        };
+        let resolved = resolve_effective_rules(&[], Some(&stale));
+        assert!(!resolved.contains(&LintRuleName::StaleByGit));
+    }
+
+    #[test]
+    fn cli_rule_overrides_config_disable() {
+        // Even if config disables stale-by-git, explicit `--rule stale-by-git`
+        // still runs only that rule.
+        let stale = StaleByGitConfig {
+            enabled: false,
+            threshold_days: None,
+        };
+        let resolved = resolve_effective_rules(&[LintRuleName::StaleByGit], Some(&stale));
+        assert_eq!(resolved, vec![LintRuleName::StaleByGit]);
     }
 }

--- a/src/cli/config/scrap_config.rs
+++ b/src/cli/config/scrap_config.rs
@@ -33,12 +33,40 @@ impl SsgConfig {
     }
 }
 
+/// Lint-specific configuration. Each rule lives in its own nested table.
+///
+/// Rules surface opt-in/opt-out via `enabled` (default `true` when the
+/// section is present) and rule-specific parameters as sibling fields. This
+/// keeps selection and parameters co-located, so writing `[lint.stale_by_git]`
+/// is enough to opt in with defaults.
+#[derive(Debug, Deserialize, Default)]
+pub struct LintConfig {
+    pub stale_by_git: Option<StaleByGitConfig>,
+}
+
+/// Configuration for the `stale_by_git` lint rule.
+///
+/// `enabled` defaults to `true` when the section is present in `.scraps.toml`,
+/// so a bare `[lint.stale_by_git]` opts the rule in. Setting `enabled = false`
+/// disables the rule while preserving the threshold for later toggling.
+#[derive(Debug, Deserialize)]
+pub struct StaleByGitConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub threshold_days: Option<u64>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 /// Main configuration struct
 #[derive(Debug, Deserialize)]
 pub struct ScrapConfig {
     pub scraps_dir: Option<PathBuf>,
     pub timezone: Option<Tz>,
     pub ssg: Option<SsgConfig>,
+    pub lint: Option<LintConfig>,
 }
 
 impl ScrapConfig {

--- a/src/usecase/init/builtins/.scraps.toml
+++ b/src/usecase/init/builtins/.scraps.toml
@@ -33,3 +33,14 @@ title = "My Site"
 
 # Scraps pagination on index page(optional, default=no pagination)
 # paginate_by = 20
+
+# Lint rule configuration (optional)
+# Each opt-in rule lives in its own [lint.<rule>] section. Section presence
+# enables the rule (enabled defaults to true); set enabled = false to disable
+# while preserving the rule's parameters.
+
+# stale_by_git: flag scraps whose latest git commit is older than the threshold.
+# Opt-in because it shells out to git per scrap.
+# [lint.stale_by_git]
+# enabled = true
+# threshold_days = 180

--- a/src/usecase/lint.rs
+++ b/src/usecase/lint.rs
@@ -1,3 +1,3 @@
 pub mod rule;
-mod rules;
+pub mod rules;
 pub mod usecase;

--- a/src/usecase/lint/rule.rs
+++ b/src/usecase/lint/rule.rs
@@ -10,6 +10,7 @@ pub enum LintRuleName {
     Overlinking,
     BrokenLink,
     BrokenHeadingRef,
+    StaleByGit,
 }
 
 impl LintRuleName {
@@ -21,7 +22,28 @@ impl LintRuleName {
             Self::Overlinking => "overlinking",
             Self::BrokenLink => "broken-link",
             Self::BrokenHeadingRef => "broken-heading-ref",
+            Self::StaleByGit => "stale-by-git",
         }
+    }
+
+    /// Rules selected when `scraps lint` is invoked without `--rule` or `--all`.
+    /// Excludes opt-in rules with external dependencies (e.g. `_by_git`).
+    pub fn default_rules() -> Vec<LintRuleName> {
+        vec![
+            Self::DeadEnd,
+            Self::Lonely,
+            Self::SelfLink,
+            Self::Overlinking,
+            Self::BrokenLink,
+            Self::BrokenHeadingRef,
+        ]
+    }
+
+    /// All rules including opt-in ones. Used by `scraps lint --all`.
+    pub fn all_rules() -> Vec<LintRuleName> {
+        let mut rules = Self::default_rules();
+        rules.push(Self::StaleByGit);
+        rules
     }
 }
 

--- a/src/usecase/lint/rules.rs
+++ b/src/usecase/lint/rules.rs
@@ -4,3 +4,4 @@ pub mod dead_end;
 pub mod lonely;
 pub mod overlinking;
 pub mod self_link;
+pub mod stale_by_git;

--- a/src/usecase/lint/rules/stale_by_git.rs
+++ b/src/usecase/lint/rules/stale_by_git.rs
@@ -1,0 +1,235 @@
+use std::path::PathBuf;
+
+use rayon::prelude::*;
+use scraps_libs::git::GitCommand;
+use scraps_libs::model::{scrap::Scrap, tags::Tags};
+
+use crate::usecase::build::model::backlinks_map::BacklinksMap;
+use crate::usecase::lint::rule::{scrap_relative_path, LintRule, LintRuleName, LintWarning};
+
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Flag scraps whose latest git commit is older than `threshold_days`.
+///
+/// Maps to Notion's "Verified Pages" concept: knowledge bases accumulate
+/// content that was once accurate but rots when left untouched. The default
+/// 180-day threshold matches Notion's default re-verification cycle.
+///
+/// Opt-in by rule name (`--rule stale-by-git` or `--all`) so that the default
+/// `scraps lint` invocation stays git-free and fast.
+pub struct StaleByGitRule<GC: GitCommand> {
+    pub git_command: GC,
+    pub scraps_dir: PathBuf,
+    pub threshold_days: u64,
+    pub now_ts: i64,
+}
+
+impl<GC: GitCommand + Send + Sync> LintRule for StaleByGitRule<GC> {
+    fn name(&self) -> LintRuleName {
+        LintRuleName::StaleByGit
+    }
+
+    fn check(
+        &self,
+        scraps: &[Scrap],
+        _backlinks_map: &BacklinksMap,
+        _tags: &Tags,
+    ) -> Vec<LintWarning> {
+        let is_repo = self.git_command.is_git_repository(&self.scraps_dir);
+        match is_repo {
+            Ok(true) => {}
+            Ok(false) => {
+                eprintln!("info: stale-by-git: git unavailable, skipping stale check");
+                return Vec::new();
+            }
+            Err(e) => {
+                eprintln!(
+                    "info: stale-by-git: git unavailable ({}), skipping stale check",
+                    e
+                );
+                return Vec::new();
+            }
+        }
+
+        let threshold_secs = (self.threshold_days as i64).saturating_mul(SECONDS_PER_DAY);
+        let cutoff = self.now_ts.saturating_sub(threshold_secs);
+
+        scraps
+            .par_iter()
+            .filter_map(|scrap| {
+                let path = self.scraps_dir.join(scrap_relative_path(scrap));
+                let ts = match self.git_command.commited_ts(&path) {
+                    Ok(Some(ts)) => ts,
+                    Ok(None) => return None,
+                    Err(_) => return None,
+                };
+                if ts >= cutoff {
+                    return None;
+                }
+                let age_days = (self.now_ts - ts) / SECONDS_PER_DAY;
+                Some(LintWarning {
+                    rule_name: LintRuleName::StaleByGit,
+                    scrap_path: scrap_relative_path(scrap),
+                    message: format!("scrap not updated in {} days", age_days),
+                    source: None,
+                    span: None,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scraps_libs::git::tests::GitCommandTest;
+    use std::io;
+    use std::path::Path;
+
+    /// Stub git command that returns scripted timestamps and repo status.
+    #[derive(Clone, Copy)]
+    struct GitStub {
+        ts: Option<i64>,
+        is_repo: bool,
+    }
+
+    impl GitCommand for GitStub {
+        fn init(&self, _path: &Path) -> io::Result<()> {
+            Ok(())
+        }
+        fn commited_ts(&self, _path: &Path) -> io::Result<Option<i64>> {
+            Ok(self.ts)
+        }
+        fn is_git_repository(&self, _path: &Path) -> io::Result<bool> {
+            Ok(self.is_repo)
+        }
+    }
+
+    fn now_ts() -> i64 {
+        1_700_000_000
+    }
+
+    #[test]
+    fn flag_scrap_older_than_threshold() {
+        let now = now_ts();
+        let old_ts = now - 200 * SECONDS_PER_DAY;
+        let rule = StaleByGitRule {
+            git_command: GitStub {
+                ts: Some(old_ts),
+                is_repo: true,
+            },
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now,
+        };
+        let scraps = vec![Scrap::new("old", &None, "body")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].rule_name, LintRuleName::StaleByGit);
+        assert_eq!(warnings[0].scrap_path, "old.md");
+        assert!(warnings[0].message.contains("200 days"));
+    }
+
+    #[test]
+    fn skip_scrap_within_threshold() {
+        let now = now_ts();
+        let recent_ts = now - 30 * SECONDS_PER_DAY;
+        let rule = StaleByGitRule {
+            git_command: GitStub {
+                ts: Some(recent_ts),
+                is_repo: true,
+            },
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now,
+        };
+        let scraps = vec![Scrap::new("recent", &None, "body")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn skip_uncommitted_scrap() {
+        let now = now_ts();
+        let rule = StaleByGitRule {
+            git_command: GitStub {
+                ts: None,
+                is_repo: true,
+            },
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now,
+        };
+        let scraps = vec![Scrap::new("brand_new", &None, "body")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn skip_when_not_a_git_repo() {
+        let now = now_ts();
+        let rule = StaleByGitRule {
+            git_command: GitStub {
+                ts: Some(0),
+                is_repo: false,
+            },
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now,
+        };
+        let scraps = vec![Scrap::new("a", &None, "body")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn flag_scrap_with_context_path() {
+        let now = now_ts();
+        let old_ts = now - 365 * SECONDS_PER_DAY;
+        let rule = StaleByGitRule {
+            git_command: GitStub {
+                ts: Some(old_ts),
+                is_repo: true,
+            },
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now,
+        };
+        let scraps = vec![Scrap::new("note", &Some("ai".into()), "body")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].scrap_path, "ai/note.md");
+    }
+
+    #[test]
+    fn default_test_git_returns_zero_so_old_scraps_flagged() {
+        // Sanity check that scraps_libs GitCommandTest still works as a stub.
+        let rule = StaleByGitRule {
+            git_command: GitCommandTest::new(),
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 180,
+            now_ts: now_ts(),
+        };
+        let scraps = vec![Scrap::new("a", &None, "")];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = rule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+    }
+}

--- a/src/usecase/lint/usecase.rs
+++ b/src/usecase/lint/usecase.rs
@@ -19,15 +19,25 @@ impl LintUsecase {
         LintUsecase
     }
 
+    /// Run lint rules over `scraps` and return collected warnings.
+    ///
+    /// `rule_names` selects which rules to run:
+    /// - empty: default rules only (excludes opt-in rules like `stale-by-git`)
+    /// - non-empty: only the listed rules, drawn from default and `extra_rules`
+    ///
+    /// `extra_rules` lets the caller register opt-in rules (e.g. `StaleByGitRule`)
+    /// whose construction depends on resources the usecase does not own
+    /// (git command, project path, current time).
     pub fn execute(
         &self,
         scraps: &[Scrap],
         rule_names: &[LintRuleName],
+        extra_rules: Vec<Box<dyn LintRule>>,
     ) -> ScrapsResult<Vec<LintWarning>> {
         let backlinks_map = BacklinksMap::new(scraps);
         let tags = Tags::new(&scraps);
 
-        let all_rules: Vec<Box<dyn LintRule>> = vec![
+        let mut rules: Vec<Box<dyn LintRule>> = vec![
             Box::new(DeadEndRule),
             Box::new(LonelyRule),
             Box::new(SelfLinkRule),
@@ -36,14 +46,10 @@ impl LintUsecase {
             Box::new(BrokenHeadingRefRule),
         ];
 
-        let rules: Vec<Box<dyn LintRule>> = if rule_names.is_empty() {
-            all_rules
-        } else {
-            all_rules
-                .into_iter()
-                .filter(|r| rule_names.contains(&r.name()))
-                .collect()
-        };
+        if !rule_names.is_empty() {
+            rules.extend(extra_rules);
+            rules.retain(|r| rule_names.contains(&r.name()));
+        }
 
         let warnings: Vec<LintWarning> = rules
             .par_iter()
@@ -76,7 +82,7 @@ mod tests {
         ];
 
         let usecase = LintUsecase::new();
-        let warnings = usecase.execute(&scraps, &[]).unwrap();
+        let warnings = usecase.execute(&scraps, &[], Vec::new()).unwrap();
 
         let rule_names: Vec<&LintRuleName> = warnings.iter().map(|w| &w.rule_name).collect();
         assert!(rule_names.contains(&&LintRuleName::DeadEnd));
@@ -97,7 +103,7 @@ mod tests {
         ];
 
         let usecase = LintUsecase::new();
-        let warnings = usecase.execute(&scraps, &[]).unwrap();
+        let warnings = usecase.execute(&scraps, &[], Vec::new()).unwrap();
 
         assert!(warnings.is_empty());
     }
@@ -105,7 +111,7 @@ mod tests {
     #[test]
     fn empty_project_no_errors() {
         let usecase = LintUsecase::new();
-        let warnings = usecase.execute(&[], &[]).unwrap();
+        let warnings = usecase.execute(&[], &[], Vec::new()).unwrap();
 
         assert!(warnings.is_empty());
     }
@@ -118,11 +124,76 @@ mod tests {
         ];
 
         let usecase = LintUsecase::new();
-        let warnings = usecase.execute(&scraps, &[LintRuleName::DeadEnd]).unwrap();
+        let warnings = usecase
+            .execute(&scraps, &[LintRuleName::DeadEnd], Vec::new())
+            .unwrap();
 
         assert!(warnings
             .iter()
             .all(|w| w.rule_name == LintRuleName::DeadEnd));
         assert!(!warnings.is_empty());
+    }
+
+    #[test]
+    fn default_excludes_opt_in_rules() {
+        // StaleByGit must not run when no rule is explicitly requested,
+        // even if an extra rule is registered.
+        use crate::usecase::lint::rules::stale_by_git::StaleByGitRule;
+        use scraps_libs::git::tests::GitCommandTest;
+        use std::path::PathBuf;
+
+        let scraps = vec![
+            Scrap::new("a", &None, "[[b]]"),
+            Scrap::new("b", &None, "[[a]]"),
+        ];
+        let stale_rule = StaleByGitRule {
+            git_command: GitCommandTest::new(),
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 1,
+            now_ts: 1_700_000_000,
+        };
+
+        let usecase = LintUsecase::new();
+        let warnings = usecase
+            .execute(&scraps, &[], vec![Box::new(stale_rule)])
+            .unwrap();
+
+        assert!(warnings
+            .iter()
+            .all(|w| w.rule_name != LintRuleName::StaleByGit));
+    }
+
+    #[test]
+    fn extra_rule_runs_when_explicitly_selected() {
+        use crate::usecase::lint::rules::stale_by_git::StaleByGitRule;
+        use scraps_libs::git::tests::GitCommandTest;
+        use std::path::PathBuf;
+
+        // GitCommandTest returns ts=0 for every scrap, so any positive
+        // threshold flags everything as stale.
+        let scraps = vec![
+            Scrap::new("a", &None, "[[b]]"),
+            Scrap::new("b", &None, "[[a]]"),
+        ];
+        let stale_rule = StaleByGitRule {
+            git_command: GitCommandTest::new(),
+            scraps_dir: PathBuf::from("/tmp"),
+            threshold_days: 1,
+            now_ts: 1_700_000_000,
+        };
+
+        let usecase = LintUsecase::new();
+        let warnings = usecase
+            .execute(
+                &scraps,
+                &[LintRuleName::StaleByGit],
+                vec![Box::new(stale_rule)],
+            )
+            .unwrap();
+
+        assert!(!warnings.is_empty());
+        assert!(warnings
+            .iter()
+            .all(|w| w.rule_name == LintRuleName::StaleByGit));
     }
 }


### PR DESCRIPTION
## Summary

Adds a new opt-in lint rule `stale_by_git` that flags scraps whose latest git commit timestamp is older than a configurable threshold (default 180 days, matching Notion's Verified Pages cycle).

```
$ scraps lint --rule stale-by-git
warning: stale-by-git: scrap not updated in 187 days
 --> scraps/programming/rust/borrowing.md
```

## Related Issues

Fixes #480

## Additional Notes

### Selection model
- **CLI**: `scraps lint --rule stale-by-git` runs only this rule.
- **Config (project default)**: `[lint.stale_by_git]` section opts the rule in. Section presence enables it (`enabled` defaults to `true`); `enabled = false` disables while preserving the threshold.
- **Default `scraps lint`**: runs only the existing default rules — git-free fast path is preserved as before.

### Config schema (D pattern)
After comparing how ruff / clippy / golangci-lint / rubocop / selene / pylint / mypy each solve the same "enable + per-rule params in TOML" problem, this PR adopts a per-rule section that co-locates `enabled` and parameters. None of the surveyed tools does it this way, but it is the most TOML-natural form and removes the orphan-config foot-gun (`threshold_days` written but rule not in some `enable` list elsewhere) entirely.

```toml
[lint.stale_by_git]
# enabled = true        # default true when section present
# threshold_days = 180  # default 180
```

The init template now ships the section commented-out for discoverability.

### Graceful degradation
- Outside a git working tree → emit one info message (`stale-by-git: git unavailable, skipping stale check`) and skip; other selected rules continue.
- Uncommitted scraps (`git log` returns no timestamp) → silently excluded from staleness flagging.
- Missing `git` binary → same as above (treated as "not a git repo").

### Architectural notes
- `LintRule` trait stays object-safe; `StaleByGitRule<GC: GitCommand>` carries its own dependencies (git command, scraps_dir, threshold, now_ts) so other rules' signatures do not change.
- `LintUsecase::execute` gains an `extra_rules: Vec<Box<dyn LintRule>>` parameter for opt-in rules whose construction depends on resources the usecase doesn't own (git command, current time).
- `GitCommand` trait gains `is_git_repository(&Path) -> io::Result<bool>` for the gating check; missing `git` binary is reported as `Ok(false)` for graceful degradation.
- `LintRuleName` gains `default_rules()` / `all_rules()` helpers so the opt-in vs default distinction is encoded once.

### Tests
- 6 unit tests for `StaleByGitRule` (threshold edges, uncommitted, non-git, ctx path)
- 2 usecase tests for opt-in semantics (`extra_rules` only runs when explicitly requested)
- 4 cmd-level tests for the CLI/config selection logic
- Existing 159 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)