### PR TITLE
Add structured headings and fenced code blocks to `scraps get --json`

### DIFF
--- a/docs/Reference/MCP Tools.md
+++ b/docs/Reference/MCP Tools.md
@@ -28,39 +28,6 @@ matching.
 - `{"query": "rust cli", "logic": "or"}` - Returns scraps containing "rust" OR
   "cli"
 
-## get_scrap
-
-Get a single scrap by title and optional context. Returns the full Markdown
-content together with extracted structural data (headings, fenced code blocks)
-so AI assistants can introspect a scrap in a single call without re-parsing.
-
-**Parameters:**
-- `title` (string, required): Title of the scrap to get
-- `ctx` (string, optional): Context if the scrap has one
-
-**Returns:**
-- `title`: Scrap title
-- `ctx`: Context folder path (null if in root)
-- `md_text`: Full Markdown body
-- `headings`: Array of headings in occurrence order, each with:
-  - `level`: ATX/Setext heading level (1–6)
-  - `text`: Plain-text label (inline markup and wiki-link aliases collapsed)
-  - `line`: 1-based source line of the heading
-  - `parent` (optional): Text of the closest enclosing heading at a lower
-    level. Omitted for top-level headings
-- `code_blocks`: Array of fenced code blocks in occurrence order, each with:
-  - `lang`: Language tag from the info string, or `null` when none
-  - `content`: Raw block body
-  - `line`: 1-based source line of the opening fence
-
-Indented (4-space) code blocks are intentionally excluded — only fenced
-blocks carry an explicit language tag.
-
-Future structural fields (tables, callouts, images, …) will follow the same
-pattern: a top-level array on the response keyed by the construct name,
-with one object per occurrence carrying its semantic attributes plus a
-`line` anchor back into `md_text`.
-
 ## list_tags
 
 List all available tags in your Scraps repository with their backlink counts,

--- a/docs/Reference/MCP Tools.md
+++ b/docs/Reference/MCP Tools.md
@@ -28,6 +28,39 @@ matching.
 - `{"query": "rust cli", "logic": "or"}` - Returns scraps containing "rust" OR
   "cli"
 
+## get_scrap
+
+Get a single scrap by title and optional context. Returns the full Markdown
+content together with extracted structural data (headings, fenced code blocks)
+so AI assistants can introspect a scrap in a single call without re-parsing.
+
+**Parameters:**
+- `title` (string, required): Title of the scrap to get
+- `ctx` (string, optional): Context if the scrap has one
+
+**Returns:**
+- `title`: Scrap title
+- `ctx`: Context folder path (null if in root)
+- `md_text`: Full Markdown body
+- `headings`: Array of headings in occurrence order, each with:
+  - `level`: ATX/Setext heading level (1–6)
+  - `text`: Plain-text label (inline markup and wiki-link aliases collapsed)
+  - `line`: 1-based source line of the heading
+  - `parent` (optional): Text of the closest enclosing heading at a lower
+    level. Omitted for top-level headings
+- `code_blocks`: Array of fenced code blocks in occurrence order, each with:
+  - `lang`: Language tag from the info string, or `null` when none
+  - `content`: Raw block body
+  - `line`: 1-based source line of the opening fence
+
+Indented (4-space) code blocks are intentionally excluded — only fenced
+blocks carry an explicit language tag.
+
+Future structural fields (tables, callouts, images, …) will follow the same
+pattern: a top-level array on the response keyed by the construct name,
+with one object per occurrence carrying its semantic attributes plus a
+`line` anchor back into `md_text`.
+
 ## list_tags
 
 List all available tags in your Scraps repository with their backlink counts,

--- a/modules/libs/src/markdown/query.rs
+++ b/modules/libs/src/markdown/query.rs
@@ -1,3 +1,4 @@
+mod code_blocks;
 mod common;
 mod embeds;
 mod headings;
@@ -8,8 +9,9 @@ mod task_items;
 mod wiki_ref;
 mod wikilinks;
 
+pub use code_blocks::{code_blocks, CodeBlock};
 pub use embeds::{embeds, EmbedRef};
-pub use headings::headings;
+pub use headings::{headings, Heading};
 pub use images::images;
 pub use section::section;
 pub use tags::{tags, TagRef};

--- a/modules/libs/src/markdown/query/code_blocks.rs
+++ b/modules/libs/src/markdown/query/code_blocks.rs
@@ -1,0 +1,135 @@
+use comrak::{
+    nodes::{NodeCodeBlock, NodeValue},
+    parse_document, Arena,
+};
+
+use super::common::options;
+
+/// A fenced code block extracted from a markdown document.
+///
+/// `lang` is the first whitespace-delimited token of the info string (the
+/// conventional language tag), or `None` when the fence has no info string.
+/// `content` is the raw block body as authored, with the trailing newline
+/// preserved by comrak. `line` is the 1-based source line of the opening
+/// fence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeBlock {
+    pub lang: Option<String>,
+    pub content: String,
+    pub line: usize,
+}
+
+/// Extract fenced code blocks from a markdown document, in occurrence order.
+///
+/// Indented (4-space) code blocks are intentionally skipped: only fenced
+/// blocks (``` ``` ``` or ``` ~~~ ```) carry an explicit language tag, and
+/// they're the construct agents care about for code introspection.
+pub fn code_blocks(text: &str) -> Vec<CodeBlock> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let arena = Arena::new();
+    let opts = options();
+    let root = parse_document(&arena, text, &opts);
+
+    let mut out = Vec::new();
+    for n in root.descendants() {
+        let NodeValue::CodeBlock(cb) = &n.data().value else {
+            continue;
+        };
+        let NodeCodeBlock {
+            fenced,
+            info,
+            literal,
+            ..
+        } = cb.as_ref();
+        if !*fenced {
+            continue;
+        }
+        let lang = info
+            .split_whitespace()
+            .next()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let line = n.data().sourcepos.start.line;
+        out.push(CodeBlock {
+            lang,
+            content: literal.clone(),
+            line,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_code_blocks_basic_with_lang() {
+        let input = "```rust\nlet x = 1;\n```\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].lang.as_deref(), Some("rust"));
+        assert_eq!(res[0].content, "let x = 1;\n");
+        assert_eq!(res[0].line, 1);
+    }
+
+    #[test]
+    fn it_code_blocks_no_lang() {
+        let input = "```\nplain\n```\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 1);
+        assert!(res[0].lang.is_none());
+        assert_eq!(res[0].content, "plain\n");
+    }
+
+    #[test]
+    fn it_code_blocks_skips_indented() {
+        // 4-space indented code block — not fenced, so excluded.
+        let input = "para\n\n    indented code\n";
+        assert!(code_blocks(input).is_empty());
+    }
+
+    #[test]
+    fn it_code_blocks_multiple_with_line_numbers() {
+        let input = "intro\n\n```rust\nlet x = 1;\n```\n\nmid\n\n```sh\ncargo build\n```\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].lang.as_deref(), Some("rust"));
+        assert_eq!(res[0].line, 3);
+        assert_eq!(res[1].lang.as_deref(), Some("sh"));
+        assert_eq!(res[1].line, 9);
+    }
+
+    #[test]
+    fn it_code_blocks_info_string_takes_first_token() {
+        // GFM: only the first whitespace-delimited token is the lang.
+        let input = "```rust ignore\nlet x = 1;\n```\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].lang.as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn it_code_blocks_tilde_fence() {
+        let input = "~~~python\nprint(1)\n~~~\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].lang.as_deref(), Some("python"));
+        assert_eq!(res[0].content, "print(1)\n");
+    }
+
+    #[test]
+    fn it_code_blocks_empty_input() {
+        assert!(code_blocks("").is_empty());
+    }
+
+    #[test]
+    fn it_code_blocks_preserves_inner_whitespace() {
+        let input = "```\n  indented inside\n\nblank line above\n```\n";
+        let res = code_blocks(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].content, "  indented inside\n\nblank line above\n");
+    }
+}

--- a/modules/libs/src/markdown/query/headings.rs
+++ b/modules/libs/src/markdown/query/headings.rs
@@ -2,13 +2,26 @@ use comrak::{nodes::NodeValue, parse_document, Arena};
 
 use super::common::{collect_text, options};
 
-/// Extract heading text strings from a markdown document, in occurrence order.
+/// Structural information for a single markdown heading.
 ///
-/// Returns the visible label of every ATX/Setext heading. Levels and structural
-/// information are not preserved — callers that need them should parse the
-/// document themselves. Wiki-link / inline markup inside a heading is collapsed
+/// `parent` is the text label of the closest preceding heading whose level is
+/// strictly lower than this heading's, mirroring how readers nest sections.
+/// Top-level headings have `parent: None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Heading {
+    pub level: u8,
+    pub text: String,
+    pub line: usize,
+    pub parent: Option<String>,
+}
+
+/// Extract structured heading information from a markdown document, in
+/// occurrence order.
+///
+/// Returns the level, plain-text label, source line, and parent label of every
+/// ATX/Setext heading. Wiki-link / inline markup inside a heading is collapsed
 /// to its plain-text label, mirroring how `section()` identifies headings.
-pub fn headings(text: &str) -> Vec<String> {
+pub fn headings(text: &str) -> Vec<Heading> {
     if text.is_empty() {
         return Vec::new();
     }
@@ -16,10 +29,26 @@ pub fn headings(text: &str) -> Vec<String> {
     let opts = options();
     let root = parse_document(&arena, text, &opts);
 
-    let mut out = Vec::new();
+    let mut out: Vec<Heading> = Vec::new();
+    let mut stack: Vec<(u8, String)> = Vec::new();
     for n in root.descendants() {
-        if let NodeValue::Heading(_) = &n.data().value {
-            out.push(collect_text(n));
+        if let NodeValue::Heading(h) = &n.data().value {
+            let level = h.level as u8;
+            let label = collect_text(n);
+            let line = n.data().sourcepos.start.line;
+
+            while matches!(stack.last(), Some((lvl, _)) if *lvl >= level) {
+                stack.pop();
+            }
+            let parent = stack.last().map(|(_, t)| t.clone());
+            stack.push((level, label.clone()));
+
+            out.push(Heading {
+                level,
+                text: label,
+                line,
+                parent,
+            });
         }
     }
     out
@@ -29,28 +58,54 @@ pub fn headings(text: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
+    fn h(level: u8, text: &str, line: usize, parent: Option<&str>) -> Heading {
+        Heading {
+            level,
+            text: text.to_string(),
+            line,
+            parent: parent.map(|s| s.to_string()),
+        }
+    }
+
     #[test]
     fn it_headings_basic() {
         let input = "# H1\n\n## H2\n\n### H3\n";
-        assert_eq!(headings(input), vec!["H1", "H2", "H3"]);
+        assert_eq!(
+            headings(input),
+            vec![
+                h(1, "H1", 1, None),
+                h(2, "H2", 3, Some("H1")),
+                h(3, "H3", 5, Some("H2")),
+            ]
+        );
     }
 
     #[test]
     fn it_headings_setext() {
         let input = "Title\n=====\n\nSub\n---\n";
-        assert_eq!(headings(input), vec!["Title", "Sub"]);
+        let res = headings(input);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].text, "Title");
+        assert_eq!(res[0].level, 1);
+        assert_eq!(res[1].text, "Sub");
+        assert_eq!(res[1].level, 2);
+        assert_eq!(res[1].parent.as_deref(), Some("Title"));
     }
 
     #[test]
     fn it_headings_with_inline_markup() {
         let input = "## Hello **bold** world\n";
-        assert_eq!(headings(input), vec!["Hello bold world"]);
+        let res = headings(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].text, "Hello bold world");
     }
 
     #[test]
     fn it_headings_with_wikilink() {
         let input = "## see [[topic]]\n";
-        assert_eq!(headings(input), vec!["see topic"]);
+        let res = headings(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].text, "see topic");
     }
 
     #[test]
@@ -67,12 +122,48 @@ mod tests {
     #[test]
     fn it_headings_preserves_order_and_duplicates() {
         let input = "## same\n\nbody\n\n## same\n\nmore\n";
-        assert_eq!(headings(input), vec!["same", "same"]);
+        let res = headings(input);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].text, "same");
+        assert_eq!(res[1].text, "same");
     }
 
     #[test]
     fn it_headings_japanese() {
         let input = "## 見出し\n\n本文\n";
-        assert_eq!(headings(input), vec!["見出し"]);
+        let res = headings(input);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].text, "見出し");
+    }
+
+    #[test]
+    fn it_headings_parent_resets_at_higher_level() {
+        let input = "# A\n\n## B\n\n### C\n\n## D\n\n# E\n\n## F\n";
+        let res = headings(input);
+        assert_eq!(res.len(), 6);
+        assert_eq!(res[0].parent, None); // A
+        assert_eq!(res[1].parent.as_deref(), Some("A")); // B under A
+        assert_eq!(res[2].parent.as_deref(), Some("B")); // C under B
+        assert_eq!(res[3].parent.as_deref(), Some("A")); // D back under A
+        assert_eq!(res[4].parent, None); // E top-level
+        assert_eq!(res[5].parent.as_deref(), Some("E")); // F under E
+    }
+
+    #[test]
+    fn it_headings_skipping_levels_picks_nearest_lower() {
+        // h1 then h4: parent of h4 is h1 (only lower-level seen).
+        let input = "# A\n\n#### D\n";
+        let res = headings(input);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[1].level, 4);
+        assert_eq!(res[1].parent.as_deref(), Some("A"));
+    }
+
+    #[test]
+    fn it_headings_line_numbers() {
+        let input = "# top\n\nbody\n\n## sub\n";
+        let res = headings(input);
+        assert_eq!(res[0].line, 1);
+        assert_eq!(res[1].line, 5);
     }
 }

--- a/src/cli/cmd/get.rs
+++ b/src/cli/cmd/get.rs
@@ -2,11 +2,12 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::cli::config::scrap_config::ScrapConfig;
-use crate::cli::json::scrap::ScrapJson;
+use crate::cli::json::scrap::{CodeBlockJson, HeadingJson, ScrapJson};
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
 use crate::usecase::scrap::get::usecase::GetScrapUsecase;
+use scraps_libs::markdown::query::{code_blocks, headings};
 use scraps_libs::model::context::Ctx;
 use scraps_libs::model::title::Title;
 
@@ -29,10 +30,20 @@ pub fn run(
     let result = usecase.execute(&scraps, &target_title, &target_ctx)?;
 
     if json {
+        let headings_json: Vec<HeadingJson> = headings(&result.md_text)
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let code_blocks_json: Vec<CodeBlockJson> = code_blocks(&result.md_text)
+            .into_iter()
+            .map(Into::into)
+            .collect();
         let scrap_json = ScrapJson {
             title: result.title.to_string(),
             ctx: result.ctx.map(|c| c.to_string()),
             md_text: result.md_text,
+            headings: headings_json,
+            code_blocks: code_blocks_json,
         };
         writeln!(writer, "{}", serde_json::to_string(&scrap_json)?)?;
     } else {
@@ -89,6 +100,116 @@ mod tests {
         assert_eq!(scrap.title, "Auth");
         assert_eq!(scrap.ctx.as_deref(), Some("Backend"));
         assert!(scrap.md_text.contains("# Auth"));
+    }
+
+    #[rstest]
+    fn run_json_includes_headings_with_structure(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_config(b"").add_scrap(
+            "Tokio.md",
+            b"# Tokio\n\nintro\n\n## Scheduling\n\nbody\n\n### Work-stealing\n\ndetails\n",
+        );
+
+        let mut buf = Vec::new();
+        run(
+            "Tokio",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(scrap.headings.len(), 3);
+
+        assert_eq!(scrap.headings[0].level, 1);
+        assert_eq!(scrap.headings[0].text, "Tokio");
+        assert_eq!(scrap.headings[0].line, 1);
+        assert!(scrap.headings[0].parent.is_none());
+
+        assert_eq!(scrap.headings[1].level, 2);
+        assert_eq!(scrap.headings[1].text, "Scheduling");
+        assert_eq!(scrap.headings[1].parent.as_deref(), Some("Tokio"));
+
+        assert_eq!(scrap.headings[2].level, 3);
+        assert_eq!(scrap.headings[2].text, "Work-stealing");
+        assert_eq!(scrap.headings[2].parent.as_deref(), Some("Scheduling"));
+    }
+
+    #[rstest]
+    fn run_json_includes_fenced_code_blocks(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_config(b"").add_scrap(
+            "Snippets.md",
+            b"# Snippets\n\n```rust\nlet x = 1;\n```\n\ntext\n\n```sh\ncargo build\n```\n",
+        );
+
+        let mut buf = Vec::new();
+        run(
+            "Snippets",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(scrap.code_blocks.len(), 2);
+        assert_eq!(scrap.code_blocks[0].lang.as_deref(), Some("rust"));
+        assert_eq!(scrap.code_blocks[0].content, "let x = 1;\n");
+        assert_eq!(scrap.code_blocks[1].lang.as_deref(), Some("sh"));
+        assert_eq!(scrap.code_blocks[1].content, "cargo build\n");
+    }
+
+    #[rstest]
+    fn run_json_emits_empty_arrays_for_plain_scrap(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("plain.md", b"just a paragraph\n");
+
+        let mut buf = Vec::new();
+        run(
+            "plain",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
+        assert!(scrap.headings.is_empty());
+        assert!(scrap.code_blocks.is_empty());
+    }
+
+    #[rstest]
+    fn run_text_output_omits_structural_data(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("doc.md", b"# Doc\n\n```rust\nlet x = 1;\n```\n");
+
+        let mut buf = Vec::new();
+        run(
+            "doc",
+            None,
+            false,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(!output.contains("\"headings\""));
+        assert!(!output.contains("\"code_blocks\""));
     }
 
     #[rstest]

--- a/src/cli/json/scrap.rs
+++ b/src/cli/json/scrap.rs
@@ -1,3 +1,4 @@
+use scraps_libs::markdown::query::{CodeBlock, Heading};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,4 +12,43 @@ pub struct ScrapJson {
     pub title: String,
     pub ctx: Option<String>,
     pub md_text: String,
+    pub headings: Vec<HeadingJson>,
+    pub code_blocks: Vec<CodeBlockJson>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HeadingJson {
+    pub level: u8,
+    pub text: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+}
+
+impl From<Heading> for HeadingJson {
+    fn from(h: Heading) -> Self {
+        Self {
+            level: h.level,
+            text: h.text,
+            line: h.line,
+            parent: h.parent,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CodeBlockJson {
+    pub lang: Option<String>,
+    pub content: String,
+    pub line: usize,
+}
+
+impl From<CodeBlock> for CodeBlockJson {
+    fn from(c: CodeBlock) -> Self {
+        Self {
+            lang: c.lang,
+            content: c.content,
+            line: c.line,
+        }
+    }
 }

--- a/src/mcp/json/scrap.rs
+++ b/src/mcp/json/scrap.rs
@@ -1,3 +1,4 @@
+use scraps_libs::markdown::query::{CodeBlock, Heading};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -5,10 +6,49 @@ pub struct ScrapJson {
     pub title: String,
     pub ctx: Option<String>,
     pub md_text: String,
+    pub headings: Vec<HeadingJson>,
+    pub code_blocks: Vec<CodeBlockJson>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ScrapKeyJson {
     pub title: String,
     pub ctx: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeadingJson {
+    pub level: u8,
+    pub text: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+}
+
+impl From<Heading> for HeadingJson {
+    fn from(h: Heading) -> Self {
+        Self {
+            level: h.level,
+            text: h.text,
+            line: h.line,
+            parent: h.parent,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CodeBlockJson {
+    pub lang: Option<String>,
+    pub content: String,
+    pub line: usize,
+}
+
+impl From<CodeBlock> for CodeBlockJson {
+    fn from(c: CodeBlock) -> Self {
+        Self {
+            lang: c.lang,
+            content: c.content,
+            line: c.line,
+        }
+    }
 }

--- a/src/mcp/tools/get_scrap.rs
+++ b/src/mcp/tools/get_scrap.rs
@@ -1,5 +1,5 @@
 use crate::input::file::read_scraps;
-use crate::mcp::json::scrap::ScrapJson;
+use crate::mcp::json::scrap::{CodeBlockJson, HeadingJson, ScrapJson};
 use crate::usecase::scrap::get::usecase::GetScrapUsecase;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
@@ -7,6 +7,7 @@ use rmcp::model::{CallToolResult, Content};
 use rmcp::schemars::JsonSchema;
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer};
+use scraps_libs::markdown::query::{code_blocks, headings};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -45,10 +46,21 @@ pub async fn get_scrap(
         .execute(&scraps, &title, &ctx)
         .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("Get scrap failed: {e}"), None))?;
 
+    let headings_json: Vec<HeadingJson> = headings(&result.md_text)
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    let code_blocks_json: Vec<CodeBlockJson> = code_blocks(&result.md_text)
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
     let scrap_json = ScrapJson {
         title: result.title.to_string(),
         ctx: result.ctx.map(|c| c.to_string()),
         md_text: result.md_text,
+        headings: headings_json,
+        code_blocks: code_blocks_json,
     };
 
     Ok(CallToolResult::success(vec![Content::text(

--- a/src/usecase/lint/rules/broken_heading_ref.rs
+++ b/src/usecase/lint/rules/broken_heading_ref.rs
@@ -41,7 +41,7 @@ impl LintRule for BrokenHeadingRefRule {
             .map(|(key, scrap)| {
                 let slugs = markdown::query::headings(scrap.md_text())
                     .into_iter()
-                    .map(|h| slugify::by_dash(&h))
+                    .map(|h| slugify::by_dash(&h.text))
                     .collect();
                 (key.clone(), slugs)
             })


### PR DESCRIPTION
## Summary

Closes #489.

Extends `scraps get --json` and the MCP `get_scrap` tool so a single fetch returns the scrap's structural data alongside the existing markdown body. Agents can introspect a scrap without re-parsing it.

New `--json` fields:
- `headings`: ordered list of `{ level, text, line, parent? }` per ATX/Setext heading. `parent` is the closest preceding heading at a strictly lower level (omitted for top-level headings).
- `code_blocks`: ordered list of `{ lang, content, line }` per fenced code block. `lang` is the first whitespace-delimited token of the info string (or `null`); indented (4-space) blocks are intentionally excluded.

Default human output remains content-only — structure is only emitted under `--json`.

### Implementation
- `modules/libs/src/markdown/query/headings.rs`: returns the new `Heading { level, text, line, parent }` struct (was `Vec<String>`); the lone caller in the `broken_heading_ref` lint rule is updated.
- `modules/libs/src/markdown/query/code_blocks.rs`: new `CodeBlock { lang, content, line }` query that walks comrak's fenced code blocks and skips indented ones.
- `src/cli/json/scrap.rs` and `src/mcp/json/scrap.rs`: extend `ScrapJson` with `headings` / `code_blocks` and add `HeadingJson` / `CodeBlockJson` (with `parent` skipped when `None`).
- `src/cli/cmd/get.rs` and `src/mcp/tools/get_scrap.rs`: populate the new fields when serializing.
- `docs/Reference/MCP Tools.md`: document `get_scrap`, the new fields, and the forward-compat pattern for future structural fields (tables, callouts, …).

## Test plan
- [x] `mise run cargo:quality` (build + test + fmt + clippy) passes locally.
- [x] New unit tests cover heading nesting (parent walks up to nearest lower level, resets at higher level, skipped levels), heading line/text extraction, and fenced code blocks (lang, no-lang, tilde fence, multi-token info string, indented-block exclusion).
- [x] New `src/cli/cmd/get.rs` tests assert `--json` exposes structural fields and that the default text output omits them.
- [x] Existing MCP `get_scrap` integration test still passes; structural fields ride along automatically.
- [ ] Manual verification with a real wiki: `scraps get <title> --json | jq '.headings, .code_blocks'`.

https://claude.ai/code/session_01WuJ4JiPFCzpTdFUYqXspzx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuJ4JiPFCzpTdFUYqXspzx)_