### PR TITLE
Rename build output dir to `_site/` and make `output_dir` configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target
-public
+_site
 
 # Claude Code
 .claude/worktrees/

--- a/docs/Explanation/README Processing.md
+++ b/docs/Explanation/README Processing.md
@@ -1,6 +1,6 @@
 #[[Markdown]]
 
-In Scraps, the `scraps/README.md` file is automatically converted to HTML and included in the static site's top page ( `public/index.html` ).
+In Scraps, the `scraps/README.md` file is automatically converted to HTML and included in the static site's top page ( `_site/index.html` ).
 
 For Markdown syntax, please refer to [[Reference/CommonMark]].
 

--- a/docs/Reference/Build.md
+++ b/docs/Reference/Build.md
@@ -17,11 +17,11 @@ scraps
 
 ## Generated Files
 
-The command generates the following files in the `public` directory:
+The command generates the following files in the `_site` directory (configurable via `output_dir` in `.scraps.toml`):
 
 ```bash
-❯ tree public
-public
+❯ tree _site
+_site
 ├── index.html      # Main page with scrap list
 ├── getting-started.html
 ├── documentation.html

--- a/docs/Reference/Serve.md
+++ b/docs/Reference/Serve.md
@@ -4,7 +4,7 @@
 ❯ scraps serve
 ```
 
-This command starts a local development server to preview your static site. The server automatically serves the files from the `public` directory at [http://127.0.0.1:1112](http://127.0.0.1:1112).
+This command starts a local development server to preview your static site. The server automatically serves the files from the build output directory (`_site` by default, configurable via `output_dir` in `.scraps.toml`) at [http://127.0.0.1:1112](http://127.0.0.1:1112).
 
 ## Examples
 

--- a/src/cli/cmd/build.rs
+++ b/src/cli/cmd/build.rs
@@ -50,14 +50,14 @@ fn execute(git: bool, project_path: Option<&Path>) -> ScrapsResult<()> {
     let ssg = config.require_ssg()?;
     let scraps_dir_path = path_resolver.scraps_dir(&config);
     let static_dir_path = path_resolver.static_dir();
-    let public_dir_path = path_resolver.public_dir();
+    let output_dir_path = path_resolver.output_dir(&config);
 
     // Input: read scraps (with git timestamps if --git is set) and README
     let git_command = git.then(GitCommandImpl::new);
     let (scraps_with_ts, readme_text) =
         read_scraps::to_all_scraps_with_timestamps(&scraps_dir_path, git_command)?;
 
-    let renderer = BuildRendererImpl::new(&static_dir_path, &public_dir_path);
+    let renderer = BuildRendererImpl::new(&static_dir_path, &output_dir_path);
     let usecase = BuildUsecase::new();
     let progress = ProgressImpl::init(Instant::now());
     let base_url = ssg.base_url();
@@ -124,21 +124,21 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify scrap HTMLs generated
-        let html1 = fs::read_to_string(project.public_path("scraps/test1.html")).unwrap();
+        let html1 = fs::read_to_string(project.output_path("scraps/test1.html")).unwrap();
         assert!(!html1.is_empty());
-        let html2 = fs::read_to_string(project.public_path("scraps/test2.html")).unwrap();
+        let html2 = fs::read_to_string(project.output_path("scraps/test2.html")).unwrap();
         assert!(!html2.is_empty());
 
         // Verify index.html generated
-        let index = fs::read_to_string(project.public_path("index.html")).unwrap();
+        let index = fs::read_to_string(project.output_path("index.html")).unwrap();
         assert!(!index.is_empty());
 
         // Verify CSS generated
-        let css = fs::read_to_string(project.public_path("main.css")).unwrap();
+        let css = fs::read_to_string(project.output_path("main.css")).unwrap();
         assert!(!css.is_empty());
 
         // Verify search index JSON generated (default: true)
-        let json = fs::read_to_string(project.public_path("search_index.json")).unwrap();
+        let json = fs::read_to_string(project.output_path("search_index.json")).unwrap();
         assert!(!json.is_empty());
     }
 
@@ -155,7 +155,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify search index JSON not generated
-        let json = fs::read_to_string(project.public_path("search_index.json"));
+        let json = fs::read_to_string(project.output_path("search_index.json"));
         assert!(json.is_err());
     }
 
@@ -175,7 +175,7 @@ mod tests {
         let result = execute(false, Some(project.project_root.as_path()));
         assert!(result.is_ok());
 
-        let html = fs::read_to_string(project.public_path("scraps/source.html")).unwrap();
+        let html = fs::read_to_string(project.output_path("scraps/source.html")).unwrap();
         assert!(html.contains("http://localhost:1112/tags/ai/ml.html"));
         assert!(html.contains("embedded body"));
         assert!(!html.contains("hidden body"));
@@ -192,7 +192,7 @@ mod tests {
         let result = execute(false, Some(project.project_root.as_path()));
         assert!(result.is_ok());
 
-        let index = fs::read_to_string(project.public_path("index.html")).unwrap();
+        let index = fs::read_to_string(project.output_path("index.html")).unwrap();
         assert!(index.contains("tags/ai.html"));
     }
 
@@ -209,7 +209,7 @@ mod tests {
 
         // Outside a git repo `commited_ts` is None so the conditional block
         // is omitted; this test just asserts that --git does not error out.
-        let html = fs::read_to_string(project.public_path("scraps/test1.html")).unwrap();
+        let html = fs::read_to_string(project.output_path("scraps/test1.html")).unwrap();
         assert!(!html.is_empty());
     }
 }

--- a/src/cli/cmd/serve.rs
+++ b/src/cli/cmd/serve.rs
@@ -35,14 +35,14 @@ pub fn run(git: bool, project_path: Option<&Path>) -> ScrapsResult<()> {
     let ssg = config.require_ssg()?;
     let scraps_dir_path = path_resolver.scraps_dir(&config);
     let static_dir_path = path_resolver.static_dir();
-    let public_dir_path = path_resolver.public_dir();
+    let output_dir_path = path_resolver.output_dir(&config);
 
     // Input: read scraps (with git timestamps if --git is set) and README
     let git_command = git.then(GitCommandImpl::new);
     let (scraps_with_ts, readme_text) =
         read_scraps::to_all_scraps_with_timestamps(&scraps_dir_path, git_command)?;
 
-    let renderer = BuildRendererImpl::new(&static_dir_path, &public_dir_path);
+    let renderer = BuildRendererImpl::new(&static_dir_path, &output_dir_path);
     let build_usecase = BuildUsecase::new();
 
     let progress = ProgressImpl::init(Instant::now());
@@ -94,6 +94,6 @@ pub fn run(git: bool, project_path: Option<&Path>) -> ScrapsResult<()> {
     println!("{serve_info}");
 
     // serve command
-    let serve_usecase = ServeUsecase::new(&public_dir_path);
+    let serve_usecase = ServeUsecase::new(&output_dir_path);
     serve_usecase.execute(&addr)
 }

--- a/src/cli/config/scrap_config.rs
+++ b/src/cli/config/scrap_config.rs
@@ -64,6 +64,7 @@ fn default_true() -> bool {
 #[derive(Debug, Deserialize)]
 pub struct ScrapConfig {
     pub scraps_dir: Option<PathBuf>,
+    pub output_dir: Option<PathBuf>,
     pub timezone: Option<Tz>,
     pub ssg: Option<SsgConfig>,
     pub lint: Option<LintConfig>,

--- a/src/cli/path_resolver.rs
+++ b/src/cli/path_resolver.rs
@@ -57,9 +57,12 @@ impl PathResolver {
         self.project_root.join("static")
     }
 
-    /// Get the public directory path
-    pub fn public_dir(&self) -> PathBuf {
-        self.project_root.join("public")
+    /// Get the build output directory path
+    pub fn output_dir(&self, config: &ScrapConfig) -> PathBuf {
+        match &config.output_dir {
+            Some(dir) => self.project_root.join(dir),
+            None => self.project_root.join("_site"),
+        }
     }
 
     /// Get the config file path
@@ -161,14 +164,45 @@ base_url = "http://example.com/"
     }
 
     #[rstest]
-    fn test_public_dir_path(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
-        temp_dir.add_dir("test_project_public");
+    fn test_output_dir_path_default(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
+        temp_dir.add_dir("test_project_output").add_file(
+            "test_project_output/.scraps.toml",
+            br#"
+[ssg]
+title = "Test"
+base_url = "http://example.com/"
+"#,
+        );
 
-        let test_project_path = temp_dir.path.join("test_project_public");
+        let test_project_path = temp_dir.path.join("test_project_output");
         let resolver = PathResolver::new(Some(&test_project_path)).unwrap();
-        let public_dir = resolver.public_dir();
-        assert_eq!(public_dir.file_name().unwrap(), "public");
-        assert!(public_dir.starts_with(&test_project_path));
+        let config = ScrapConfig::from_path(Some(&test_project_path)).unwrap();
+
+        let output_dir = resolver.output_dir(&config);
+        assert_eq!(output_dir.file_name().unwrap(), "_site");
+        assert!(output_dir.starts_with(&test_project_path));
+    }
+
+    #[rstest]
+    fn test_output_dir_path_custom(#[from(simple_temp_dir)] temp_dir: SimpleTempDir) {
+        temp_dir.add_dir("test_project_output_custom").add_file(
+            "test_project_output_custom/.scraps.toml",
+            br#"
+output_dir = "dist"
+
+[ssg]
+title = "Test"
+base_url = "http://example.com/"
+"#,
+        );
+
+        let test_project_path = temp_dir.path.join("test_project_output_custom");
+        let resolver = PathResolver::new(Some(&test_project_path)).unwrap();
+        let config = ScrapConfig::from_path(Some(&test_project_path)).unwrap();
+
+        let output_dir = resolver.output_dir(&config);
+        assert_eq!(output_dir.file_name().unwrap(), "dist");
+        assert!(output_dir.starts_with(&test_project_path));
     }
 
     #[rstest]

--- a/src/output/build_renderer.rs
+++ b/src/output/build_renderer.rs
@@ -26,14 +26,14 @@ use crate::usecase::build::{
 
 pub struct BuildRendererImpl {
     static_dir_path: PathBuf,
-    public_dir_path: PathBuf,
+    output_dir_path: PathBuf,
 }
 
 impl BuildRendererImpl {
-    pub fn new(static_dir_path: &Path, public_dir_path: &Path) -> BuildRendererImpl {
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> BuildRendererImpl {
         BuildRendererImpl {
             static_dir_path: static_dir_path.to_path_buf(),
-            public_dir_path: public_dir_path.to_path_buf(),
+            output_dir_path: output_dir_path.to_path_buf(),
         }
     }
 }
@@ -48,7 +48,7 @@ impl HtmlIndexRenderer for BuildRendererImpl {
         backlinks_map: &BacklinksMap,
         readme_content: &Option<Content>,
     ) -> ScrapsResult<usize> {
-        let index_render = IndexRender::new(&self.static_dir_path, &self.public_dir_path)?;
+        let index_render = IndexRender::new(&self.static_dir_path, &self.output_dir_path)?;
         index_render.run(
             base_url,
             html_metadata,
@@ -69,7 +69,7 @@ impl HtmlScrapRenderer for BuildRendererImpl {
         scrap_detail: &ScrapDetail,
         backlinks_map: &BacklinksMap,
     ) -> ScrapsResult<()> {
-        let scrap_render = ScrapRender::new(&self.static_dir_path, &self.public_dir_path)?;
+        let scrap_render = ScrapRender::new(&self.static_dir_path, &self.output_dir_path)?;
         scrap_render.run(
             base_url,
             timezone,
@@ -88,7 +88,7 @@ impl HtmlTagsIndexRenderer for BuildRendererImpl {
         scraps: &[Scrap],
         backlinks_map: &BacklinksMap,
     ) -> ScrapsResult<()> {
-        let tags_index_render = TagsIndexRender::new(&self.static_dir_path, &self.public_dir_path)?;
+        let tags_index_render = TagsIndexRender::new(&self.static_dir_path, &self.output_dir_path)?;
         tags_index_render.run(base_url, html_metadata, scraps, backlinks_map)
     }
 }
@@ -101,14 +101,14 @@ impl HtmlTagRenderer for BuildRendererImpl {
         tag: &Tag,
         backlinks_map: &BacklinksMap,
     ) -> ScrapsResult<()> {
-        let tag_render = TagRender::new(&self.static_dir_path, &self.public_dir_path)?;
+        let tag_render = TagRender::new(&self.static_dir_path, &self.output_dir_path)?;
         tag_render.run(base_url, html_metadata, tag, backlinks_map)
     }
 }
 
 impl CssRenderer for BuildRendererImpl {
     fn render_css(&self, css_metadata: &CssMetadata) -> ScrapsResult<()> {
-        let css_render = CSSRender::new(&self.static_dir_path, &self.public_dir_path);
+        let css_render = CSSRender::new(&self.static_dir_path, &self.output_dir_path);
         css_render.render_main(css_metadata)
     }
 }
@@ -116,7 +116,7 @@ impl CssRenderer for BuildRendererImpl {
 impl SearchIndexJsonRenderer for BuildRendererImpl {
     fn render_search_index(&self, base_url: &BaseUrl, scraps: &[Scrap]) -> ScrapsResult<()> {
         let search_index_render =
-            SearchIndexRender::new(&self.static_dir_path, &self.public_dir_path)?;
+            SearchIndexRender::new(&self.static_dir_path, &self.output_dir_path)?;
         search_index_render.run(base_url, scraps)
     }
 }

--- a/src/service/search/render.rs
+++ b/src/service/search/render.rs
@@ -10,19 +10,19 @@ use super::serde::search_index_scraps::SearchIndexScrapsTera;
 
 pub struct SearchIndexRender {
     static_dir_path: PathBuf,
-    public_dir_path: PathBuf,
+    output_dir_path: PathBuf,
 }
 
 impl SearchIndexRender {
     pub fn new(
         static_dir_path: &PathBuf,
-        public_dir_path: &PathBuf,
+        output_dir_path: &PathBuf,
     ) -> ScrapsResult<SearchIndexRender> {
-        std::fs::create_dir_all(public_dir_path).context(BuildError::CreateDir)?;
+        std::fs::create_dir_all(output_dir_path).context(BuildError::CreateDir)?;
 
         Ok(SearchIndexRender {
             static_dir_path: static_dir_path.to_owned(),
-            public_dir_path: public_dir_path.to_owned(),
+            output_dir_path: output_dir_path.to_owned(),
         })
     }
 
@@ -47,7 +47,7 @@ impl SearchIndexRender {
             "__builtins/search_index.json"
         };
         context.insert("scraps", scraps);
-        let file_path = &self.public_dir_path.join("search_index.json");
+        let file_path = &self.output_dir_path.join("search_index.json");
         let wtr = File::create(file_path).context(BuildError::WriteFailure(file_path.clone()))?;
         tera.render_to(template_name, &context, wtr)
             .context(BuildError::WriteFailure(file_path.clone()))
@@ -79,10 +79,10 @@ mod tests {
         let sc2 = Scrap::new("scrap2", &Some("Context".into()), "## header2");
         let scraps = vec![sc1, sc2];
 
-        let render = SearchIndexRender::new(&project.static_dir, &project.public_dir).unwrap();
+        let render = SearchIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render.run(&base_url, &scraps).unwrap();
 
-        let result = fs::read_to_string(project.public_path("search_index.json")).unwrap();
+        let result = fs::read_to_string(project.output_path("search_index.json")).unwrap();
         assert_eq!(
             result,
             "[{ \"title\": \"scrap1\", \"url\": \"http://localhost:1112/scraps/scrap1.html\" },{ \"title\": \"Context/scrap2\", \"url\": \"http://localhost:1112/scraps/context/scrap2.html\" }]");

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -11,7 +11,7 @@ use tempfile::TempDir;
 
 /// High-level fixture for a complete Scraps project structure
 ///
-/// Provides a temporary project with scraps/, static/, and public/
+/// Provides a temporary project with scraps/, static/, and _site/
 /// directories automatically created and cleaned up after the test.
 ///
 /// # Example
@@ -24,7 +24,7 @@ use tempfile::TempDir;
 ///     temp_scrap_project
 ///         .add_scrap("test.md", b"# Test Content");
 ///
-///     // Use temp_scrap_project.scraps_dir, .static_dir, .public_dir, etc.
+///     // Use temp_scrap_project.scraps_dir, .static_dir, .output_dir, etc.
 ///     // Automatic cleanup when temp_scrap_project goes out of scope
 /// }
 /// ```
@@ -33,7 +33,7 @@ pub struct TempScrapProject {
     temp_dir: TempDir,
     pub scraps_dir: PathBuf,
     pub static_dir: PathBuf,
-    pub public_dir: PathBuf,
+    pub output_dir: PathBuf,
     pub project_root: PathBuf,
 }
 
@@ -45,18 +45,18 @@ impl TempScrapProject {
 
         let scraps_dir = project_root.join("scraps");
         let static_dir = project_root.join("static");
-        let public_dir = project_root.join("public");
+        let output_dir = project_root.join("_site");
 
         // Create all directories
         fs::create_dir_all(&scraps_dir).expect("Failed to create scraps dir");
         fs::create_dir_all(&static_dir).expect("Failed to create static dir");
-        fs::create_dir_all(&public_dir).expect("Failed to create public dir");
+        fs::create_dir_all(&output_dir).expect("Failed to create output dir");
 
         Self {
             temp_dir,
             scraps_dir,
             static_dir,
-            public_dir,
+            output_dir,
             project_root,
         }
     }
@@ -128,19 +128,19 @@ impl TempScrapProject {
         self
     }
 
-    /// Get the path to a file in the public directory
+    /// Get the path to a file in the build output directory
     ///
     /// Useful for checking generated output files.
     ///
     /// # Arguments
-    /// * `filename` - Relative path from public_dir (e.g., "index.html" or "scraps/test.html")
+    /// * `filename` - Relative path from output_dir (e.g., "index.html" or "scraps/test.html")
     ///
     /// # Example
     /// ```no_run
-    /// assert!(project.public_path("index.html").exists());
+    /// assert!(project.output_path("index.html").exists());
     /// ```
-    pub fn public_path(&self, filename: &str) -> PathBuf {
-        self.public_dir.join(filename)
+    pub fn output_path(&self, filename: &str) -> PathBuf {
+        self.output_dir.join(filename)
     }
 
     /// Get the path to a file in the scraps directory
@@ -258,7 +258,7 @@ mod tests {
 
         assert!(project.scraps_dir.exists());
         assert!(project.static_dir.exists());
-        assert!(project.public_dir.exists());
+        assert!(project.output_dir.exists());
         assert!(project.project_root.exists());
     }
 

--- a/src/usecase/build/css/render.rs
+++ b/src/usecase/build/css/render.rs
@@ -9,14 +9,14 @@ use super::css_tera;
 
 pub struct CSSRender {
     static_dir_path: PathBuf,
-    public_dir_path: PathBuf,
+    output_dir_path: PathBuf,
 }
 
 impl CSSRender {
-    pub fn new(static_dir_path: &PathBuf, public_dir_path: &PathBuf) -> CSSRender {
+    pub fn new(static_dir_path: &PathBuf, output_dir_path: &PathBuf) -> CSSRender {
         CSSRender {
             static_dir_path: static_dir_path.to_owned(),
-            public_dir_path: public_dir_path.to_owned(),
+            output_dir_path: output_dir_path.to_owned(),
         }
     }
 
@@ -30,7 +30,7 @@ impl CSSRender {
         } else {
             "__builtins/main.css"
         };
-        let file_path = &self.public_dir_path.join("main.css");
+        let file_path = &self.output_dir_path.join("main.css");
         let wtr = File::create(file_path).context(BuildError::WriteFailure(file_path.clone()))?;
         tera.render_to(template_name, &context, wtr)
             .context(BuildError::WriteFailure(file_path.clone()))
@@ -54,10 +54,10 @@ mod tests {
         let css_metadata = &CssMetadata::new(&ColorScheme::OsSetting);
 
         // Run render
-        let render = CSSRender::new(&project.static_dir, &project.public_dir);
+        let render = CSSRender::new(&project.static_dir, &project.output_dir);
         render.render_main(css_metadata).unwrap();
 
-        let result = fs::read_to_string(project.public_path("main.css")).unwrap();
+        let result = fs::read_to_string(project.output_path("main.css")).unwrap();
         assert_eq!(result, ":root { color-scheme: light dark;}");
     }
 }

--- a/src/usecase/build/html/index_render.rs
+++ b/src/usecase/build/html/index_render.rs
@@ -21,16 +21,16 @@ use super::serde::tags::TagsTera;
 
 pub struct IndexRender {
     static_dir_path: PathBuf,
-    public_dir_path: PathBuf,
+    output_dir_path: PathBuf,
 }
 
 impl IndexRender {
-    pub fn new(static_dir_path: &Path, public_dir_path: &Path) -> ScrapsResult<IndexRender> {
-        fs::create_dir_all(public_dir_path).context(BuildError::CreateDir)?;
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<IndexRender> {
+        fs::create_dir_all(output_dir_path).context(BuildError::CreateDir)?;
 
         Ok(IndexRender {
             static_dir_path: static_dir_path.to_path_buf(),
-            public_dir_path: public_dir_path.to_path_buf(),
+            output_dir_path: output_dir_path.to_path_buf(),
         })
     }
 
@@ -150,7 +150,7 @@ impl IndexRender {
         } else {
             "__builtins/index.html"
         };
-        let file_path = &self.public_dir_path.join(pointer.current_file_name());
+        let file_path = &self.output_dir_path.join(pointer.current_file_name());
         let wtr = File::create(file_path).context(BuildError::WriteFailure(file_path.clone()))?;
         tera.render_to(template_name, context, wtr)
             .context(BuildError::WriteFailure(file_path.clone()))?;
@@ -206,7 +206,7 @@ mod tests {
         let scraps = scrap_details.to_scraps();
         let backlinks_map = BacklinksMap::new(&scraps);
 
-        let render = IndexRender::new(&project.static_dir, &project.public_dir).unwrap();
+        let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render
             .run(
                 base_url,
@@ -218,7 +218,7 @@ mod tests {
             )
             .unwrap();
 
-        let result = fs::read_to_string(project.public_path("index.html")).unwrap();
+        let result = fs::read_to_string(project.output_path("index.html")).unwrap();
         assert_eq!(
             result,
             "true<a href=\"./scrap1.html\">scrap1</a><a href=\"./scrap2.html\">scrap2</a>"
@@ -272,7 +272,7 @@ mod tests {
         let scraps = scrap_details.to_scraps();
         let backlinks_map = BacklinksMap::new(&scraps);
 
-        let render = IndexRender::new(&project.static_dir, &project.public_dir).unwrap();
+        let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         let readme_content: Option<Content> = None;
         render
             .run(
@@ -285,13 +285,13 @@ mod tests {
             )
             .unwrap();
 
-        let index_result = fs::read_to_string(project.public_path("index.html")).unwrap();
+        let index_result = fs::read_to_string(project.output_path("index.html")).unwrap();
         assert_eq!(
             index_result,
             "true<a href=\"./scrap1.html\">scrap1</a><a href=\"./scrap2.html\">scrap2</a>"
         );
 
-        let page2_result = fs::read_to_string(project.public_path("2.html")).unwrap();
+        let page2_result = fs::read_to_string(project.output_path("2.html")).unwrap();
         assert_eq!(
             page2_result,
             "true<a href=\"./scrap3.html\">scrap3</a><a href=\"./scrap4.html\">scrap4</a>"

--- a/src/usecase/build/html/scrap_render.rs
+++ b/src/usecase/build/html/scrap_render.rs
@@ -18,17 +18,17 @@ use super::serde::scrap_detail::ScrapDetailTera;
 
 pub struct ScrapRender {
     static_dir_path: PathBuf,
-    public_scraps_dir_path: PathBuf,
+    output_scraps_dir_path: PathBuf,
 }
 
 impl ScrapRender {
-    pub fn new(static_dir_path: &Path, public_dir_path: &Path) -> ScrapsResult<ScrapRender> {
-        let public_scraps_dir_path = &public_dir_path.join("scraps");
-        fs::create_dir_all(public_scraps_dir_path).context(BuildError::CreateDir)?;
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<ScrapRender> {
+        let output_scraps_dir_path = &output_dir_path.join("scraps");
+        fs::create_dir_all(output_scraps_dir_path).context(BuildError::CreateDir)?;
 
         Ok(ScrapRender {
             static_dir_path: static_dir_path.to_owned(),
-            public_scraps_dir_path: public_scraps_dir_path.to_owned(),
+            output_scraps_dir_path: output_scraps_dir_path.to_owned(),
         })
     }
 
@@ -58,7 +58,7 @@ impl ScrapRender {
         );
 
         let file_path = &self
-            .public_scraps_dir_path
+            .output_scraps_dir_path
             .join(format!("{}.html", ScrapFileStem::from(scrap.self_key())));
         // The stem may contain `/`-separated context directories; ensure the
         // parent directory exists before creating the file.
@@ -99,7 +99,7 @@ mod tests {
         let test_resource_path =
             PathBuf::from("tests/resource/build/html/render/it_render_scrap_htmls");
         let static_dir_path = test_resource_path.join("static");
-        let public_dir_path = test_resource_path.join("public");
+        let output_dir_path = test_resource_path.join("_site");
 
         // scraps
         let commited_ts1 = None;
@@ -112,12 +112,12 @@ mod tests {
             .collect();
         let backlinks_map = BacklinksMap::new(&scraps);
 
-        let scrap1_html_path = public_dir_path.join("scraps/scrap-1.html");
+        let scrap1_html_path = output_dir_path.join("scraps/scrap-1.html");
         // v1: nested ctx is a directory (`context/scrap-2.html`), not a
         // dot-suffix on the file stem.
-        let scrap2_html_path = public_dir_path.join("scraps/context/scrap-2.html");
+        let scrap2_html_path = output_dir_path.join("scraps/context/scrap-2.html");
 
-        let render = ScrapRender::new(&static_dir_path, &public_dir_path).unwrap();
+        let render = ScrapRender::new(&static_dir_path, &output_dir_path).unwrap();
 
         render
             .run(

--- a/src/usecase/build/html/tag_render.rs
+++ b/src/usecase/build/html/tag_render.rs
@@ -17,19 +17,19 @@ use super::serde::tag::TagTera;
 
 pub struct TagRender {
     static_dir_path: PathBuf,
-    public_tags_dir_path: PathBuf,
+    output_tags_dir_path: PathBuf,
 }
 
 impl TagRender {
-    pub fn new(static_dir_path: &Path, public_dir_path: &Path) -> ScrapsResult<TagRender> {
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<TagRender> {
         // Tag pages live in their own `tags/` directory, separate from
         // `scraps/`, to keep the two namespaces isolated (v1 design).
-        let public_tags_dir_path = &public_dir_path.join("tags");
-        fs::create_dir_all(public_tags_dir_path).context(BuildError::CreateDir)?;
+        let output_tags_dir_path = &output_dir_path.join("tags");
+        fs::create_dir_all(output_tags_dir_path).context(BuildError::CreateDir)?;
 
         Ok(TagRender {
             static_dir_path: static_dir_path.to_owned(),
-            public_tags_dir_path: public_tags_dir_path.to_owned(),
+            output_tags_dir_path: output_tags_dir_path.to_owned(),
         })
     }
 
@@ -59,7 +59,7 @@ impl TagRender {
         // segment of a hierarchical tag becomes a directory.
         let slug_path = tag_slug_path(tag);
         let file_path = self
-            .public_tags_dir_path
+            .output_tags_dir_path
             .join(format!("{}.html", slug_path));
         if let Some(parent) = file_path.parent() {
             fs::create_dir_all(parent).context(BuildError::CreateDir)?;
@@ -102,7 +102,7 @@ mod tests {
         let test_resource_path =
             PathBuf::from("tests/resource/build/html/render/it_render_tag_htmls");
         let static_dir_path = test_resource_path.join("static");
-        let public_dir_path = test_resource_path.join("public");
+        let output_dir_path = test_resource_path.join("_site");
 
         // scraps with explicit `#[[tag]]` tags
         let scrap1 = &Scrap::new("scrap1", &None, "#[[tag 1]]");
@@ -114,9 +114,9 @@ mod tests {
 
         // v1: tag pages live under `tags/` (not `scraps/`) and the slug is
         // built per-segment. "tag 1" slugifies to "tag-1".
-        let tag1_html_path = public_dir_path.join("tags/tag-1.html");
+        let tag1_html_path = output_dir_path.join("tags/tag-1.html");
 
-        let render = TagRender::new(&static_dir_path, &public_dir_path).unwrap();
+        let render = TagRender::new(&static_dir_path, &output_dir_path).unwrap();
 
         render
             .run(&base_url, &metadata, &tag1, &backlinks_map)
@@ -139,7 +139,7 @@ mod tests {
         let test_resource_path =
             PathBuf::from("tests/resource/build/html/render/it_render_nested_tag_htmls");
         let static_dir_path = test_resource_path.join("static");
-        let public_dir_path = test_resource_path.join("public");
+        let output_dir_path = test_resource_path.join("_site");
 
         let scrap = Scrap::new("paper", &None, "#[[ai/ml]]");
         let scraps = vec![scrap];
@@ -147,9 +147,9 @@ mod tests {
 
         let tag: Tag = "ai/ml".into();
         // Expected path: public/tags/ai/ml.html
-        let html_path = public_dir_path.join("tags/ai/ml.html");
+        let html_path = output_dir_path.join("tags/ai/ml.html");
 
-        let render = TagRender::new(&static_dir_path, &public_dir_path).unwrap();
+        let render = TagRender::new(&static_dir_path, &output_dir_path).unwrap();
         render
             .run(&base_url, &metadata, &tag, &backlinks_map)
             .unwrap();

--- a/src/usecase/build/html/tags_index_render.rs
+++ b/src/usecase/build/html/tags_index_render.rs
@@ -16,17 +16,17 @@ use super::serde::tags::TagsTera;
 
 pub struct TagsIndexRender {
     static_dir_path: PathBuf,
-    public_tags_dir_path: PathBuf,
+    output_tags_dir_path: PathBuf,
 }
 
 impl TagsIndexRender {
-    pub fn new(static_dir_path: &Path, public_dir_path: &Path) -> ScrapsResult<TagsIndexRender> {
-        let public_tags_dir_path = &public_dir_path.join("tags");
-        fs::create_dir_all(public_tags_dir_path).context(BuildError::CreateDir)?;
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<TagsIndexRender> {
+        let output_tags_dir_path = &output_dir_path.join("tags");
+        fs::create_dir_all(output_tags_dir_path).context(BuildError::CreateDir)?;
 
         Ok(TagsIndexRender {
             static_dir_path: static_dir_path.to_owned(),
-            public_tags_dir_path: public_tags_dir_path.to_owned(),
+            output_tags_dir_path: output_tags_dir_path.to_owned(),
         })
     }
 
@@ -59,7 +59,7 @@ impl TagsIndexRender {
             "__builtins/tags_index.html"
         };
         context.insert("tags", tags);
-        let file_path = &self.public_tags_dir_path.join("index.html");
+        let file_path = &self.output_tags_dir_path.join("index.html");
         let wtr = File::create(file_path).context(BuildError::WriteFailure(file_path.clone()))?;
         tera.render_to(template_name, &context, wtr)
             .context(BuildError::WriteFailure(file_path.clone()))
@@ -101,12 +101,12 @@ mod tests {
 
         let backlinks_map = BacklinksMap::new(&scraps);
 
-        let render = TagsIndexRender::new(&project.static_dir, &project.public_dir).unwrap();
+        let render = TagsIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render
             .run(&base_url, &metadata, &scraps, &backlinks_map)
             .unwrap();
 
-        let result1 = fs::read_to_string(project.public_path("tags/index.html")).unwrap();
+        let result1 = fs::read_to_string(project.output_path("tags/index.html")).unwrap();
         assert_eq!(
             result1,
             "<a href=\"./tag1.html\">tag1</a><a href=\"./tag2.html\">tag2</a>"

--- a/src/usecase/init/builtins/.scraps.toml
+++ b/src/usecase/init/builtins/.scraps.toml
@@ -1,6 +1,9 @@
 # The scraps directory path relative to this .scraps.toml (optional, default=scraps)
 # scraps_dir = "scraps"
 
+# The build output directory path relative to this .scraps.toml (optional, default=_site)
+# output_dir = "_site"
+
 # The site timezone (optional, default=UTC)
 # timezone = "UTC"
 

--- a/src/usecase/init/usecase.rs
+++ b/src/usecase/init/usecase.rs
@@ -22,7 +22,7 @@ impl<GC: GitCommand> InitUsecase<GC> {
         fs::create_dir(scraps_dir).context(InitError::CreateDirectory)?;
         fs::write(config_toml_file, include_str!("builtins/.scraps.toml"))
             .context(InitError::WriteFailure(config_toml_file.clone()))?;
-        fs::write(gitignore_file, "public")
+        fs::write(gitignore_file, "_site")
             .context(InitError::WriteFailure(gitignore_file.clone()))?;
         self.git_command
             .init(project_dir)

--- a/src/usecase/serve/service.rs
+++ b/src/usecase/serve/service.rs
@@ -18,13 +18,13 @@ use percent_encoding::percent_decode_str;
 
 #[derive(Clone)]
 pub struct ScrapsService {
-    pub public_dir_path: PathBuf,
+    pub output_dir_path: PathBuf,
 }
 
 impl ScrapsService {
-    pub fn new(public_dir_path: &Path) -> ScrapsService {
+    pub fn new(output_dir_path: &Path) -> ScrapsService {
         ScrapsService {
-            public_dir_path: public_dir_path.to_owned(),
+            output_dir_path: output_dir_path.to_owned(),
         }
     }
 
@@ -81,7 +81,7 @@ impl Service<Request<Incoming>> for ScrapsService {
 
     fn call(&self, request: Request<Incoming>) -> Self::Future {
         let requested_path = request.uri().path().replacen('/', "", 1); // remove head absolute slash;
-        let allowed_path = self.public_dir_path.join(requested_path);
+        let allowed_path = self.output_dir_path.join(requested_path);
         let resolved_index_path = if allowed_path.is_dir() {
             allowed_path.join("index.html")
         } else {

--- a/src/usecase/serve/usecase.rs
+++ b/src/usecase/serve/usecase.rs
@@ -11,13 +11,13 @@ use tokio::net::TcpListener;
 use crate::error::ScrapsResult;
 
 pub struct ServeUsecase {
-    public_dir_path: PathBuf,
+    output_dir_path: PathBuf,
 }
 
 impl ServeUsecase {
-    pub fn new(public_dir_path: &Path) -> ServeUsecase {
+    pub fn new(output_dir_path: &Path) -> ServeUsecase {
         ServeUsecase {
-            public_dir_path: public_dir_path.to_path_buf(),
+            output_dir_path: output_dir_path.to_path_buf(),
         }
     }
 
@@ -29,7 +29,7 @@ impl ServeUsecase {
             let (stream, _) = listener.accept().await?;
             let io = TokioIo::new(stream);
 
-            let service = ScrapsService::new(&self.public_dir_path);
+            let service = ScrapsService::new(&self.output_dir_path);
             tokio::task::spawn(async move {
                 if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
                     println!("Failed to serve connection: {err:?}");


### PR DESCRIPTION
## Summary

Closes #508.

- Rename default build output directory from `public/` to `_site/` (Jekyll/Hakyll convention) to avoid v1 ctx-namespace collisions when `.scraps.toml` lives at the wiki root.
- Add `output_dir: Option<PathBuf>` to `.scraps.toml` so users can override the default.
- Wire `PathResolver::output_dir(&config)` through `build` / `serve`, update the `TempScrapProject` fixture (`output_dir` / `output_path()`), update `scraps init` (`.gitignore` writes `_site`, bundled `.scraps.toml` has a commented `output_dir` example), and sweep internal `public_dir_path` names to `output_dir_path` for vocabulary consistency.
- Update docs (`Build.md`, `Serve.md`, `README Processing.md`) and the repo `.gitignore`.

This is a v1 breaking change. Existing wikis must regenerate (or rename their checked-in output dir); the migration note will land in the v1 release notes.

## Test plan

- [x] `mise run cargo:quality` passes locally (build + test + fmt + clippy)
- [ ] CI green
- [ ] Manual: run `scraps init` in a fresh dir → verify `.gitignore` contains `_site` and bundled config shows the `output_dir` comment
- [ ] Manual: run `scraps build` → verify output lands in `_site/`, then set `output_dir = "dist"` and re-run → verify output lands in `dist/`
- [ ] Manual: `scraps serve` serves from the configured `output_dir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)