### PR TITLE
Rename `--path`/`-p` to `--directory`/`-C` aligning with git/make conventions

### DIFF
--- a/docs/How-to/Install Claude Code Plugin.md
+++ b/docs/How-to/Install Claude Code Plugin.md
@@ -32,15 +32,15 @@ path.
 
 ## Configuration
 
-### Custom Project Path (Optional)
+### Custom Project Directory (Optional)
 
-To specify a different Scraps project path, set the `SCRAPS_PROJECT_PATH`
+To specify a different Scraps project directory, set the `SCRAPS_DIRECTORY`
 environment variable:
 
 ```json
 {
   "env": {
-    "SCRAPS_PROJECT_PATH": "/path/to/your/scraps/project"
+    "SCRAPS_DIRECTORY": "/path/to/your/scraps/project"
   },
   "enabledPlugins": {
     "mcp-server@scraps-claude-code-plugins": true

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -17,7 +17,7 @@ For Claude Code users, we provide an official plugin for seamless integration. S
 For other MCP-compatible clients or advanced configurations, you can add Scraps as an MCP server directly:
 
 ```bash
-claude mcp add scraps -- scraps mcp serve --path ~/path/to/your/scraps/project/
+claude mcp add scraps -- scraps mcp serve -C ~/path/to/your/scraps/project/
 ```
 
 Replace `~/path/to/your/scraps/project/` with the actual path to your Scraps project directory.

--- a/docs/Reference/Build.md
+++ b/docs/Reference/Build.md
@@ -41,7 +41,7 @@ Each Markdown file is converted to a slugified HTML file. Additional files like 
 ❯ scraps build --verbose
 
 # Build from specific directory
-❯ scraps build --path /path/to/project
+❯ scraps build -C /path/to/project
 ```
 
 After building, use [[Reference/Serve]] to preview your site locally.

--- a/docs/Reference/Init.md
+++ b/docs/Reference/Init.md
@@ -21,8 +21,8 @@ This command initializes a new Scraps project. It creates the following structur
 ❯ scraps init my-knowledge-base
 ❯ cd my-knowledge-base
 
-# Initialize with specific path
-❯ scraps init docs --path /path/to/workspace
+# Initialize with specific directory
+❯ scraps init -C /path/to/workspace
 ```
 
 After initializing the project, proceed to [[Reference/Build|Build]] to generate your static site.

--- a/docs/Reference/Lint.md
+++ b/docs/Reference/Lint.md
@@ -53,5 +53,5 @@ warning[overlinking]: link [[Rust]] appears 3 times
 ❯ scraps lint
 
 # Lint from specific directory
-❯ scraps lint --path /path/to/project
+❯ scraps lint -C /path/to/project
 ```

--- a/docs/Reference/MCP Serve.md
+++ b/docs/Reference/MCP Serve.md
@@ -13,7 +13,7 @@ This command starts an MCP (Model Context Protocol) server that enables AI assis
 ❯ scraps mcp serve
 
 # Serve from specific directory  
-❯ scraps mcp serve --path /path/to/project
+❯ scraps mcp serve -C /path/to/project
 
 ```
 

--- a/docs/Reference/Serve.md
+++ b/docs/Reference/Serve.md
@@ -13,7 +13,7 @@ This command starts a local development server to preview your static site. The 
 ❯ scraps serve
 
 # Serve from specific directory
-❯ scraps serve --path /path/to/project
+❯ scraps serve -C /path/to/project
 ```
 
 Use this command to check how your site looks and functions before deployment.

--- a/docs/Reference/Tag.md
+++ b/docs/Reference/Tag.md
@@ -13,5 +13,5 @@ This command lists all tags found in your Scraps content, helping you understand
 ❯ scraps tag
 
 # List tags from specific directory
-❯ scraps tag --path /path/to/project
+❯ scraps tag -C /path/to/project
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,16 +17,46 @@ mod progress;
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     #[arg(
+        short = 'C',
+        long = "directory",
+        global = true,
+        env = "SCRAPS_DIRECTORY",
+        value_name = "DIR",
+        help = "Run as if started in <DIR> (instead of the current directory)"
+    )]
+    pub directory: Option<PathBuf>,
+
+    #[arg(
         short = 'p',
         long = "path",
         global = true,
         env = "SCRAPS_PROJECT_PATH",
-        help = "Specify the project directory path"
+        value_name = "DIR",
+        hide = true,
+        help = "[DEPRECATED] Use -C/--directory instead. Will be removed in v1.1."
     )]
     pub path: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: SubCommands,
+}
+
+impl Cli {
+    /// Resolve the effective working directory, preferring `-C/--directory`.
+    ///
+    /// Emits a deprecation warning to stderr when `-p/--path` (or
+    /// `SCRAPS_PROJECT_PATH`) is used.
+    pub fn resolve_directory<'a>(
+        directory: Option<&'a std::path::Path>,
+        path: Option<&'a std::path::Path>,
+    ) -> Option<&'a std::path::Path> {
+        if path.is_some() {
+            eprintln!(
+                "warning: -p/--path (and SCRAPS_PROJECT_PATH) is deprecated and will be removed in v1.1. Use -C/--directory (or SCRAPS_DIRECTORY) instead."
+            );
+        }
+        directory.or(path)
+    }
 }
 
 #[derive(Subcommand)]
@@ -236,5 +266,39 @@ impl From<CliLintRuleName> for LintRuleName {
             CliLintRuleName::BrokenHeadingRef => LintRuleName::BrokenHeadingRef,
             CliLintRuleName::StaleByGit => LintRuleName::StaleByGit,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn resolve_directory_prefers_directory_over_path() {
+        let directory = PathBuf::from("/dir");
+        let path = PathBuf::from("/path");
+        let resolved = Cli::resolve_directory(Some(&directory), Some(&path));
+        assert_eq!(resolved, Some(Path::new("/dir")));
+    }
+
+    #[test]
+    fn resolve_directory_falls_back_to_path_when_directory_absent() {
+        let path = PathBuf::from("/path");
+        let resolved = Cli::resolve_directory(None, Some(&path));
+        assert_eq!(resolved, Some(Path::new("/path")));
+    }
+
+    #[test]
+    fn resolve_directory_uses_directory_when_path_absent() {
+        let directory = PathBuf::from("/dir");
+        let resolved = Cli::resolve_directory(Some(&directory), None);
+        assert_eq!(resolved, Some(Path::new("/dir")));
+    }
+
+    #[test]
+    fn resolve_directory_returns_none_when_both_absent() {
+        let resolved = Cli::resolve_directory(None, None);
+        assert_eq!(resolved, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,36 +14,39 @@ use clap::Parser;
 use error::McpError;
 
 fn main() -> error::ScrapsResult<()> {
-    let cli = cli::Cli::parse();
+    let cli::Cli {
+        directory,
+        path,
+        command,
+    } = cli::Cli::parse();
+    let directory = cli::Cli::resolve_directory(directory.as_deref(), path.as_deref());
 
-    match cli.command {
-        cli::SubCommands::Init => cli::cmd::init::run(cli.path.as_deref()),
-        cli::SubCommands::Build { verbose, git } => {
-            cli::cmd::build::run(verbose, git, cli.path.as_deref())
-        }
+    match command {
+        cli::SubCommands::Init => cli::cmd::init::run(directory),
+        cli::SubCommands::Build { verbose, git } => cli::cmd::build::run(verbose, git, directory),
         cli::SubCommands::Get { title, ctx, json } => cli::cmd::get::run(
             &title,
             ctx.as_deref(),
             json,
-            cli.path.as_deref(),
+            directory,
             &mut std::io::stdout(),
         ),
         cli::SubCommands::Lint { rules } => {
             let rule_names: Vec<_> = rules.into_iter().map(Into::into).collect();
-            cli::cmd::lint::run(cli.path.as_deref(), &rule_names)
+            cli::cmd::lint::run(directory, &rule_names)
         }
         cli::SubCommands::Links { title, ctx, json } => cli::cmd::links::run(
             &title,
             ctx.as_deref(),
             json,
-            cli.path.as_deref(),
+            directory,
             &mut std::io::stdout(),
         ),
         cli::SubCommands::Backlinks { title, ctx, json } => cli::cmd::backlinks::run(
             &title,
             ctx.as_deref(),
             json,
-            cli.path.as_deref(),
+            directory,
             &mut std::io::stdout(),
         ),
         cli::SubCommands::Search {
@@ -56,32 +59,26 @@ fn main() -> error::ScrapsResult<()> {
             num,
             logic.into(),
             json,
-            cli.path.as_deref(),
+            directory,
             &mut std::io::stdout(),
         ),
-        cli::SubCommands::Serve { git } => cli::cmd::serve::run(git, cli.path.as_deref()),
+        cli::SubCommands::Serve { git } => cli::cmd::serve::run(git, directory),
         cli::SubCommands::Tag { tag_command } => match tag_command {
             cli::TagSubCommands::List { json } => {
-                cli::cmd::tag::list::run(json, cli.path.as_deref(), &mut std::io::stdout())
+                cli::cmd::tag::list::run(json, directory, &mut std::io::stdout())
             }
-            cli::TagSubCommands::Backlinks { tag, json } => cli::cmd::tag::backlinks::run(
-                &tag,
-                json,
-                cli.path.as_deref(),
-                &mut std::io::stdout(),
-            ),
+            cli::TagSubCommands::Backlinks { tag, json } => {
+                cli::cmd::tag::backlinks::run(&tag, json, directory, &mut std::io::stdout())
+            }
         },
-        cli::SubCommands::Todo { status, json } => cli::cmd::todo::run(
-            status.into(),
-            json,
-            cli.path.as_deref(),
-            &mut std::io::stdout(),
-        ),
+        cli::SubCommands::Todo { status, json } => {
+            cli::cmd::todo::run(status.into(), json, directory, &mut std::io::stdout())
+        }
         cli::SubCommands::Mcp { mcp_command } => match mcp_command {
             cli::McpSubCommands::Serve => {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|e| McpError::RuntimeCreation(e.to_string()))?;
-                runtime.block_on(cli::cmd::mcp::serve::run(cli.path.as_deref()))
+                runtime.block_on(cli::cmd::mcp::serve::run(directory))
             }
         },
     }


### PR DESCRIPTION
## Summary

Closes #510.

- Add `-C` / `--directory <DIR>` as the primary global flag (env: `SCRAPS_DIRECTORY`), aligning with the widely recognized "act as if started in dir" convention from git, make, and pnpm.
- Keep `-p` / `--path` (env: `SCRAPS_PROJECT_PATH`) as a hidden deprecated alias. Using it now emits a stderr warning. Slated for full removal in v1.1.
- Update all docs to use `-C`.

## Behavior

```text
$ scraps build
📦 Building site...
✨ Done build in 0.46 secs

$ scraps build --path /tmp/foo
warning: -p/--path (and SCRAPS_PROJECT_PATH) is deprecated and will be removed in v1.1. Use -C/--directory (or SCRAPS_DIRECTORY) instead.
Error: Project directory does not exist: /tmp/foo
```

`-C` is location-agnostic: it covers cross-repo invocation as well as intra-repo child invocation (`scraps build -C docs/`) under a single flag, matching the v1 mise-pattern config discovery design.

## Test plan

- [x] `mise run cargo:quality` (build + test + fmt + clippy) passes
- [x] New unit tests for `Cli::resolve_directory` (priority of `-C` > `-p`, fallback, none)
- [x] Manual: `scraps --help` shows only `-C/--directory` (deprecated alias hidden)
- [x] Manual: `scraps --path` still works and emits the deprecation warning
- [ ] Follow-up: open a v1.1 milestone task to remove `-p/--path` and `SCRAPS_PROJECT_PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)