### PR TITLE
docs: revert unreleased -C/--directory references from #517

### DIFF
--- a/docs/How-to/Install Claude Code Plugin.md
+++ b/docs/How-to/Install Claude Code Plugin.md
@@ -32,15 +32,15 @@ path.
 
 ## Configuration
 
-### Custom Project Directory (Optional)
+### Custom Project Path (Optional)
 
-To specify a different Scraps project directory, set the `SCRAPS_DIRECTORY`
+To specify a different Scraps project path, set the `SCRAPS_PROJECT_PATH`
 environment variable:
 
 ```json
 {
   "env": {
-    "SCRAPS_DIRECTORY": "/path/to/your/scraps/project"
+    "SCRAPS_PROJECT_PATH": "/path/to/your/scraps/project"
   },
   "enabledPlugins": {
     "mcp-server@scraps-claude-code-plugins": true

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -17,7 +17,7 @@ For Claude Code users, we provide an official plugin for seamless integration. S
 For other MCP-compatible clients or advanced configurations, you can add Scraps as an MCP server directly:
 
 ```bash
-claude mcp add scraps -- scraps mcp serve -C ~/path/to/your/scraps/project/
+claude mcp add scraps -- scraps mcp serve --path ~/path/to/your/scraps/project/
 ```
 
 Replace `~/path/to/your/scraps/project/` with the actual path to your Scraps project directory.

--- a/docs/Reference/Build.md
+++ b/docs/Reference/Build.md
@@ -41,7 +41,7 @@ Each Markdown file is converted to a slugified HTML file. Additional files like 
 ❯ scraps build --verbose
 
 # Build from specific directory
-❯ scraps build -C /path/to/project
+❯ scraps build --path /path/to/project
 ```
 
 After building, use [[Reference/Serve]] to preview your site locally.

--- a/docs/Reference/Init.md
+++ b/docs/Reference/Init.md
@@ -21,8 +21,8 @@ This command initializes a new Scraps project. It creates the following structur
 ❯ scraps init my-knowledge-base
 ❯ cd my-knowledge-base
 
-# Initialize with specific directory
-❯ scraps init -C /path/to/workspace
+# Initialize with specific path
+❯ scraps init docs --path /path/to/workspace
 ```
 
 After initializing the project, proceed to [[Reference/Build|Build]] to generate your static site.

--- a/docs/Reference/Lint.md
+++ b/docs/Reference/Lint.md
@@ -53,5 +53,5 @@ warning[overlinking]: link [[Rust]] appears 3 times
 ❯ scraps lint
 
 # Lint from specific directory
-❯ scraps lint -C /path/to/project
+❯ scraps lint --path /path/to/project
 ```

--- a/docs/Reference/MCP Serve.md
+++ b/docs/Reference/MCP Serve.md
@@ -13,7 +13,7 @@ This command starts an MCP (Model Context Protocol) server that enables AI assis
 ❯ scraps mcp serve
 
 # Serve from specific directory  
-❯ scraps mcp serve -C /path/to/project
+❯ scraps mcp serve --path /path/to/project
 
 ```
 

--- a/docs/Reference/Serve.md
+++ b/docs/Reference/Serve.md
@@ -13,7 +13,7 @@ This command starts a local development server to preview your static site. The 
 ❯ scraps serve
 
 # Serve from specific directory
-❯ scraps serve -C /path/to/project
+❯ scraps serve --path /path/to/project
 ```
 
 Use this command to check how your site looks and functions before deployment.

--- a/docs/Reference/Tag.md
+++ b/docs/Reference/Tag.md
@@ -13,5 +13,5 @@ This command lists all tags found in your Scraps content, helping you understand
 ❯ scraps tag
 
 # List tags from specific directory
-❯ scraps tag -C /path/to/project
+❯ scraps tag --path /path/to/project
 ```


### PR DESCRIPTION
## Summary

PR #517 updated the user-facing docs to use the new `-C/--directory` flag and `SCRAPS_DIRECTORY` environment variable, but those changes are not yet released. This PR reverts only the docs portion so the published documentation continues to match the currently released CLI (`-p/--path` / `SCRAPS_PROJECT_PATH`).

The code changes from #517 (new `-C/--directory` flag + deprecation alias for `-p/--path`) are intentionally kept — only the docs are rolled back.

## Files reverted

- `docs/How-to/Install Claude Code Plugin.md`
- `docs/How-to/Integrate with AI Assistants.md`
- `docs/Reference/Build.md`
- `docs/Reference/Init.md`
- `docs/Reference/Lint.md`
- `docs/Reference/MCP Serve.md`
- `docs/Reference/Serve.md`
- `docs/Reference/Tag.md`

## Follow-up

Re-apply these doc updates as part of the release that ships `-C/--directory`.

## Test plan

- [x] Confirm only `docs/**/*.md` files are touched
- [ ] After merge, verify the published docs site shows `--path` again

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsaTu2pUCStjrW3TbDirgk)_