### PR TITLE
docs: update v1 reference docs

### DIFF
--- a/docs/How-to/Install Claude Code Plugin.md
+++ b/docs/How-to/Install Claude Code Plugin.md
@@ -34,13 +34,13 @@ path.
 
 ### Custom Project Path (Optional)
 
-To specify a different Scraps project path, set the `SCRAPS_PROJECT_PATH`
+To specify a different Scraps project path, set the `SCRAPS_DIRECTORY`
 environment variable:
 
 ```json
 {
   "env": {
-    "SCRAPS_PROJECT_PATH": "/path/to/your/scraps/project"
+    "SCRAPS_DIRECTORY": "/path/to/your/wiki"
   },
   "enabledPlugins": {
     "mcp-server@scraps-claude-code-plugins": true

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -1,6 +1,21 @@
 #[[Integration]]
 
-Scraps includes comprehensive Model Context Protocol (MCP) server functionality, enabling AI assistants to directly interact with your Scraps knowledge base.
+Scraps is CLI-first for AI integration. Prefer `--json` commands when your
+assistant can run shell commands, and use the MCP server when your client expects
+Model Context Protocol tools.
+
+## CLI JSON
+
+Any assistant with shell access can query Scraps without a long-running server:
+
+```bash
+❯ scraps search "rust cli" --logic and --json
+❯ scraps get "Getting Started" --json
+❯ scraps links "Getting Started" --json
+❯ scraps backlinks "Configuration" --json
+❯ scraps tag list --json
+❯ scraps todo --status all --json
+```
 
 ## What is MCP?
 
@@ -17,13 +32,14 @@ For Claude Code users, we provide an official plugin for seamless integration. S
 For other MCP-compatible clients or advanced configurations, you can add Scraps as an MCP server directly:
 
 ```bash
-claude mcp add scraps -- scraps mcp serve --path ~/path/to/your/scraps/project/
+claude mcp add scraps -- scraps -C ~/path/to/your/wiki mcp serve
 ```
 
-Replace `~/path/to/your/scraps/project/` with the actual path to your Scraps project directory.
+Replace `~/path/to/your/wiki` with the directory containing `.scraps.toml`.
 
 For command details, see [[Reference/MCP Serve]].
 
 ## Available Tools
 
-For detailed MCP tool documentation, see [[Reference/MCP Tools]].
+For detailed MCP tool documentation, see [[Reference/MCP Tools]]. For CLI JSON
+commands, see [[Reference/Get]], [[Reference/Search]], [[Reference/Links]], [[Reference/Backlinks]], [[Reference/Tag]], and [[Reference/Todo]].

--- a/docs/How-to/Setup LSP.md
+++ b/docs/How-to/Setup LSP.md
@@ -9,7 +9,9 @@ markdown-oxide supports the following editing environments:
 - Zed
 - Helix
 
-To match the current features provided by Scraps, place the following configuration file `.moxide.toml` under the `scraps/` directory and open the `scraps/` directory directly for a comfortable editing experience.
+To match the current features provided by Scraps, place the following
+configuration file `.moxide.toml` in the wiki root and open that directory
+directly for a comfortable editing experience.
 
 ```toml
 heading_completions = false

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,8 @@
-Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation.
+Scraps is a wiki-link document compiler for the LLM era.
+
+Write plain Markdown, connect scraps with typed wiki-links, and compile the same
+source into a static site for readers and JSON-queryable knowledge for CLI
+tools and AI agents.
 
 Learn more: [[Explanation/What is Scraps?]]
 
@@ -7,8 +11,8 @@ Learn more: [[Explanation/What is Scraps?]]
 This documentation follows the [Diátaxis](https://diataxis.fr/) framework:
 
 - **Tutorials** - Learn Scraps: [[Tutorial/Getting Started]]
-- **How-to Guides** - Solve problems: [[How-to/Deploy to GitHub Pages]], [[How-to/Setup LSP]]
-- **Reference** - Look up details: [[Reference/Build]], [[Reference/Configuration]], [[Reference/Normal Link]]
-- **Explanation** - Understand concepts: [[Explanation/What is Scraps?]], [[Explanation/Search Architecture]]
+- **How-to Guides** - Solve problems: [[How-to/Deploy to GitHub Pages]], [[How-to/Setup LSP]], [[How-to/Integrate with AI Assistants]]
+- **Reference** - Look up details: [[Reference/Build]], [[Reference/Configuration]], [[Reference/Get]], [[Reference/Search]], [[Reference/Lint]]
+- **Explanation** - Understand concepts: [[Explanation/What is Scraps?]], [[Explanation/Search Architecture]], [[Explanation/README Processing]]
 
-Browse by topic: #[[CLI]] #[[Wiki-Links]] #[[Markdown]]
+Browse by topic: #[[CLI]] #[[Wiki-Links]] #[[Markdown]] #[[LLM]]

--- a/docs/Reference/Backlinks.md
+++ b/docs/Reference/Backlinks.md
@@ -1,0 +1,35 @@
+#[[CLI]] #[[Wiki-Links]]
+
+```bash
+❯ scraps backlinks <TITLE>
+```
+
+This command lists inbound wiki-links to a scrap. Use `--ctx` when the target
+title needs context disambiguation.
+
+## Examples
+
+```bash
+# Table output
+❯ scraps backlinks "Configuration"
+
+# Context-qualified target scrap
+❯ scraps backlinks "Service" --ctx Kubernetes
+
+# JSON output
+❯ scraps backlinks "Configuration" --json
+```
+
+## JSON Shape
+
+```json
+{
+  "results": [
+    {
+      "title": "Getting Started",
+      "ctx": null
+    }
+  ],
+  "count": 1
+}
+```

--- a/docs/Reference/Build.md
+++ b/docs/Reference/Build.md
@@ -4,15 +4,18 @@
 ❯ scraps build
 ```
 
-This command processes Markdown files from the `/scraps` directory and generates a static website.
+This command processes Markdown files under the wiki root and generates a static website. The wiki root is the directory containing `.scraps.toml`.
 
 ## Source Structure
 
 ```bash
-❯ tree scraps
-scraps
+❯ tree -a -I _site
+.
+├── .scraps.toml
 ├── Getting Started.md
-└── Documentation.md
+├── Documentation.md
+└── Guide
+    └── Links.md
 ```
 
 ## Generated Files
@@ -23,13 +26,19 @@ The command generates the following files in the `_site` directory (configurable
 ❯ tree _site
 _site
 ├── index.html      # Main page with scrap list
-├── getting-started.html
-├── documentation.html
+├── scraps
+│   ├── getting-started.html
+│   ├── documentation.html
+│   └── guide
+│       └── links.html
 ├── main.css       # Styling for the site
-└── search.json    # Search index (if enabled)
+└── search_index.json # Search index (if enabled)
 ```
 
-Each Markdown file is converted to a slugified HTML file. Additional files like `index.html` and `main.css` are generated to create a complete static website.
+Each Markdown file is converted to a slugified HTML file. `README.md` is special:
+it becomes the site top page (`index.html`) instead of a normal scrap page.
+Files in `static/` and the build output directory are excluded from scrap
+traversal.
 
 ## Examples
 
@@ -40,8 +49,11 @@ Each Markdown file is converted to a slugified HTML file. Additional files like 
 # Build with verbose output
 ❯ scraps build --verbose
 
+# Include git-derived committed timestamps in generated pages
+❯ scraps build --git
+
 # Build from specific directory
-❯ scraps build --path /path/to/project
+❯ scraps -C /path/to/wiki build
 ```
 
 After building, use [[Reference/Serve]] to preview your site locally.

--- a/docs/Reference/Configuration.md
+++ b/docs/Reference/Configuration.md
@@ -1,13 +1,16 @@
 #[[Configuration]]
 
-Configuration is managed by `.scraps.toml` in the Scraps project.
+Configuration is managed by `.scraps.toml`. The directory containing this file
+is the Scraps wiki root, and every Markdown file under it is treated as a
+scrap unless it is in `static/` or the configured output directory.
 
 ## Configuration Structure
 
-The configuration file has two sections:
+The configuration file has three areas:
 
-- **Root level**: Contains `scraps_dir` and `timezone` for general settings
+- **Root level**: Contains `output_dir` and `timezone`
 - **[ssg] section**: Contains all static site generator settings
+- **[lint.*] sections**: Configure opt-in lint rules
 
 The `[ssg]` section is required for `build` and `serve` commands. Other commands
 like `lint`, `tag`, and `mcp` can work without this section.
@@ -19,8 +22,8 @@ Within the `[ssg]` section, `base_url` and `title` are required fields.
 All configuration variables used by Scraps and their default values are listed below.
 
 ```toml:.scraps.toml
-# The scraps directory path relative to this .scraps.toml (optional, default=scraps)
-scraps_dir = "scraps"
+# Build output directory relative to this .scraps.toml (optional, default=_site)
+output_dir = "_site"
 
 # The site timezone (optional, default=UTC)
 timezone = "UTC"
@@ -57,4 +60,25 @@ sort_key = "committed_date"
 
 # Scraps pagination on index page(optional, default=no pagination)
 paginate_by = 20
+
+# Optional lint rule configuration.
+# Presence of this section enables stale-by-git during `scraps lint`.
+[lint.stale_by_git]
+enabled = true
+threshold_days = 180
 ```
+
+## Project Root
+
+Scraps does not use a `scraps_dir` setting in v1. To keep multiple independent
+wikis in one repository, place a separate `.scraps.toml` in each wiki directory
+and run commands with `-C`:
+
+```bash
+❯ scraps -C docs build
+❯ scraps -C internal-wiki lint
+```
+
+The old `-p` / `--path` flag is still accepted as a deprecated alias for one
+release. Prefer `-C` / `--directory` or the `SCRAPS_DIRECTORY` environment
+variable.

--- a/docs/Reference/Context Link.md
+++ b/docs/Reference/Context Link.md
@@ -3,17 +3,19 @@
 In cases where the same term exists in different contexts and Scrap titles would overlap, you can use the context feature by separating them with folders. For example:
 
 ```bash
-❯ tree scraps
-scraps
+❯ tree
+.
 ├── DDD
 │   └── Service.md
 └── Kubernetes
     └── Service.md
 ```
 
-Links to Scrap with different contexts can be specified like `[[DDD/Service]]`, `[[Kubernetes/Service]]`. You can also combine them with [[Reference/Alias Link|Alias link]] such as `[[Kubernetes/Service|Kubernetes Service]]`.
+Links to scraps with different contexts can be specified like `[[DDD/Service]]`, `[[Kubernetes/Service]]`. You can also combine them with [[Reference/Alias Link|Alias link]] such as `[[Kubernetes/Service|Kubernetes Service]]`.
 
 The context is also displayed on the Scrap detail page in the static site.
+
+Context depth is bounded to three folder segments.
 
 ## Not Recommended
 

--- a/docs/Reference/Get.md
+++ b/docs/Reference/Get.md
@@ -1,0 +1,45 @@
+#[[CLI]]
+
+```bash
+❯ scraps get <TITLE>
+```
+
+This command prints the Markdown body of one scrap. Use `--ctx` when multiple
+scraps share the same title in different context folders.
+
+## Examples
+
+```bash
+# Print Markdown
+❯ scraps get "Getting Started"
+
+# Disambiguate by context
+❯ scraps get "Service" --ctx Kubernetes
+
+# JSON output for agents and scripts
+❯ scraps get "Getting Started" --json
+```
+
+## JSON Shape
+
+```json
+{
+  "title": "Getting Started",
+  "ctx": null,
+  "md_text": "# Getting Started\n...",
+  "headings": [
+    {
+      "level": 1,
+      "text": "Getting Started",
+      "line": 1
+    }
+  ],
+  "code_blocks": [
+    {
+      "lang": "bash",
+      "content": "scraps build",
+      "line": 12
+    }
+  ]
+}
+```

--- a/docs/Reference/Init.md
+++ b/docs/Reference/Init.md
@@ -1,28 +1,29 @@
 #[[CLI]]
 
 ```bash
-❯ scraps init <PROJECT_NAME>
+❯ scraps init
 ```
 
-This command initializes a new Scraps project. It creates the following structure:
+This command initializes the current directory as a Scraps wiki. Create the
+directory first, then run `scraps init` inside it.
 
 ```bash
 ❯ tree -a -L 1
 .
 ├── .gitignore    # Git ignore patterns for Scraps projects
-├── .scraps.toml  # Project configuration file
-└── scraps       # Directory for your Markdown files
+└── .scraps.toml  # Project configuration file
 ```
 
 ## Examples
 
 ```bash
 # Initialize new project
-❯ scraps init my-knowledge-base
+❯ mkdir my-knowledge-base
 ❯ cd my-knowledge-base
+❯ scraps init
 
-# Initialize with specific path
-❯ scraps init docs --path /path/to/workspace
+# Initialize a specific existing directory
+❯ scraps -C /path/to/wiki init
 ```
 
 After initializing the project, proceed to [[Reference/Build|Build]] to generate your static site.

--- a/docs/Reference/Links.md
+++ b/docs/Reference/Links.md
@@ -1,0 +1,35 @@
+#[[CLI]] #[[Wiki-Links]]
+
+```bash
+❯ scraps links <TITLE>
+```
+
+This command lists outbound wiki-links from a scrap. Use `--ctx` when the title
+needs context disambiguation.
+
+## Examples
+
+```bash
+# Table output
+❯ scraps links "Getting Started"
+
+# Context-qualified target scrap
+❯ scraps links "Service" --ctx Kubernetes
+
+# JSON output
+❯ scraps links "Getting Started" --json
+```
+
+## JSON Shape
+
+```json
+{
+  "results": [
+    {
+      "title": "Configuration",
+      "ctx": null
+    }
+  ],
+  "count": 1
+}
+```

--- a/docs/Reference/Lint.md
+++ b/docs/Reference/Lint.md
@@ -26,9 +26,21 @@ Detects the same `[[link]]` appearing multiple times within a single scrap. Repe
 
 `[[Page|alias]]` and `[[Page]]` are treated as the same link.
 
-### singleton-tag
+### broken-link
 
-Detects tags referenced by only 1 scrap. Tags used by a single scrap provide no grouping value and may indicate a tag that should be removed or consolidated.
+Detects `[[link]]` references that do not resolve to an existing scrap. Tags are
+not implicit fallback targets in v1; write `#[[tag]]` when you mean a tag.
+
+### broken-heading-ref
+
+Detects `[[Page#Heading]]` references where the scrap exists but the heading
+fragment does not match any heading in that target scrap.
+
+### stale-by-git
+
+Detects scraps whose latest git commit is older than a threshold. This rule is
+opt-in because it depends on git metadata. Enable it with `--rule stale-by-git`
+or with `[lint.stale_by_git]` in `.scraps.toml`.
 
 ## Output Format
 
@@ -36,10 +48,10 @@ Diagnostics follow the same style as `cargo clippy`:
 
 ```
 warning[dead-end]: scrap has no links to other scraps
- --> scraps/orphan.md
+ --> /path/to/wiki/orphan.md
 
 warning[overlinking]: link [[Rust]] appears 3 times
- --> scraps/programming.md:2:5
+ --> /path/to/wiki/programming.md:2:5
   |
 2 | See [[Rust]] for details. Also [[Rust]] and [[Rust]].
   |     ^^^^^^^^
@@ -52,6 +64,12 @@ warning[overlinking]: link [[Rust]] appears 3 times
 # Lint current project
 ❯ scraps lint
 
+# Run one rule
+❯ scraps lint --rule broken-link
+
+# Run opt-in stale check
+❯ scraps lint --rule stale-by-git
+
 # Lint from specific directory
-❯ scraps lint --path /path/to/project
+❯ scraps -C /path/to/wiki lint
 ```

--- a/docs/Reference/MCP Serve.md
+++ b/docs/Reference/MCP Serve.md
@@ -12,11 +12,14 @@ This command starts an MCP (Model Context Protocol) server that enables AI assis
 # Basic MCP server
 ❯ scraps mcp serve
 
-# Serve from specific directory  
-❯ scraps mcp serve --path /path/to/project
+# Serve from specific directory
+❯ scraps -C /path/to/wiki mcp serve
 
 ```
 
-The MCP server provides tools for AI assistants to search through your content and list available tags, enabling intelligent assistance with your documentation.
+The MCP server provides tools for AI assistants to search content, retrieve
+scraps, inspect wiki-links, and list tags. CLI JSON commands are the primary
+agent integration surface in v1; MCP remains available for MCP-compatible
+clients.
 
 For more details, see [[How-to/Integrate with AI Assistants]].

--- a/docs/Reference/MCP Tools.md
+++ b/docs/Reference/MCP Tools.md
@@ -40,6 +40,21 @@ Array of tags with the following fields:
 - `title`: Tag name
 - `backlinks_count`: Number of scraps referencing this tag
 
+## get_scrap
+
+Retrieve a single scrap by title and optional context.
+
+**Parameters:**
+- `title` (string, required): Title of the scrap
+- `ctx` (string, optional): Context folder path if the title is not at the root
+
+**Returns:**
+- `title`: Scrap title
+- `ctx`: Context folder path, or null if the scrap is at the root
+- `md_text`: Full Markdown content
+- `headings`: Parsed headings with `level`, `text`, `line`, and optional `parent`
+- `code_blocks`: Fenced code blocks with `lang`, `content`, and `line`
+
 ## lookup_scrap_links
 
 Find outbound wiki links from a specific scrap. Returns all scraps that the
@@ -50,7 +65,8 @@ specified scrap links to.
 - `ctx` (string, optional): Context if the scrap has one
 
 **Returns:**
-Array of linked scraps with `title` and `ctx`.
+- `results`: Array of linked scraps with `title` and `ctx`
+- `count`: Total number of linked scraps
 
 ## lookup_scrap_backlinks
 
@@ -62,7 +78,8 @@ that link to the specified scrap.
 - `ctx` (string, optional): Context if the scrap has one
 
 **Returns:**
-Array of scraps that link to the specified scrap, with `title` and `ctx`.
+- `results`: Array of scraps that link to the specified scrap, with `title` and `ctx`
+- `count`: Total number of backlinks
 
 ## lookup_tag_backlinks
 
@@ -72,7 +89,8 @@ Find all scraps that reference a specific tag.
 - `tag` (string, required): Tag name to get backlinks for
 
 **Returns:**
-Array of scraps that reference the specified tag, with `title` and `ctx`.
+- `results`: Array of scraps that reference the specified tag, with `title` and `ctx`
+- `count`: Total number of tag backlinks
 
 ## Notes
 

--- a/docs/Reference/Normal Link.md
+++ b/docs/Reference/Normal Link.md
@@ -5,13 +5,13 @@ Specifying the name of the markdown file with a notation such as `[[Link]]` will
 For example, if you have the following set of files.
 
 ```bash
-❯ tree scraps
-scraps
+❯ tree
+.
 ├── Overview.md
 └── Usage.md
 ```
 
-Fill in the file name in the `scraps` directory in `Overview.md` as follows to generate the link.
+Fill in the target file name in `Overview.md` as follows to generate the link.
 
 ```markdown:Overview.md
 See [[Usage]] for detail.

--- a/docs/Reference/Search.md
+++ b/docs/Reference/Search.md
@@ -1,0 +1,38 @@
+#[[CLI]]
+
+```bash
+❯ scraps search <QUERY>
+```
+
+This command searches scrap titles and Markdown bodies using fuzzy matching.
+Space-separated keywords use `or` logic by default.
+
+## Examples
+
+```bash
+# Search with default OR logic
+❯ scraps search "rust cli"
+
+# Require every keyword to match
+❯ scraps search "rust cli" --logic and
+
+# Limit result count
+❯ scraps search "rust cli" --num 20
+
+# JSON output for agents and scripts
+❯ scraps search "rust cli" --logic and --json
+```
+
+## JSON Shape
+
+```json
+{
+  "results": [
+    {
+      "title": "Rust CLI",
+      "ctx": "Programming"
+    }
+  ],
+  "count": 1
+}
+```

--- a/docs/Reference/Serve.md
+++ b/docs/Reference/Serve.md
@@ -6,6 +6,9 @@
 
 This command starts a local development server to preview your static site. The server automatically serves the files from the build output directory (`_site` by default, configurable via `output_dir` in `.scraps.toml`) at [http://127.0.0.1:1112](http://127.0.0.1:1112).
 
+Like [[Reference/Build]], `serve` builds the site before starting the local
+server.
+
 ## Examples
 
 ```bash
@@ -13,7 +16,10 @@ This command starts a local development server to preview your static site. The 
 ❯ scraps serve
 
 # Serve from specific directory
-❯ scraps serve --path /path/to/project
+❯ scraps -C /path/to/wiki serve
+
+# Include git-derived committed timestamps in generated pages
+❯ scraps serve --git
 ```
 
 Use this command to check how your site looks and functions before deployment.

--- a/docs/Reference/Tag Link.md
+++ b/docs/Reference/Tag Link.md
@@ -1,5 +1,13 @@
 #[[Wiki-Links]] #[[Markdown]]
 
-If there is no scrap with the specified title, such as #[[Markdown]], it becomes a tag.
+Tags use explicit `#[[tag]]` syntax.
+
+```markdown
+This scrap is about #[[Markdown]] and #[[Writing/Reference]].
+```
+
+Tags and scraps live in separate namespaces. `[[Markdown]]` is a link to a
+scrap named `Markdown`; `#[[Markdown]]` is a tag. If `[[Markdown]]` does not
+resolve to a scrap, `scraps lint` reports a `broken-link` warning.
 
 Tags are displayed on the index page. Each tag links to a page that lists all scraps using that tag.

--- a/docs/Reference/Tag.md
+++ b/docs/Reference/Tag.md
@@ -1,17 +1,25 @@
 #[[CLI]]
 
 ```bash
-❯ scraps tag
+❯ scraps tag list
 ```
 
 This command lists all tags found in your Scraps content, helping you understand the tag distribution across your knowledge base.
+
+Use `scraps tag backlinks <TAG>` to list scraps that reference a specific tag.
 
 ## Examples
 
 ```bash
 # List all tags
-❯ scraps tag
+❯ scraps tag list
+
+# JSON output
+❯ scraps tag list --json
+
+# List scraps tagged with rust
+❯ scraps tag backlinks rust
 
 # List tags from specific directory
-❯ scraps tag --path /path/to/project
+❯ scraps -C /path/to/wiki tag list
 ```

--- a/docs/Reference/Todo.md
+++ b/docs/Reference/Todo.md
@@ -1,0 +1,47 @@
+#[[CLI]] #[[Markdown]]
+
+```bash
+❯ scraps todo
+```
+
+This command aggregates GitHub-flavored Markdown task list items across the
+wiki. Open tasks are shown by default.
+
+## Status Filters
+
+- `open`: `- [ ] task`
+- `done`: `- [x] task`
+- `deferred`: `- [-] task`
+- `all`: all task items
+
+## Examples
+
+```bash
+# Open tasks
+❯ scraps todo
+
+# Completed tasks
+❯ scraps todo --status done
+
+# JSON output for agents and scripts
+❯ scraps todo --status all --json
+```
+
+## JSON Shape
+
+```json
+{
+  "results": [
+    {
+      "scrap": {
+        "title": "Release",
+        "ctx": "Planning"
+      },
+      "status": "open",
+      "text": "write release notes",
+      "line": 3
+    }
+  ],
+  "count": 1
+}
+```

--- a/docs/Tutorial/Getting Started.md
+++ b/docs/Tutorial/Getting Started.md
@@ -1,4 +1,5 @@
-This guide covers using Scraps as a static site generator (SSG).
+This guide gets you from an empty directory to a small Scraps wiki that can be
+built as a static site and queried from the CLI.
 
 ## Setup
 
@@ -6,28 +7,35 @@ This guide covers using Scraps as a static site generator (SSG).
    - Follow the [[Tutorial/Installation]] guide to install Scraps on your system
 
 2. **Initialize Project**
-   - Create a new Scraps project using [[Reference/Init]]:
+   - Create a project directory and initialize it using [[Reference/Init]]:
 
      ```bash
-     ❯ scraps init my-knowledge-base
+     ❯ mkdir my-knowledge-base
      ❯ cd my-knowledge-base
+     ❯ scraps init
      ```
 
 3. **Configure Project**
-   - Follow [[Reference/Configuration]] to set up your `.scraps.toml`
+   - Edit `.scraps.toml`. The directory containing this file is the wiki root.
 
 ## Content Creation
 
 1. **Write Markdown Files**
-   - Create Markdown files in the `/scraps` directory
+   - Create Markdown files next to `.scraps.toml` or in folders under it
    - Use [[Reference/CommonMark]] and [[Reference/GitHub-flavored Markdown]]
 
 2. **Add Internal Links**
    - Connect documents using [[Reference/Normal Link]] syntax:
      - `[[Page Name]]` for simple links
      - `[[Page Name|Custom Text]]` for custom link text
+     - `[[Folder/Page Name]]` for a context-qualified link
 
-3. **Enhance Content**
+3. **Add Tags**
+   - Use [[Reference/Tag Link]] syntax:
+     - `#[[Topic]]` for a tag
+     - `#[[Area/Subtopic]]` for a nested tag
+
+4. **Enhance Content**
    - Add [[Reference/Mermaid]] diagrams for visual representations
    - Use [[Reference/Autolink]] functionality for external links
    - Organize with [[Reference/Context Link|context folders]] when needed
@@ -61,4 +69,6 @@ This guide covers using Scraps as a static site generator (SSG).
 
 ## AI Integration
 
-- **MCP Server**: Enable AI assistant integration using [[How-to/Integrate with AI Assistants]] for intelligent search and content assistance
+- **CLI JSON**: Query scraps with commands like `scraps search "query" --json`,
+  `scraps get "Page Name" --json`, and `scraps todo --json`
+- **MCP Server**: Enable MCP-compatible assistant integration using [[How-to/Integrate with AI Assistants]]

--- a/plugins/mcp-server/.mcp.json
+++ b/plugins/mcp-server/.mcp.json
@@ -4,7 +4,7 @@
       "command": "scraps",
       "args": ["mcp", "serve"],
       "env": {
-        "SCRAPS_PROJECT_PATH": "${SCRAPS_PROJECT_PATH:-.}"
+        "SCRAPS_DIRECTORY": "${SCRAPS_DIRECTORY:-.}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update non-Explanation official docs for v1 CLI/config/link/tag behavior
- add reference pages for JSON-friendly CLI commands: get, search, links, backlinks, todo
- align Claude Code MCP plugin configuration with SCRAPS_DIRECTORY

## Notes
- Excludes docs/Explanation changes intentionally; those remain local for follow-up discussion.

## Verification
- git diff --cached --check before commit
- git diff --check -- docs plugins/mcp-server/.mcp.json