### PR TITLE
ci: resume docs deploy and migrate the docs site to v1 config

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -26,14 +26,11 @@ jobs:
         with:
           fetch-depth: 0 # For scraps git committed date
 
-      - name: Setup mise
+      - name: Setup mise (install scraps)
         uses: jdx/mise-action@v4
         with:
           cache: false
-          install_args: "rust"
-
-      - name: Install scraps from source
-        run: cargo install --path . --locked
+          install_args: "github:boykush/scraps"
 
       - name: Build docs
         run: scraps build --directory docs

--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -1,18 +1,58 @@
 name: Deploy scraps github pages
-# Auto-deploy on push to main is paused while v1 docs are being rewritten.
-# Re-enable the push trigger when v1 docs are ready to publish.
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-scraps-github-pages.yml'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # For scraps git commited date
-      - name: build_and_deploy
-        uses: boykush/scraps-deploy-action@fb0c9aa408b81b7a45f00329c92054a26e0e8333 # v4.4.0
+          fetch-depth: 0 # For scraps git committed date
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pages-branch: gh-pages
+          cache: false
+          install_args: "rust"
+
+      - name: Install scraps from source
+        run: cargo install --path . --locked
+
+      - name: Build docs
+        run: scraps build --directory docs
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.mise-tasks/docs/build
+++ b/.mise-tasks/docs/build
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 #MISE description="Build documentation with scraps"
-scraps build
+scraps build --directory docs

--- a/.mise-tasks/docs/serve
+++ b/.mise-tasks/docs/serve
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 #MISE description="Serve documentation locally with scraps"
-scraps serve
+scraps serve --directory docs

--- a/docs/.scraps.toml
+++ b/docs/.scraps.toml
@@ -1,4 +1,3 @@
-scraps_dir = "docs"
 timezone = "Asia/Tokyo"
 
 [ssg]


### PR DESCRIPTION
## Summary

v1 docs はすでに [#522](https://github.com/boykush/scraps/pull/522) / [#523](https://github.com/boykush/scraps/pull/523) で main に揃ったので、[ff00b80](https://github.com/boykush/scraps/commit/ff00b80) で停止した公式 Doc の自動デプロイを再開しつつ、Doc 自身の scraps 利用を v1 仕様に合わせて移行します。

### Resume deploy
- `.github/workflows/deploy-scraps-github-pages.yml` の `push: main` トリガーを復活。
- 旧 `boykush/scraps-deploy-action`（`scraps_dir`/`public/` 前提・固定 binary）から、v1 の [Deploy to GitHub Pages](https://github.com/boykush/scraps/blob/main/docs/How-to/Deploy%20to%20GitHub%20Pages.md) ガイドと同じ artifact 方式へ移行：
  - `actions/upload-pages-artifact` + `actions/deploy-pages`
  - scraps バイナリは未リリースの v1 を使うため `cargo install --path . --locked` で本リポジトリのソースから入れて `scraps build --directory docs` を実行
  - 成果物は `docs/_site` をアップロード

### Migrate docs to v1
- `.scraps.toml` をリポジトリルートから `docs/.scraps.toml` へ移設し、`scraps_dir = "docs"` を削除（[#509](https://github.com/boykush/scraps/pull/509) の mise パターンに合わせ、`.scraps.toml` のあるディレクトリ＝wiki root に）。
- `output_dir` は v1 デフォルトの `_site/` をそのまま採用（[#508](https://github.com/boykush/scraps/pull/508)、`.gitignore` は対応済み）。
- `mise run docs:build` / `docs:serve` を `scraps {build,serve} --directory docs` に更新（v1 の `-C` リネーム、[#510](https://github.com/boykush/scraps/pull/510)）。

## Test plan

- [x] ローカルで `cargo build --release` → `target/release/scraps build --directory docs -v` を実行。`docs/_site/` に `index.html`, `2.html`, `tags/`, `scraps/`, `search_index.json`, `main.css` が生成され `Done build in 0.19 secs` を確認。
- [x] `target/release/scraps lint --directory docs` が完走（v1 化に伴う既存 docs の `dead-end` / `lonely` / `broken-link` 22 件は本 PR の対象外、別途対応）。
- [ ] PR 上で `Deploy scraps github pages` workflow の `build` ジョブが成功することを確認（マージ後に `push: main` で自動起動）。
- [ ] 公開後 `https://boykush.github.io/scraps/` が v1 docs を表示することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153xupmQp7wReuobu5RLuhg)_