### PR TITLE
chore: pin scraps to v1.0.0-rc.1 and route playwright through mise

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,13 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Setup Rust
+    - name: Setup mise (install scraps)
       uses: jdx/mise-action@v4
       with:
         cache: false
-        install_args: "rust"
-    - name: Pre build
-      run: mise run cargo:build
+        install_args: "github:boykush/scraps"
     - name: Setup Node.js
       uses: jdx/mise-action@v4
       with:

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ experimental = true
 "rust" = { version = "1.93.0", profile = "default" }
 "hk" = "latest"
 "pkl" = "latest"
-"github:boykush/scraps" = "latest"
+"github:boykush/scraps" = "1.0.0-rc.1"
 "npm:markdownlint-cli2" = "latest"
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-deny" = "latest"

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     cwd: '../..',
-    command: 'cargo run serve',
+    command: 'mise run docs:serve',
     url: 'http://127.0.0.1:1112',
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary

- Pin `github:boykush/scraps` in `mise.toml` from `latest` to `1.0.0-rc.1` so the dev environment and CI consume the v1 RC binary. The latest stable (`v0.33.0`) cannot parse the v1 docs config, which has been failing the docs deploy and Playwright workflows.
- Route Playwright's `webServer` through `mise run docs:serve` (which wraps `scraps serve --directory docs`) instead of `cargo run serve`. This means Playwright now exercises the same published binary as the deploy workflow, and the `cargo build` prebuild step in CI is no longer needed.
- Drop the rust setup + `cargo:build` step from `playwright.yml` and replace with a mise scraps install.

## Test plan

- [x] Local: `mise install github:boykush/scraps` → `scraps -V` reports `1.0.0-rc.1`.
- [x] Local: smoke-tested `build` / `get` / `links` / `backlinks` / `search` / `lint` / `todo` / `tag list` / `mcp --help` / `init` / `serve` against `docs/` with the v1.0.0-rc.1 binary.
- [ ] CI: `Playwright Test` succeeds.
- [ ] CI: `Deploy scraps github pages` succeeds (will run on merge to main).