### PR TITLE
fix(ci): disable mise auto-install for playwright webServer subprocess

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,4 +34,10 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       working-directory: ./tests/e2e
+      env:
+        # Skip auto-install of dev-only tools (rust, cargo-deny, llvm-cov, hk,
+        # pkl, markdownlint-cli2) when the webServer subprocess invokes
+        # `mise run docs:serve`. Only scraps is required and is installed
+        # explicitly by the mise-action step above.
+        MISE_AUTO_INSTALL: "false"
       run: npx playwright test


### PR DESCRIPTION
## Summary

After [#532](https://github.com/boykush/scraps/pull/532), Playwright's webServer was switched to `mise run docs:serve`. The post-merge run still failed with:

\`\`\`
[WebServer] Compiling thiserror v2.0.18
Error: Timed out waiting 60000ms from config.webServer.
\`\`\`

Root cause: when the webServer subprocess invokes \`mise run docs:serve\` from the repo root, mise sees \`mise.toml\` listing rust, \`cargo:cargo-llvm-cov\`, \`cargo:cargo-deny\`, hk, pkl, etc., and auto-installs all of them. Compiling the cargo plugins blows past Playwright's 60s webServer timeout.

Fix: set \`MISE_AUTO_INSTALL=false\` on the Playwright step. The required \`scraps\` binary is already installed by the prior \`mise-action\` step, so disabling auto-install is safe.

## Test plan

- [ ] CI: Playwright Test succeeds on this PR / after merge to main.