### PR TITLE
feat(links): return structured outbound refs from scraps links --json

### DIFF
--- a/src/cli/cmd/links.rs
+++ b/src/cli/cmd/links.rs
@@ -7,17 +7,40 @@ use comfy_table::{Cell, Table};
 use serde::{Deserialize, Serialize};
 
 use crate::cli::config::scrap_config::ScrapConfig;
-use crate::cli::json::scrap::ScrapKeyJson;
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
-use crate::usecase::scrap::lookup_links::usecase::LookupScrapLinksUsecase;
+use crate::usecase::scrap::lookup_links::usecase::{LinkRefKind, LookupScrapLinksUsecase};
 use scraps_libs::model::context::Ctx;
 use scraps_libs::model::title::Title;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum LinkRefKindJson {
+    Link,
+    Embed,
+}
+
+impl From<LinkRefKind> for LinkRefKindJson {
+    fn from(k: LinkRefKind) -> Self {
+        match k {
+            LinkRefKind::Link => LinkRefKindJson::Link,
+            LinkRefKind::Embed => LinkRefKindJson::Embed,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LinkRefJson {
+    kind: LinkRefKindJson,
+    title: String,
+    ctx: Option<String>,
+    heading: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct LinksResponse {
-    results: Vec<ScrapKeyJson>,
+    results: Vec<LinkRefJson>,
     count: usize,
 }
 
@@ -43,34 +66,47 @@ pub fn run(
     let usecase = LookupScrapLinksUsecase::new();
     let results = usecase.execute(&scraps, &target_title, &target_ctx)?;
 
-    let scrap_keys: Vec<ScrapKeyJson> = results
+    let refs: Vec<LinkRefJson> = results
         .into_iter()
-        .map(|r| ScrapKeyJson {
+        .map(|r| LinkRefJson {
+            kind: r.kind.into(),
             title: r.title.to_string(),
             ctx: r.ctx.map(|c| c.to_string()),
+            heading: r.heading,
         })
         .collect();
 
     if json {
-        let count = scrap_keys.len();
+        let count = refs.len();
         let response = LinksResponse {
-            results: scrap_keys,
+            results: refs,
             count,
         };
         writeln!(writer, "{}", serde_json::to_string(&response)?)?;
     } else {
-        if scrap_keys.is_empty() {
+        if refs.is_empty() {
             return Ok(());
         }
 
         let mut table = Table::new();
         table.load_preset(NOTHING);
-        table.set_header(vec![Cell::new("Title".bold()), Cell::new("Context".bold())]);
+        table.set_header(vec![
+            Cell::new("Kind".bold()),
+            Cell::new("Title".bold()),
+            Cell::new("Context".bold()),
+            Cell::new("Heading".bold()),
+        ]);
 
-        for key in &scrap_keys {
+        for r in &refs {
+            let kind_str = match r.kind {
+                LinkRefKindJson::Link => "link",
+                LinkRefKindJson::Embed => "embed",
+            };
             table.add_row(vec![
-                Cell::new(&key.title),
-                Cell::new(key.ctx.as_deref().unwrap_or("")),
+                Cell::new(kind_str),
+                Cell::new(&r.title),
+                Cell::new(r.ctx.as_deref().unwrap_or("")),
+                Cell::new(r.heading.as_deref().unwrap_or("")),
             ]);
         }
         writeln!(writer, "{table}")?;
@@ -133,6 +169,11 @@ mod tests {
         let titles: Vec<&str> = response.results.iter().map(|r| r.title.as_str()).collect();
         assert!(titles.contains(&"cargo"));
         assert!(titles.contains(&"clippy"));
+        assert!(response
+            .results
+            .iter()
+            .all(|r| r.kind == LinkRefKindJson::Link));
+        assert!(response.results.iter().all(|r| r.heading.is_none()));
     }
 
     #[rstest]
@@ -228,5 +269,113 @@ mod tests {
             &mut buf,
         );
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn run_json_outputs_heading_qualified_occurrences(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap(
+                "rust.md",
+                b"# Rust\n\nSee [[Target#Install]] and [[Target#Usage]].",
+            )
+            .add_scrap("Target.md", b"# Target");
+
+        let mut buf = Vec::new();
+        run(
+            "rust",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: LinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 2);
+        let headings: Vec<Option<&str>> = response
+            .results
+            .iter()
+            .map(|r| r.heading.as_deref())
+            .collect();
+        assert!(headings.contains(&Some("Install")));
+        assert!(headings.contains(&Some("Usage")));
+    }
+
+    #[rstest]
+    fn run_json_includes_embed_kind(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nEmbed ![[Guide]] and link [[Other]].")
+            .add_scrap("Guide.md", b"# Guide")
+            .add_scrap("Other.md", b"# Other");
+
+        let mut buf = Vec::new();
+        run(
+            "rust",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: LinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 2);
+        let kinds: Vec<LinkRefKindJson> = response.results.iter().map(|r| r.kind).collect();
+        assert!(kinds.contains(&LinkRefKindJson::Embed));
+        assert!(kinds.contains(&LinkRefKindJson::Link));
+    }
+
+    #[rstest]
+    fn run_json_excludes_explicit_tags(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nLink [[Target]] and tag #[[ai]].")
+            .add_scrap("Target.md", b"# Target");
+
+        let mut buf = Vec::new();
+        run(
+            "rust",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: LinksResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 1);
+        assert_eq!(response.results[0].title, "Target");
+    }
+
+    #[rstest]
+    fn run_json_serializes_kind_as_lowercase(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\n[[Target]] and ![[Guide]].")
+            .add_scrap("Target.md", b"# Target")
+            .add_scrap("Guide.md", b"# Guide");
+
+        let mut buf = Vec::new();
+        run(
+            "rust",
+            None,
+            true,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("\"kind\":\"link\""));
+        assert!(output.contains("\"kind\":\"embed\""));
     }
 }

--- a/src/mcp/tools/lookup_scrap_links.rs
+++ b/src/mcp/tools/lookup_scrap_links.rs
@@ -1,6 +1,5 @@
 use crate::input::file::read_scraps;
-use crate::mcp::json::scrap::ScrapKeyJson;
-use crate::usecase::scrap::lookup_links::usecase::LookupScrapLinksUsecase;
+use crate::usecase::scrap::lookup_links::usecase::{LinkRefKind, LookupScrapLinksUsecase};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
 use rmcp::model::{CallToolResult, Content};
@@ -19,9 +18,33 @@ pub struct LookupScrapLinksRequest {
     pub ctx: Option<String>,
 }
 
+#[derive(Debug, Serialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum LinkRefKindJson {
+    Link,
+    Embed,
+}
+
+impl From<LinkRefKind> for LinkRefKindJson {
+    fn from(k: LinkRefKind) -> Self {
+        match k {
+            LinkRefKind::Link => LinkRefKindJson::Link,
+            LinkRefKind::Embed => LinkRefKindJson::Embed,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct LinkRefJson {
+    pub kind: LinkRefKindJson,
+    pub title: String,
+    pub ctx: Option<String>,
+    pub heading: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct LookupScrapLinksResponse {
-    pub results: Vec<ScrapKeyJson>,
+    pub results: Vec<LinkRefJson>,
     pub count: usize,
 }
 
@@ -61,17 +84,19 @@ pub async fn lookup_scrap_links(
         })?;
 
     // Convert results to structured response
-    let scrap_jsons: Vec<ScrapKeyJson> = results
+    let refs: Vec<LinkRefJson> = results
         .into_iter()
-        .map(|result| ScrapKeyJson {
+        .map(|result| LinkRefJson {
+            kind: result.kind.into(),
             title: result.title.to_string(),
             ctx: result.ctx.map(|c| c.to_string()),
+            heading: result.heading,
         })
         .collect();
 
-    let count = scrap_jsons.len();
+    let count = refs.len();
     let response = LookupScrapLinksResponse {
-        results: scrap_jsons,
+        results: refs,
         count,
     };
 

--- a/src/usecase/scrap/lookup_links/usecase.rs
+++ b/src/usecase/scrap/lookup_links/usecase.rs
@@ -1,16 +1,27 @@
 use crate::error::ScrapsResult;
+use scraps_libs::markdown::query::{wiki_refs, WikiRef};
 use scraps_libs::model::context::Ctx;
 use scraps_libs::model::key::ScrapKey;
 use scraps_libs::model::scrap::Scrap;
 use scraps_libs::model::title::Title;
 use std::collections::HashMap;
 
-/// Result for scrap links lookup operation
+/// Kind of an outbound reference occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkRefKind {
+    /// Plain wikilink `[[...]]`.
+    Link,
+    /// Inline embed `![[...]]`.
+    Embed,
+}
+
+/// One outbound reference occurrence found in a scrap.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LookupScrapLinksResult {
+    pub kind: LinkRefKind,
     pub title: Title,
     pub ctx: Option<Ctx>,
-    pub md_text: String,
+    pub heading: Option<String>,
 }
 
 pub struct LookupScrapLinksUsecase;
@@ -26,14 +37,12 @@ impl LookupScrapLinksUsecase {
         title: &Title,
         ctx: &Option<Ctx>,
     ) -> ScrapsResult<Vec<LookupScrapLinksResult>> {
-        // Create scrap key for the target scrap
         let target_key = if let Some(ctx) = ctx {
             ScrapKey::with_ctx(title, ctx)
         } else {
             ScrapKey::from(title.clone())
         };
 
-        // Find the target scrap
         let target_scrap = scraps
             .iter()
             .find(|scrap| scrap.self_key() == target_key)
@@ -41,33 +50,51 @@ impl LookupScrapLinksUsecase {
                 anyhow::anyhow!("Scrap not found: title='{}', ctx='{:?}'", title, ctx)
             })?;
 
-        // Create scrap key-to-scrap mapping for efficient lookup
         let scrap_map: HashMap<ScrapKey, &Scrap> = scraps
             .iter()
             .map(|scrap| (scrap.self_key(), scrap))
             .collect();
 
-        // Convert each link to LookupScrapLinksResult
-        let results: Vec<LookupScrapLinksResult> = target_scrap
-            .links()
-            .iter()
-            .filter_map(|link_key| {
-                // Find the linked scrap
-                scrap_map.get(link_key).map(|linked_scrap| {
-                    let scrap_key = &linked_scrap.self_key();
-                    let title: Title = scrap_key.into();
-                    let ctx: Option<Ctx> = scrap_key.into();
-
-                    LookupScrapLinksResult {
-                        title,
-                        ctx,
-                        md_text: linked_scrap.md_text().to_string(),
-                    }
-                })
+        let results: Vec<LookupScrapLinksResult> = wiki_refs(target_scrap.md_text())
+            .into_iter()
+            .filter_map(|wref| match wref {
+                WikiRef::Link(r) => {
+                    let key = ScrapKey::from_path_str(&join_path(&r.ctx_path, &r.title));
+                    scrap_map.get(&key).map(|linked| {
+                        let linked_key = linked.self_key();
+                        LookupScrapLinksResult {
+                            kind: LinkRefKind::Link,
+                            title: (&linked_key).into(),
+                            ctx: (&linked_key).into(),
+                            heading: r.heading,
+                        }
+                    })
+                }
+                WikiRef::Embed(r) => {
+                    let key = ScrapKey::from_path_str(&join_path(&r.ctx_path, &r.title));
+                    scrap_map.get(&key).map(|linked| {
+                        let linked_key = linked.self_key();
+                        LookupScrapLinksResult {
+                            kind: LinkRefKind::Embed,
+                            title: (&linked_key).into(),
+                            ctx: (&linked_key).into(),
+                            heading: r.heading,
+                        }
+                    })
+                }
+                WikiRef::Tag(_) => None,
             })
             .collect();
 
         Ok(results)
+    }
+}
+
+fn join_path(ctx_path: &[String], title: &str) -> String {
+    if ctx_path.is_empty() {
+        title.to_string()
+    } else {
+        format!("{}/{}", ctx_path.join("/"), title)
     }
 }
 
@@ -94,11 +121,10 @@ mod tests {
             .expect("Should succeed");
 
         assert_eq!(results.len(), 2);
-
-        // Check that we got the expected linked scraps
-        let titles: Vec<String> = results.iter().map(|r| r.title.to_string()).collect();
-        assert!(titles.contains(&"scrap2".to_string()));
-        assert!(titles.contains(&"scrap3".to_string()));
+        assert_eq!(results[0].kind, LinkRefKind::Link);
+        assert_eq!(results[0].title.to_string(), "scrap2");
+        assert_eq!(results[1].kind, LinkRefKind::Link);
+        assert_eq!(results[1].title.to_string(), "scrap3");
     }
 
     #[test]
@@ -149,5 +175,96 @@ mod tests {
             .expect("Should succeed");
 
         assert_eq!(results.len(), 0);
+    }
+
+    // Heading-qualified references for the same target are preserved as
+    // separate occurrences so callers can distinguish them.
+    #[test]
+    fn test_lookup_scrap_links_preserves_heading_occurrences() {
+        let scraps = vec![
+            Scrap::new(
+                "scrap1",
+                &None,
+                "# Scrap 1\n\nSee [[Target#Install]] and [[Target#Usage]].",
+            ),
+            Scrap::new("Target", &None, "# Target"),
+        ];
+
+        let usecase = LookupScrapLinksUsecase::new();
+        let results = usecase
+            .execute(&scraps, &Title::from("scrap1"), &None)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].kind, LinkRefKind::Link);
+        assert_eq!(results[0].title.to_string(), "Target");
+        assert_eq!(results[0].heading.as_deref(), Some("Install"));
+        assert_eq!(results[1].heading.as_deref(), Some("Usage"));
+    }
+
+    #[test]
+    fn test_lookup_scrap_links_includes_embeds() {
+        let scraps = vec![
+            Scrap::new(
+                "scrap1",
+                &None,
+                "# Scrap 1\n\nEmbed ![[Target#Install]] and link [[Other]].",
+            ),
+            Scrap::new("Target", &None, "# Target"),
+            Scrap::new("Other", &None, "# Other"),
+        ];
+
+        let usecase = LookupScrapLinksUsecase::new();
+        let results = usecase
+            .execute(&scraps, &Title::from("scrap1"), &None)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].kind, LinkRefKind::Embed);
+        assert_eq!(results[0].title.to_string(), "Target");
+        assert_eq!(results[0].heading.as_deref(), Some("Install"));
+        assert_eq!(results[1].kind, LinkRefKind::Link);
+        assert_eq!(results[1].title.to_string(), "Other");
+        assert_eq!(results[1].heading, None);
+    }
+
+    #[test]
+    fn test_lookup_scrap_links_excludes_tags() {
+        let scraps = vec![
+            Scrap::new(
+                "scrap1",
+                &None,
+                "# Scrap 1\n\nLink [[Target]] and tag #[[ai]].",
+            ),
+            Scrap::new("Target", &None, "# Target"),
+        ];
+
+        let usecase = LookupScrapLinksUsecase::new();
+        let results = usecase
+            .execute(&scraps, &Title::from("scrap1"), &None)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.to_string(), "Target");
+    }
+
+    #[test]
+    fn test_lookup_scrap_links_resolves_ctx_target() {
+        let scraps = vec![
+            Scrap::new("scrap1", &None, "# Scrap 1\n\nSee [[Book/Target]]."),
+            Scrap::new("Target", &Some("Book".into()), "# Target"),
+        ];
+
+        let usecase = LookupScrapLinksUsecase::new();
+        let results = usecase
+            .execute(&scraps, &Title::from("scrap1"), &None)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.to_string(), "Target");
+        assert_eq!(
+            results[0].ctx.as_ref().map(|c| c.to_string()).as_deref(),
+            Some("Book")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #540.

`scraps links --json` now returns outbound reference occurrences instead of unique linked scrap keys, so LLM-oriented consumers can navigate to heading-scoped targets and distinguish embeds from plain links.

### New JSON shape

```json
{
  "results": [
    { "kind": "link",  "title": "Target", "ctx": null,   "heading": "Install" },
    { "kind": "embed", "title": "Guide",  "ctx": "Docs", "heading": null }
  ],
  "count": 2
}
```

### Field semantics

- `kind`: `"link"` for plain `[[...]]`, `"embed"` for `![[...]]`
- `title`: target scrap title
- `ctx`: target scrap context, or `null`
- `heading`: target heading selector, or `null`

### Behavior

- Includes plain wikilinks (`[[Target]]`, `[[Ctx/Target]]`, `[[Target#Heading]]`) and embeds (`![[Target]]`, `![[Ctx/Target#Heading]]`)
- Preserves heading-qualified occurrences as separate entries (e.g. `[[Target#Install]]` and `[[Target#Usage]]`)
- Excludes explicit tags (`#[[tag]]`)
- Filters to references whose target scrap exists (unchanged)
- v1 non-goals: `alias` and `line` are not exposed in `scraps links`
- `scraps backlinks` is unchanged

### Implementation

- `LookupScrapLinksUsecase` now iterates `wiki_refs(target.md_text())` and yields `LookupScrapLinksResult { kind, title, ctx, heading }` for Link/Embed variants only
- New `LinkRefJson` and `LinkRefKindJson` types in CLI and MCP layers; `kind` serializes as lowercase
- CLI table output gained `Kind` and `Heading` columns
- MCP `lookup_scrap_links` tool aligned with the same shape

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features` (no new warnings)
- [x] `cargo fmt --all -- --check`
- [x] Added unit tests for: heading-qualified occurrences, embed kind, tag exclusion, ctx-resolved target, lowercase `kind` serialization


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bojo9XgwpLkqNTsUK9FKJH)_