### PR TITLE
feat: redesign `scraps get --json` as field projection (#539)

### DIFF
--- a/modules/libs/src/markdown/query.rs
+++ b/modules/libs/src/markdown/query.rs
@@ -13,7 +13,7 @@ pub use code_blocks::{code_blocks, CodeBlock};
 pub use embeds::{embeds, EmbedRef};
 pub use headings::{headings, Heading};
 pub use images::images;
-pub use section::section;
+pub use section::{heading_slug, section};
 pub use tags::{tags, TagRef};
 pub use task_items::{task_items, TaskItem, TaskStatus};
 pub use wiki_ref::{wiki_refs, WikiRef};

--- a/modules/libs/src/markdown/query/section.rs
+++ b/modules/libs/src/markdown/query/section.rs
@@ -2,6 +2,14 @@ use comrak::{nodes::NodeValue, parse_document, Arena};
 
 use super::common::{collect_text, line_byte_offset, line_starts, options};
 
+/// Slugify a heading text using GitHub Flavored Markdown rules.
+///
+/// Matches the slug emitted for anchors in rendered HTML, so it can be used
+/// to look up sections by the visible heading text.
+pub fn heading_slug(s: &str) -> String {
+    gfm_slug(s)
+}
+
 fn gfm_slug(s: &str) -> String {
     let mut out = String::new();
     for c in s.chars() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,8 +80,21 @@ pub enum SubCommands {
         #[arg(long, help = "Disambiguate title across contexts")]
         ctx: Option<String>,
 
-        #[arg(long, help = "Output as JSON")]
-        json: bool,
+        #[arg(
+            long,
+            value_name = "HEADING",
+            help = "Restrict the output to the section under the given heading text"
+        )]
+        heading: Option<String>,
+
+        #[arg(
+            long,
+            value_name = "FIELDS",
+            num_args = 0..=1,
+            default_missing_value = "",
+            help = "Output as JSON. Optionally accepts a comma-separated field projection (title,ctx,body,headings,code_blocks)."
+        )]
+        json: Option<String>,
     },
 
     #[command(about = "Write .scraps.toml to the project directory")]

--- a/src/cli/cmd/get.rs
+++ b/src/cli/cmd/get.rs
@@ -2,19 +2,72 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::cli::config::scrap_config::ScrapConfig;
-use crate::cli::json::scrap::{CodeBlockJson, HeadingJson, ScrapJson};
+use crate::cli::json::scrap::{CodeBlockJson, HeadingJson};
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
 use crate::usecase::scrap::get::usecase::GetScrapUsecase;
-use scraps_libs::markdown::query::{code_blocks, headings};
+use scraps_libs::markdown::query::{code_blocks, heading_slug, headings, section};
 use scraps_libs::model::context::Ctx;
 use scraps_libs::model::title::Title;
+use serde_json::{Map, Value};
+
+const FIELD_TITLE: &str = "title";
+const FIELD_CTX: &str = "ctx";
+const FIELD_BODY: &str = "body";
+const FIELD_HEADINGS: &str = "headings";
+const FIELD_CODE_BLOCKS: &str = "code_blocks";
+
+const DEFAULT_FIELDS: &[&str] = &[FIELD_TITLE, FIELD_CTX, FIELD_BODY];
+const ALLOWED_FIELDS: &[&str] = &[
+    FIELD_TITLE,
+    FIELD_CTX,
+    FIELD_BODY,
+    FIELD_HEADINGS,
+    FIELD_CODE_BLOCKS,
+];
+
+fn parse_fields(spec: &str) -> ScrapsResult<Vec<&'static str>> {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        return Ok(DEFAULT_FIELDS.to_vec());
+    }
+    let mut out = Vec::new();
+    for raw in trimmed.split(',') {
+        let name = raw.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let allowed = ALLOWED_FIELDS.iter().find(|f| **f == name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown --json field '{}'. Allowed fields: {}",
+                name,
+                ALLOWED_FIELDS.join(", ")
+            )
+        })?;
+        if !out.contains(allowed) {
+            out.push(*allowed);
+        }
+    }
+    if out.is_empty() {
+        return Ok(DEFAULT_FIELDS.to_vec());
+    }
+    Ok(out)
+}
+
+fn scoped_body<'a>(md_text: &'a str, heading: Option<&str>) -> ScrapsResult<&'a str> {
+    match heading {
+        None => Ok(md_text),
+        Some(h) => section(md_text, &heading_slug(h))
+            .ok_or_else(|| anyhow::anyhow!("Heading not found: '{}'", h)),
+    }
+}
 
 pub fn run(
     title: &str,
     ctx: Option<&str>,
-    json: bool,
+    heading: Option<&str>,
+    json: Option<&str>,
     project_path: Option<&Path>,
     writer: &mut impl Write,
 ) -> ScrapsResult<()> {
@@ -33,25 +86,48 @@ pub fn run(
     let usecase = GetScrapUsecase::new();
     let result = usecase.execute(&scraps, &target_title, &target_ctx)?;
 
-    if json {
-        let headings_json: Vec<HeadingJson> = headings(&result.md_text)
-            .into_iter()
-            .map(Into::into)
-            .collect();
-        let code_blocks_json: Vec<CodeBlockJson> = code_blocks(&result.md_text)
-            .into_iter()
-            .map(Into::into)
-            .collect();
-        let scrap_json = ScrapJson {
-            title: result.title.to_string(),
-            ctx: result.ctx.map(|c| c.to_string()),
-            md_text: result.md_text,
-            headings: headings_json,
-            code_blocks: code_blocks_json,
-        };
-        writeln!(writer, "{}", serde_json::to_string(&scrap_json)?)?;
-    } else {
-        write!(writer, "{}", result.md_text)?;
+    let body_text = scoped_body(&result.md_text, heading)?;
+
+    match json {
+        None => {
+            write!(writer, "{}", body_text)?;
+        }
+        Some(spec) => {
+            let fields = parse_fields(spec)?;
+            let mut out = Map::new();
+            for field in fields {
+                match field {
+                    FIELD_TITLE => {
+                        out.insert(field.to_string(), Value::String(result.title.to_string()));
+                    }
+                    FIELD_CTX => {
+                        out.insert(
+                            field.to_string(),
+                            result
+                                .ctx
+                                .as_ref()
+                                .map(|c| Value::String(c.to_string()))
+                                .unwrap_or(Value::Null),
+                        );
+                    }
+                    FIELD_BODY => {
+                        out.insert(field.to_string(), Value::String(body_text.to_string()));
+                    }
+                    FIELD_HEADINGS => {
+                        let v: Vec<HeadingJson> =
+                            headings(body_text).into_iter().map(Into::into).collect();
+                        out.insert(field.to_string(), serde_json::to_value(v)?);
+                    }
+                    FIELD_CODE_BLOCKS => {
+                        let v: Vec<CodeBlockJson> =
+                            code_blocks(body_text).into_iter().map(Into::into).collect();
+                        out.insert(field.to_string(), serde_json::to_value(v)?);
+                    }
+                    _ => unreachable!("validated by parse_fields"),
+                }
+            }
+            writeln!(writer, "{}", serde_json::to_string(&Value::Object(out))?)?;
+        }
     }
     Ok(())
 }
@@ -61,6 +137,26 @@ mod tests {
     use super::*;
     use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
     use rstest::rstest;
+    use serde_json::Value;
+
+    fn run_get(
+        title: &str,
+        ctx: Option<&str>,
+        heading: Option<&str>,
+        json: Option<&str>,
+        project: &TempScrapProject,
+    ) -> ScrapsResult<String> {
+        let mut buf = Vec::new();
+        run(
+            title,
+            ctx,
+            heading,
+            json,
+            Some(project.project_root.as_path()),
+            &mut buf,
+        )?;
+        Ok(String::from_utf8(buf).unwrap())
+    }
 
     #[rstest]
     fn run_text_outputs_md_body(#[from(temp_scrap_project)] project: TempScrapProject) {
@@ -68,152 +164,149 @@ mod tests {
             .add_config(b"")
             .add_scrap("rust.md", b"# Rust\n\nBody");
 
-        let mut buf = Vec::new();
-        run(
-            "rust",
-            None,
-            false,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        )
-        .unwrap();
-
-        let output = String::from_utf8(buf).unwrap();
+        let output = run_get("rust", None, None, None, &project).unwrap();
         assert!(output.contains("# Rust"));
         assert!(output.contains("Body"));
     }
 
     #[rstest]
-    fn run_json_outputs_scrap(#[from(temp_scrap_project)] project: TempScrapProject) {
+    fn run_default_json_returns_title_ctx_body(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
         project
             .add_config(b"")
             .add_scrap("Backend/Auth.md", b"# Auth\n\nBody");
 
-        let mut buf = Vec::new();
-        run(
-            "Auth",
-            Some("Backend"),
-            true,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        )
-        .unwrap();
+        let output = run_get("Auth", Some("Backend"), None, Some(""), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+        let obj = v.as_object().unwrap();
 
-        let output = String::from_utf8(buf).unwrap();
-        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
-        assert_eq!(scrap.title, "Auth");
-        assert_eq!(scrap.ctx.as_deref(), Some("Backend"));
-        assert!(scrap.md_text.contains("# Auth"));
+        assert_eq!(obj.len(), 3);
+        assert_eq!(obj["title"], "Auth");
+        assert_eq!(obj["ctx"], "Backend");
+        assert!(obj["body"].as_str().unwrap().contains("# Auth"));
+        assert!(!obj.contains_key("headings"));
+        assert!(!obj.contains_key("code_blocks"));
     }
 
     #[rstest]
-    fn run_json_includes_headings_with_structure(
-        #[from(temp_scrap_project)] project: TempScrapProject,
-    ) {
-        project.add_config(b"").add_scrap(
-            "Tokio.md",
-            b"# Tokio\n\nintro\n\n## Scheduling\n\nbody\n\n### Work-stealing\n\ndetails\n",
-        );
-
-        let mut buf = Vec::new();
-        run(
-            "Tokio",
-            None,
-            true,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        )
-        .unwrap();
-
-        let output = String::from_utf8(buf).unwrap();
-        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
-        assert_eq!(scrap.headings.len(), 3);
-
-        assert_eq!(scrap.headings[0].level, 1);
-        assert_eq!(scrap.headings[0].text, "Tokio");
-        assert_eq!(scrap.headings[0].line, 1);
-        assert!(scrap.headings[0].parent.is_none());
-
-        assert_eq!(scrap.headings[1].level, 2);
-        assert_eq!(scrap.headings[1].text, "Scheduling");
-        assert_eq!(scrap.headings[1].parent.as_deref(), Some("Tokio"));
-
-        assert_eq!(scrap.headings[2].level, 3);
-        assert_eq!(scrap.headings[2].text, "Work-stealing");
-        assert_eq!(scrap.headings[2].parent.as_deref(), Some("Scheduling"));
-    }
-
-    #[rstest]
-    fn run_json_includes_fenced_code_blocks(#[from(temp_scrap_project)] project: TempScrapProject) {
-        project.add_config(b"").add_scrap(
-            "Snippets.md",
-            b"# Snippets\n\n```rust\nlet x = 1;\n```\n\ntext\n\n```sh\ncargo build\n```\n",
-        );
-
-        let mut buf = Vec::new();
-        run(
-            "Snippets",
-            None,
-            true,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        )
-        .unwrap();
-
-        let output = String::from_utf8(buf).unwrap();
-        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
-        assert_eq!(scrap.code_blocks.len(), 2);
-        assert_eq!(scrap.code_blocks[0].lang.as_deref(), Some("rust"));
-        assert_eq!(scrap.code_blocks[0].content, "let x = 1;\n");
-        assert_eq!(scrap.code_blocks[1].lang.as_deref(), Some("sh"));
-        assert_eq!(scrap.code_blocks[1].content, "cargo build\n");
-    }
-
-    #[rstest]
-    fn run_json_emits_empty_arrays_for_plain_scrap(
+    fn run_default_json_emits_null_ctx_when_absent(
         #[from(temp_scrap_project)] project: TempScrapProject,
     ) {
         project
             .add_config(b"")
-            .add_scrap("plain.md", b"just a paragraph\n");
+            .add_scrap("plain.md", b"# Plain\n\nbody\n");
 
-        let mut buf = Vec::new();
-        run(
-            "plain",
-            None,
-            true,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        )
-        .unwrap();
-
-        let output = String::from_utf8(buf).unwrap();
-        let scrap: ScrapJson = serde_json::from_str(output.trim()).unwrap();
-        assert!(scrap.headings.is_empty());
-        assert!(scrap.code_blocks.is_empty());
+        let output = run_get("plain", None, None, Some(""), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+        assert!(v["ctx"].is_null());
     }
 
     #[rstest]
-    fn run_text_output_omits_structural_data(
+    fn run_json_with_field_projection_includes_only_requested(
         #[from(temp_scrap_project)] project: TempScrapProject,
     ) {
         project
             .add_config(b"")
             .add_scrap("doc.md", b"# Doc\n\n```rust\nlet x = 1;\n```\n");
 
-        let mut buf = Vec::new();
-        run(
-            "doc",
+        let output = run_get("doc", None, None, Some("code_blocks"), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+        let obj = v.as_object().unwrap();
+
+        assert_eq!(obj.len(), 1);
+        let blocks = obj["code_blocks"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["lang"], "rust");
+    }
+
+    #[rstest]
+    fn run_json_field_projection_supports_headings(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("Tokio.md", b"# Tokio\n\nintro\n\n## Scheduling\n\nbody\n");
+
+        let output = run_get("Tokio", None, None, Some("title,headings"), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+        let obj = v.as_object().unwrap();
+
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj["title"], "Tokio");
+        let h = obj["headings"].as_array().unwrap();
+        assert_eq!(h.len(), 2);
+    }
+
+    #[rstest]
+    fn run_json_unknown_field_errors(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("rust.md", b"# Rust\n\nBody");
+
+        let result = run_get("rust", None, None, Some("links"), &project);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Unknown --json field"));
+        assert!(msg.contains("links"));
+    }
+
+    #[rstest]
+    fn run_text_with_heading_returns_section_only(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_config(b"").add_scrap(
+            "Guide.md",
+            b"# Guide\n\nintro\n\n## Install\n\ninstall body\n\n## Usage\n\nusage body\n",
+        );
+
+        let output = run_get("Guide", None, Some("Install"), None, &project).unwrap();
+        assert!(output.contains("install body"));
+        assert!(!output.contains("usage body"));
+        assert!(!output.contains("intro"));
+    }
+
+    #[rstest]
+    fn run_json_with_heading_scopes_body_and_structure(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_config(b"").add_scrap(
+            "Guide.md",
+            b"# Guide\n\nintro\n\n## Install\n\ninstall body\n\n```sh\nrun me\n```\n\n## Usage\n\nusage body\n",
+        );
+
+        let output = run_get(
+            "Guide",
             None,
-            false,
-            Some(project.project_root.as_path()),
-            &mut buf,
+            Some("Install"),
+            Some("body,code_blocks"),
+            &project,
         )
         .unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+        let obj = v.as_object().unwrap();
 
-        let output = String::from_utf8(buf).unwrap();
-        assert!(!output.contains("\"headings\""));
-        assert!(!output.contains("\"code_blocks\""));
+        let body = obj["body"].as_str().unwrap();
+        assert!(body.contains("install body"));
+        assert!(!body.contains("usage body"));
+
+        let blocks = obj["code_blocks"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["lang"], "sh");
+    }
+
+    #[rstest]
+    fn run_errors_when_heading_not_found(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("Guide.md", b"# Guide\n\n## Install\n\nbody\n");
+
+        let result = run_get("Guide", None, Some("Missing"), None, &project);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Heading not found"));
     }
 
     #[rstest]
@@ -224,14 +317,7 @@ mod tests {
             .add_config(b"")
             .add_scrap("Backend/Auth.md", b"# Auth\n\nFrom Backend");
 
-        let mut buf = Vec::new();
-        let result = run(
-            "Auth",
-            None,
-            false,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        );
+        let result = run_get("Auth", None, None, None, &project);
         assert!(result.is_err());
     }
 
@@ -239,27 +325,13 @@ mod tests {
     fn run_errors_on_missing_title(#[from(temp_scrap_project)] project: TempScrapProject) {
         project.add_config(b"").add_scrap("rust.md", b"# Rust");
 
-        let mut buf = Vec::new();
-        let result = run(
-            "nonexistent",
-            None,
-            false,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        );
+        let result = run_get("nonexistent", None, None, None, &project);
         assert!(result.is_err());
     }
 
     #[rstest]
     fn run_fails_without_config(#[from(temp_scrap_project)] project: TempScrapProject) {
-        let mut buf = Vec::new();
-        let result = run(
-            "rust",
-            None,
-            false,
-            Some(project.project_root.as_path()),
-            &mut buf,
-        );
+        let result = run_get("rust", None, None, None, &project);
         assert!(result.is_err());
     }
 }

--- a/src/cli/json/scrap.rs
+++ b/src/cli/json/scrap.rs
@@ -8,15 +8,6 @@ pub struct ScrapKeyJson {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ScrapJson {
-    pub title: String,
-    pub ctx: Option<String>,
-    pub md_text: String,
-    pub headings: Vec<HeadingJson>,
-    pub code_blocks: Vec<CodeBlockJson>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct HeadingJson {
     pub level: u8,
     pub text: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,16 @@ fn main() -> error::ScrapsResult<()> {
     match command {
         cli::SubCommands::Init => cli::cmd::init::run(directory),
         cli::SubCommands::Build { verbose, git } => cli::cmd::build::run(verbose, git, directory),
-        cli::SubCommands::Get { title, ctx, json } => cli::cmd::get::run(
+        cli::SubCommands::Get {
+            title,
+            ctx,
+            heading,
+            json,
+        } => cli::cmd::get::run(
             &title,
             ctx.as_deref(),
-            json,
+            heading.as_deref(),
+            json.as_deref(),
             directory,
             &mut std::io::stdout(),
         ),

--- a/src/mcp/json/scrap.rs
+++ b/src/mcp/json/scrap.rs
@@ -2,15 +2,6 @@ use scraps_libs::markdown::query::{CodeBlock, Heading};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
-pub struct ScrapJson {
-    pub title: String,
-    pub ctx: Option<String>,
-    pub md_text: String,
-    pub headings: Vec<HeadingJson>,
-    pub code_blocks: Vec<CodeBlockJson>,
-}
-
-#[derive(Debug, Serialize)]
 pub struct ScrapKeyJson {
     pub title: String,
     pub ctx: Option<String>,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -32,7 +32,7 @@ impl ScrapsServer {
 #[tool_router]
 impl ScrapsServer {
     #[tool(
-        description = "Get a single scrap by title and optional context. Returns the scrap's full content including title, context, and markdown body."
+        description = "Get a single scrap by title and optional context. Optionally restrict to a heading section via 'heading'. Optionally project specific fields via 'fields' (allowed: title, ctx, body, headings, code_blocks); defaults to ['title', 'ctx', 'body']."
     )]
     async fn get_scrap(
         &self,

--- a/src/mcp/tools/get_scrap.rs
+++ b/src/mcp/tools/get_scrap.rs
@@ -1,5 +1,5 @@
 use crate::input::file::read_scraps;
-use crate::mcp::json::scrap::{CodeBlockJson, HeadingJson, ScrapJson};
+use crate::mcp::json::scrap::{CodeBlockJson, HeadingJson};
 use crate::usecase::scrap::get::usecase::GetScrapUsecase;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
@@ -7,9 +7,25 @@ use rmcp::model::{CallToolResult, Content};
 use rmcp::schemars::JsonSchema;
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer};
-use scraps_libs::markdown::query::{code_blocks, headings};
+use scraps_libs::markdown::query::{code_blocks, heading_slug, headings, section};
 use serde::Deserialize;
+use serde_json::{Map, Value};
 use std::path::Path;
+
+const FIELD_TITLE: &str = "title";
+const FIELD_CTX: &str = "ctx";
+const FIELD_BODY: &str = "body";
+const FIELD_HEADINGS: &str = "headings";
+const FIELD_CODE_BLOCKS: &str = "code_blocks";
+
+const DEFAULT_FIELDS: &[&str] = &[FIELD_TITLE, FIELD_CTX, FIELD_BODY];
+const ALLOWED_FIELDS: &[&str] = &[
+    FIELD_TITLE,
+    FIELD_CTX,
+    FIELD_BODY,
+    FIELD_HEADINGS,
+    FIELD_CODE_BLOCKS,
+];
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
@@ -18,6 +34,45 @@ pub struct GetScrapRequest {
     pub title: String,
     /// Optional context if the scrap has one
     pub ctx: Option<String>,
+    /// Optional heading text. When set, body/headings/code_blocks are scoped to that section.
+    pub heading: Option<String>,
+    /// Optional projection of fields to include. Defaults to ["title", "ctx", "body"].
+    /// Allowed: "title", "ctx", "body", "headings", "code_blocks".
+    pub fields: Option<Vec<String>>,
+}
+
+fn resolve_fields(spec: Option<&[String]>) -> Result<Vec<&'static str>, ErrorData> {
+    let Some(spec) = spec else {
+        return Ok(DEFAULT_FIELDS.to_vec());
+    };
+    if spec.is_empty() {
+        return Ok(DEFAULT_FIELDS.to_vec());
+    }
+    let mut out: Vec<&'static str> = Vec::new();
+    for raw in spec {
+        let name = raw.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let allowed = ALLOWED_FIELDS.iter().find(|f| **f == name).ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode(-32602),
+                format!(
+                    "Unknown field '{}'. Allowed fields: {}",
+                    name,
+                    ALLOWED_FIELDS.join(", ")
+                ),
+                None,
+            )
+        })?;
+        if !out.contains(allowed) {
+            out.push(*allowed);
+        }
+    }
+    if out.is_empty() {
+        return Ok(DEFAULT_FIELDS.to_vec());
+    }
+    Ok(out)
 }
 
 pub async fn get_scrap(
@@ -26,7 +81,6 @@ pub async fn get_scrap(
     _context: RequestContext<RoleServer>,
     Parameters(request): Parameters<GetScrapRequest>,
 ) -> Result<CallToolResult, ErrorData> {
-    // Load scraps from directory
     let scraps = read_scraps::to_all_scraps(scraps_dir, exclude_dirs).map_err(|e| {
         ErrorData::new(
             ErrorCode(-32003),
@@ -47,25 +101,67 @@ pub async fn get_scrap(
         .execute(&scraps, &title, &ctx)
         .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("Get scrap failed: {e}"), None))?;
 
-    let headings_json: Vec<HeadingJson> = headings(&result.md_text)
-        .into_iter()
-        .map(Into::into)
-        .collect();
-    let code_blocks_json: Vec<CodeBlockJson> = code_blocks(&result.md_text)
-        .into_iter()
-        .map(Into::into)
-        .collect();
-
-    let scrap_json = ScrapJson {
-        title: result.title.to_string(),
-        ctx: result.ctx.map(|c| c.to_string()),
-        md_text: result.md_text,
-        headings: headings_json,
-        code_blocks: code_blocks_json,
+    let body_text: &str = match request.heading.as_deref() {
+        None => &result.md_text,
+        Some(h) => section(&result.md_text, &heading_slug(h)).ok_or_else(|| {
+            ErrorData::new(ErrorCode(-32004), format!("Heading not found: '{h}'"), None)
+        })?,
     };
 
+    let fields = resolve_fields(request.fields.as_deref())?;
+
+    let mut out = Map::new();
+    for field in fields {
+        match field {
+            FIELD_TITLE => {
+                out.insert(field.to_string(), Value::String(result.title.to_string()));
+            }
+            FIELD_CTX => {
+                out.insert(
+                    field.to_string(),
+                    result
+                        .ctx
+                        .as_ref()
+                        .map(|c| Value::String(c.to_string()))
+                        .unwrap_or(Value::Null),
+                );
+            }
+            FIELD_BODY => {
+                out.insert(field.to_string(), Value::String(body_text.to_string()));
+            }
+            FIELD_HEADINGS => {
+                let v: Vec<HeadingJson> = headings(body_text).into_iter().map(Into::into).collect();
+                out.insert(
+                    field.to_string(),
+                    serde_json::to_value(v).map_err(|e| {
+                        ErrorData::new(
+                            ErrorCode(-32005),
+                            format!("JSON serialization failed: {e}"),
+                            None,
+                        )
+                    })?,
+                );
+            }
+            FIELD_CODE_BLOCKS => {
+                let v: Vec<CodeBlockJson> =
+                    code_blocks(body_text).into_iter().map(Into::into).collect();
+                out.insert(
+                    field.to_string(),
+                    serde_json::to_value(v).map_err(|e| {
+                        ErrorData::new(
+                            ErrorCode(-32005),
+                            format!("JSON serialization failed: {e}"),
+                            None,
+                        )
+                    })?,
+                );
+            }
+            _ => unreachable!("validated by resolve_fields"),
+        }
+    }
+
     Ok(CallToolResult::success(vec![Content::text(
-        serde_json::to_string(&scrap_json).map_err(|e| {
+        serde_json::to_string(&Value::Object(out)).map_err(|e| {
             ErrorData::new(
                 ErrorCode(-32005),
                 format!("JSON serialization failed: {e}"),


### PR DESCRIPTION
## Summary

Reshape `scraps get` for v1 so it can serve as the LLM-oriented read operation. Adds field projection on `--json`, an explicit `--heading` selector for scoped reads, and renames the JSON `md_text` field to `body`. Mirrors the same surface in the MCP `get_scrap` tool.

Closes #539.

## Changes

### CLI

- `--json` is now `Option<String>` accepting a comma-separated field list:
  - `scraps get "Title" --json` → default fields `{title, ctx, body}`
  - `scraps get "Title" --json title,ctx,body`
  - `scraps get "Title" --json code_blocks`
  - `scraps get "Title" --ctx "Book" --heading "Install" --json body,code_blocks`
- Allowed fields: `title`, `ctx`, `body`, `headings`, `code_blocks`. Unknown fields error out with the allowed list.
- New `--heading <text>` flag scopes `body`/`headings`/`code_blocks` to the matching section. It also affects plain-text output (no `--json`), in which case only the section text is printed.
- Default JSON output emits `ctx: null` when the scrap has no context (matching the issue's example shape).

### Library (`scraps_libs`)

- Expose `heading_slug` from `markdown::query` so the CLI/MCP can look up sections by the visible heading text using the same GFM slug rules as `section`.

### MCP (`get_scrap`)

- New optional fields on the request:
  - `heading: Option<String>`
  - `fields: Option<Vec<String>>` (defaults to `["title", "ctx", "body"]`)
- Output is now a dynamic JSON object containing only the projected fields, mirroring the CLI.
- The legacy `md_text` field name is gone; use `body`.

### Non-goals (per the issue)

`links`, `backlinks`, `tags`, `embeds` are intentionally not part of `get` projection. They remain separate CLI / MCP operations.

## Test plan

- [x] `cargo test --workspace --all-features` passes (491 tests, 0 failures)
- [x] `mise run cargo:quality` passes (build + test + fmt + clippy)
- [x] New unit tests in `cli/cmd/get.rs` cover:
  - default JSON returns `{title, ctx, body}` with `ctx: null` when absent
  - field projection includes only requested fields and rejects unknown ones
  - `--heading` scopes both text and JSON output (`body`, `code_blocks`)
  - `--heading` with no match errors

https://claude.ai/code/session_017Ac8wf5WTLjup4gfSpDwSE

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ac8wf5WTLjup4gfSpDwSE)_