### PR TITLE
[codex] Update docs for JSON field projection and links refs

### DIFF
--- a/docs/Explanation/What is Scraps?.md
+++ b/docs/Explanation/What is Scraps?.md
@@ -54,12 +54,16 @@ Any assistant that can run shell commands can query Scraps directly:
 ```bash
 ❯ scraps search "release checklist" --json
 ❯ scraps get "Configuration" --json
+❯ scraps get "Configuration" --heading "Profiles" --json body
+❯ scraps links "Configuration" --json
 ❯ scraps backlinks "Configuration" --json
 ❯ scraps todo --status all --json
 ```
 
-Shell plus JSON is the primary agent integration path. Scraps also provides
-an MCP server for MCP-compatible clients — see
+Shell plus JSON is the primary agent integration path. `get` can project only
+the fields an agent needs, and `links` returns structured outbound references
+for follow-up reads. Scraps also provides an MCP server for MCP-compatible
+clients — see
 [[How-to/Integrate with AI Assistants]] for both paths and the trade-offs
 between them.
 

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -13,11 +13,19 @@ server.
 ```bash
 ❯ scraps search "rust cli" --logic and --json
 ❯ scraps get "Getting Started" --json
+❯ scraps get "Getting Started" --heading "Install" --json body
+❯ scraps get "Getting Started" --json code_blocks
 ❯ scraps links "Getting Started" --json
 ❯ scraps backlinks "Configuration" --json
 ❯ scraps tag list --json
 ❯ scraps todo --status all --json
 ```
+
+`scraps get --json` defaults to `title`, `ctx`, and `body`. It can project
+specific fields (`title`, `ctx`, `body`, `headings`, `code_blocks`) so an
+agent can avoid loading full bodies when it only needs structure or examples.
+`scraps links --json` returns outbound `link` and `embed` references with
+optional heading targets; `backlinks` stays a scrap-level inbound lookup.
 
 The full command map is in [[Reference/CLI Overview]]. Each command's `--help`
 documents flags and JSON shape.

--- a/docs/Reference/CLI Overview.md
+++ b/docs/Reference/CLI Overview.md
@@ -22,4 +22,32 @@ the authoritative reference for flags and arguments. This page is the
 `-C` / `--directory` (or `SCRAPS_DIRECTORY` env) runs as if started in the
 given directory.
 
+## JSON Reads
+
+`scraps get` reads one scrap, optionally scoped by context and heading:
+
+```bash
+scraps get "Title" --ctx "Book" --heading "Install" --json
+```
+
+Its `--json` flag accepts an optional comma-separated field projection. With
+no projection it returns `title`, `ctx`, and `body`.
+
+```bash
+scraps get "Title" --json title,ctx,body
+scraps get "Title" --json code_blocks
+scraps get "Title" --heading "Install" --json body,headings
+```
+
+Allowed fields are `title`, `ctx`, `body`, `headings`, and `code_blocks`.
+Reference navigation stays separate: use `scraps links`, `scraps backlinks`,
+and `scraps tag ...`.
+
+`scraps links --json` returns outbound reference occurrences. Each result has
+`kind` (`link` or `embed`), `title`, `ctx`, and `heading`, so agents can jump
+directly to `scraps get <title> --ctx <ctx> --heading <heading>`.
+
+`scraps backlinks --json` remains scrap-level inbound discovery and returns
+the scraps that link to the requested scrap.
+
 For agent integration, see [[How-to/Integrate with AI Assistants]].

--- a/docs/Tutorial/Getting Started.md
+++ b/docs/Tutorial/Getting Started.md
@@ -71,9 +71,14 @@ can query the wiki:
 ```bash
 ❯ scraps search "query" --json
 ❯ scraps get "Page Name" --json
+❯ scraps get "Page Name" --heading "Section" --json body
 ❯ scraps backlinks "Page Name" --json
 ❯ scraps todo --json
 ```
+
+`scraps get --json` returns `title`, `ctx`, and `body` by default. It can also
+project fields such as `headings` or `code_blocks`, and `--heading` narrows
+the read to one section.
 
 For Claude Code users there is also an official skills bundle. See
 [[How-to/Integrate with AI Assistants]] for both paths.

--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -61,14 +61,17 @@ Returns: `[{ title, backlinks_count }]`.
 
 ### `get_scrap`
 
-Retrieve a single scrap by title (and optional context).
+Retrieve a single scrap by title, optional context, optional heading, and
+optional field projection.
 
-| Parameter | Type | Required |
-|---|---|---|
-| `title` | string | yes |
-| `ctx` | string | no |
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `title` | string | yes | Scrap title |
+| `ctx` | string | no | Context folder/path |
+| `heading` | string | no | Restrict body/structure fields to this section |
+| `fields` | string[] | no | Defaults to `["title", "ctx", "body"]`; allowed: `title`, `ctx`, `body`, `headings`, `code_blocks` |
 
-Returns: `{ title, ctx, md_text, headings, code_blocks }`.
+Returns the requested fields. Default response: `{ title, ctx, body }`.
 
 ### `lookup_scrap_links`
 
@@ -79,7 +82,17 @@ Outbound wiki-links from a scrap.
 | `title` | string | yes |
 | `ctx` | string | no |
 
-Returns: `{ results: [{ title, ctx }], count }`.
+Returns outbound reference occurrences:
+
+```json
+{
+  "results": [
+    { "kind": "link", "title": "Target", "ctx": null, "heading": "Install" },
+    { "kind": "embed", "title": "Guide", "ctx": "Docs", "heading": null }
+  ],
+  "count": 2
+}
+```
 
 ### `lookup_scrap_backlinks`
 

--- a/plugins/scraps-writer/skills/scraps-writer/SKILL.md
+++ b/plugins/scraps-writer/skills/scraps-writer/SKILL.md
@@ -59,9 +59,9 @@ Parse the title by extracting the text between the first pair of double quotes. 
 
 - `list_tags` - Get all tags sorted by backlinks count.
 - `search_scraps` - Find related scraps by keyword with fuzzy matching against title and body content. Returns `title` and `ctx` for each result. **IMPORTANT: Each result represents an existing scrap. Only use the returned `title` and `ctx` values when creating Wiki-links.**
-- `get_scrap` - Get a single scrap's full content by `title` and optional `ctx`.
+- `get_scrap` - Get a single scrap by `title`, optional `ctx`, optional `heading`, and optional `fields`. Defaults to `title`, `ctx`, and `body`.
 - `lookup_tag_backlinks` - Check which scraps are using a specific tag. Returns `title` and `ctx` for each result.
-- `lookup_scrap_links` - Get all scraps that a scrap links to. Returns `title` and `ctx` for each result.
+- `lookup_scrap_links` - Get outbound link/embed refs from a scrap. Returns `kind`, `title`, `ctx`, and `heading` for each result.
 - `lookup_scrap_backlinks` - Get all scraps that link to a scrap. Returns `title` and `ctx` for each result.
 
 ## Wiki-Link Syntax

--- a/plugins/scraps/agents/lint-rule-handler.md
+++ b/plugins/scraps/agents/lint-rule-handler.md
@@ -61,7 +61,7 @@ Reject requests like "run all default rules" without a stated purpose.
 For each violation:
 - Identify the likely fix
   - `broken-link`: search for the closest title via `scraps search --json`
-  - `broken-heading-ref`: read the target scrap, find a matching heading
+  - `broken-heading-ref`: read target headings with `scraps get <title> --json headings`, then choose the closest valid heading
   - `self-link`: remove the link
 - Propose the Edit
 - Apply on user confirmation (or directly when invoked from a trusted skill context)
@@ -70,7 +70,7 @@ For each violation:
 ### Judgment rules (dead-end, lonely, overlinking)
 
 For each violation:
-- Read the offending scrap via `scraps get --json`
+- Read the offending scrap via `scraps get <title> [--ctx <ctx>] --json`
 - Interpret against purpose:
   - `dead-end` → atomic definition (signal: keep) vs. genuinely incomplete (signal: extend)
   - `lonely` → natural root/source note (signal: accept) vs. orphan (signal: link from a related scrap)
@@ -101,7 +101,7 @@ For each violation:
 ## CLI used
 
 - `scraps lint --rule <rule> [--rule <rule> ...]`
-- `scraps get <title> [--ctx <ctx>] --json`
+- `scraps get <title> [--ctx <ctx>] [--heading <heading>] --json [fields]`
 - `scraps search <query> --json` (for `broken-link` replacement candidates)
 
 Full command details: `scraps <cmd> --help`.

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -37,6 +37,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
    - `scraps search "<keyword>" --json` to find related scraps
    - `scraps tag list --json` to find relevant tags
    - Read 3–8 of the most related scraps via `scraps get "<title>" --json`
+   - Use `scraps get "<title>" --json headings` first when only the outline is needed
 
 3. **Decide title and ctx**
    - Pick a clear, atomic title
@@ -82,7 +83,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 ## CLI used
 
 - `scraps search <query> --json`
-- `scraps get <title> [--ctx <ctx>] --json`
+- `scraps get <title> [--ctx <ctx>] [--heading <heading>] --json [fields]`
 - `scraps tag list --json`
 - `scraps tag backlinks <tag> --json`
 - `scraps lint --rule <rule>`

--- a/plugins/scraps/skills/query/SKILL.md
+++ b/plugins/scraps/skills/query/SKILL.md
@@ -36,6 +36,8 @@ Implements Karpathy's *Query* primitive for Scraps: search the wiki, read releva
 
 4. **Read selected scraps**
    - `scraps get "<title>" [--ctx <ctx>] --json` for each candidate
+   - Use field projection to save context when appropriate, e.g. `--json body`, `--json headings`, or `--json code_blocks`
+   - If a link result includes `heading`, read just that section with `scraps get "<title>" [--ctx <ctx>] --heading "<heading>" --json body`
    - For graph-shaped questions, also use:
      - `scraps links "<title>" --json` (outbound)
      - `scraps backlinks "<title>" --json` (inbound)
@@ -59,12 +61,13 @@ Implements Karpathy's *Query* primitive for Scraps: search the wiki, read releva
 - If a claim has no source in the wiki, mark it as outside the wiki ("not in the current scraps"); do not bluff.
 - Use the exact `title` value returned by `scraps search --json` / `scraps get --json` so the citation resolves cleanly.
 - For ctx-disambiguated scraps, use `[[Ctx/Title]]`.
+- `scraps links --json` may return a `heading`; use it for targeted reads, but cite the scrap as `[[Title]]` or `[[Ctx/Title]]` unless the answer specifically needs a heading reference.
 
 ## CLI used
 
 - `scraps search <query> [--logic and|or] --json`
-- `scraps get <title> [--ctx <ctx>] --json`
-- `scraps links <title> [--ctx <ctx>] --json`
+- `scraps get <title> [--ctx <ctx>] [--heading <heading>] --json [fields]`
+- `scraps links <title> [--ctx <ctx>] --json` (returns `{ kind, title, ctx, heading }` refs)
 - `scraps backlinks <title> [--ctx <ctx>] --json`
 - `scraps tag list --json`
 - `scraps tag backlinks <tag> --json`


### PR DESCRIPTION
## Summary

- Document `scraps get --json [fields]`, `--heading`, and the `body` field in the CLI and AI integration docs.
- Update MCP plugin docs for `get_scrap` field projection and structured outbound link refs.
- Refresh bundled skill guidance so agents use field projection and heading-targeted reads.

## Validation

- Ran `git diff --cached --check` before committing.

## Notes

- `backlinks` remains documented as scrap-level inbound discovery.