### PR TITLE
fix(html): load fuse.js@7 as an ES module

### DIFF
--- a/docs/Reference/Markdown/Autolink.md
+++ b/docs/Reference/Markdown/Autolink.md
@@ -7,6 +7,10 @@ site, fetching the target page's Open Graph metadata at build time.
 <https://github.com/boykush/scraps>
 ```
 
+The example above renders as a live OGP card on this page:
+
+<https://github.com/boykush/scraps>
+
 Use autolinks deliberately: the card is heavy compared to an inline link.
 Reach for `<…>` when the link is a "you should look at this" pointer
 (canonical source, prior art, recipe target). Use `[text](url)` for inline

--- a/src/usecase/build/html/builtins/index.html
+++ b/src/usecase/build/html/builtins/index.html
@@ -42,8 +42,15 @@
 {% block script %}
   {% if build_search_index == true %}
   <!-- For search scraps -->
-  <script src="https://cdn.jsdelivr.net/npm/fuse.js@{{ cdn.fusejs }}"></script>
+  <!--
+    fuse.js@7+ ships as ESM only; loading it through a classic <script src>
+    fails to evaluate the `export` and leaves window.Fuse undefined. Import it
+    from a module script and re-expose it as a global so the classic
+    doSearch() handler below can call `new Fuse(...)`.
+  -->
   <script type="module">
+    import Fuse from "https://cdn.jsdelivr.net/npm/fuse.js@{{ cdn.fusejs }}";
+    window.Fuse = Fuse;
     fetch('./search_index.json')
       .then(response => response.json())
       .then(data => {

--- a/src/usecase/build/html/index_render.rs
+++ b/src/usecase/build/html/index_render.rs
@@ -297,4 +297,63 @@ mod tests {
             "true<a href=\"./scrap3.html\">scrap3</a><a href=\"./scrap4.html\">scrap4</a>"
         );
     }
+
+    /// Regression test for the v1.0.0-rc.1 Fuse.js loading bug.
+    ///
+    /// fuse.js@7+ ships only an ES module from cdn.jsdelivr.net. Loading it
+    /// with a classic `<script src=...>` tag makes the browser fail on the
+    /// `export` statement, so `window.Fuse` never gets defined and the
+    /// in-page search dies.
+    ///
+    /// We must (a) load fuse.js inside a `type="module"` script via `import`,
+    /// and (b) avoid emitting a classic `<script src=".../fuse.js@...">` tag.
+    #[rstest]
+    fn fusejs_loads_as_es_module_in_builtin_index(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        // Do NOT register a static index.html — we want the builtin template.
+
+        let base_url = &BaseUrl::new(Url::parse("http://localhost:1112/").unwrap()).unwrap();
+        let metadata = HtmlMetadata::new(
+            &LangCode::default(),
+            "Scrap",
+            &Some("Scrap Wiki".to_string()),
+            &Some(Url::parse("https://github.io/image.png").unwrap()),
+        );
+        let list_view_configs =
+            ListViewConfigs::new(&true, &SortKey::CommittedDate, &Paging::By(10));
+
+        let scrap1 = Scrap::new("scrap1", &None, "# header1");
+        let scrap_texts = [&scrap1]
+            .iter()
+            .map(|scrap| (scrap.self_key(), scrap.md_text().to_string()))
+            .collect();
+        let sc1 = ScrapDetail::new(&scrap1, &Some(0), base_url, &scrap_texts);
+        let scrap_details = ScrapDetails::new(&vec![sc1]);
+        let backlinks_map = BacklinksMap::new(&scrap_details.to_scraps());
+
+        let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
+        render
+            .run(
+                base_url,
+                &metadata,
+                &list_view_configs,
+                &scrap_details,
+                &backlinks_map,
+                &None,
+            )
+            .unwrap();
+
+        let html = fs::read_to_string(project.output_path("index.html")).unwrap();
+
+        assert!(
+            !html.contains(r#"<script src="https://cdn.jsdelivr.net/npm/fuse.js@"#),
+            "fuse.js@7+ is ESM-only: a classic <script src> tag fails to evaluate it. \
+             Got HTML:\n{html}"
+        );
+        assert!(
+            html.contains(r#"import Fuse from "https://cdn.jsdelivr.net/npm/fuse.js@"#),
+            "fuse.js must be imported inside a `type=\"module\"` script. Got HTML:\n{html}"
+        );
+    }
 }

--- a/tests/e2e/scraps-doc.spec.ts
+++ b/tests/e2e/scraps-doc.spec.ts
@@ -37,7 +37,10 @@ test('CDN libraries are loaded', async ({ page }) => {
 });
 
 test('fetch OGP data', async ({ page }) => {
-  await page.goto('/scraps/autolink.reference.html');
+  // Autolink.md intentionally hosts a live `<https://github.com/boykush/scraps>`
+  // autolink so this test has a stable OGP card to assert against.
+  // Keep that autolink in `docs/Reference/Markdown/Autolink.md` if you edit it.
+  await page.goto('/scraps/reference/markdown/autolink.html');
 
   // Wait for OGP card to be present
   const ogpCard = page.locator('.ogp-card').first();
@@ -57,7 +60,7 @@ test('fetch OGP data', async ({ page }) => {
   const description = await ogpCard.locator('.ogp-description').textContent();
   
   expect(title).toContain('GitHub - boykush/scraps');
-  expect(description).toContain('Scraps is a portable CLI knowledge hub');
+  expect(description).toContain('The Wiki-link doc compiler for the LLM era');
 
   // Verify image is loaded
   const image = ogpCard.locator('.ogp-image');


### PR DESCRIPTION
## Summary

`fuse.js@7` is ESM-only on cdn.jsdelivr.net, but the generated `index.html` loaded it via a classic `<script src="https://cdn.jsdelivr.net/npm/fuse.js@7.x">` tag. The browser failed on the `export` statement, leaving `window.Fuse` undefined and breaking the in-page search. The bug has been there since the search feature was introduced (`f2f03d2`, day-one of fuse.js@7+), but was masked by other Playwright failures during the v1 docs migration. With those resolved, this is the remaining real failure on `Playwright Test`.

## Changes

- **`src/usecase/build/html/builtins/index.html`**: load fuse.js inside a `type="module"` script via `import Fuse from "https://cdn.jsdelivr.net/npm/fuse.js@{{ cdn.fusejs }}"`, then `window.Fuse = Fuse` so the existing classic `doSearch()` handler keeps working.
- **`src/usecase/build/html/index_render.rs`**: add a regression test that renders the builtin template (no static override) and asserts the output uses the module import and never the classic `<script src=".../fuse.js@...">` tag.
- **`tests/e2e/scraps-doc.spec.ts`**:
  - update the OGP test URL from the v0 slug `/scraps/autolink.reference.html` to the v1 slug `/scraps/reference/markdown/autolink.html`
  - update the OGP description assertion to match the current GitHub repo description ("The Wiki-link doc compiler for the LLM era")
  - document that `Autolink.md` is the intentional fixture for this test
- **`docs/Reference/Markdown/Autolink.md`**: add a real `<https://github.com/boykush/scraps>` autolink under the existing code-fence example, so the page hosts a stable OGP card for the e2e test (and self-documents what an autolink renders into).

## Test plan

- [x] `cargo test --bin scraps fusejs_loads_as_es_module_in_builtin_index` — Rust regression test passes (red without the template fix, green with it)
- [x] `mise run cargo:quality` — build / test / fmt / clippy all green
- [x] Local Playwright (12 tests, 3 browsers): all 12 pass against `target/release/scraps serve --directory docs`
- [ ] CI: `Playwright Test` succeeds on this PR / after merge to main