### PR TITLE
[codex] Document template command migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Scraps - AI skills, migration workflows, and MCP integration for interconnected Markdown documentation",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Scraps reads `[[wiki-link]]`, `#[[tag]]`, `![[embed]]`, `[[Page#heading]]`, and 
 CLI + JSON is the primary path — any shell-capable agent can query Scraps without an MCP client implementation. Bundled plugins provide agent-facing workflows:
 
 - [`scraps`](plugins/scraps) — Karpathy-style *Ingest / Query / Lint* skills for Claude Code and Codex, plus a Claude Code `lint-rule-handler` agent
-- [`scraps-migration`](plugins/scraps-migration) — LLM-led v0 → v1 migration workflow for Claude Code and Codex with version-pinned audits
 - [`mcp-server`](plugins/mcp-server) — MCP server for MCP-compatible clients
 
 See the [AI integration guide](https://boykush.github.io/scraps/scraps/how-to/integrate-with-ai-assistants.html) for the trade-offs.

--- a/plugins/scraps-migration/.claude-plugin/plugin.json
+++ b/plugins/scraps-migration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-migration",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LLM migration workflows for moving Scraps wikis from v0 to v1. Runs version-pinned audits, converts tag and config syntax, and verifies the result with v1 lint/build.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-migration/.codex-plugin/plugin.json
+++ b/plugins/scraps-migration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps-migration",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LLM migration workflows for moving Scraps wikis from v0 to v1. Use this plugin when a user wants an agent to migrate a Scraps wiki, upgrade v0 syntax/config to v1, compare v0/v1 CLI behavior, or produce a v0 to v1 migration plan.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps-migration/README.md
+++ b/plugins/scraps-migration/README.md
@@ -43,6 +43,7 @@ The skill:
 - runs v1 lint/build to identify breaking changes
 - converts known v0 tag links to explicit v1 `#[[tag]]`
 - updates `.scraps.toml` discovery/config shape
+- removes `scraps template generate` / `scraps template list` workflow usage
 - replaces `-p` / `--path` workflow references with `-C` / `--directory`
 - fully migrates GitHub Pages deploys to v1 (`_site/`, `boykush/scraps@v1`,
   and Pages source set to GitHub Actions)

--- a/plugins/scraps-migration/skills/migrate-v0-to-v1/SKILL.md
+++ b/plugins/scraps-migration/skills/migrate-v0-to-v1/SKILL.md
@@ -69,7 +69,8 @@ support `-C`.
 | project path config / `scraps_dir` style | `.scraps.toml` directory is wiki root | Move or rewrite config so the file sits at the wiki root. |
 | `public/` output assumptions | `_site/` default output | Migrate config, deploy workflows, and docs to `_site/`; do not preserve `public/` as a compatibility branch. |
 | `-p` / `--path` / `SCRAPS_PROJECT_PATH` | `-C` / `--directory` / `SCRAPS_DIRECTORY` | Update docs, scripts, CI, and agent settings. |
-| template/frontmatter authoring path | skill-based authoring | Remove workflow dependence on generated templates/frontmatter fields; keep ordinary markdown content. |
+| `scraps template generate` / `scraps template list` | removed | Delete template command usage from docs, scripts, aliases, and agent workflows; replace authoring with `scraps` plugin `/ingest` or normal markdown edits. |
+| template/frontmatter authoring path | skill-based authoring | Remove generated template files, frontmatter fields used only by templates, and workflow dependence on generated template scaffolds; keep ordinary markdown content. |
 | `scraps-writer` plugin | `scraps` plugin | Replace `/add-scrap`, `/web-to-scrap`, `/scraps-writer` with `/ingest`; use `/query` for read-side synthesis. |
 
 ## Workflow
@@ -80,7 +81,8 @@ support `-C`.
 2. Locate the wiki root and `.scraps.toml`.
 3. Count markdown files and identify docs/scripts/CI files that mention
    `scraps`, `scraps-writer`, `-p`, `--path`, `SCRAPS_PROJECT_PATH`,
-   `public`, `_site`, `upload-pages-artifact`, `github-pages`, `template`, or
+   `public`, `_site`, `upload-pages-artifact`, `github-pages`,
+   `scraps template`, `template generate`, `template list`, `template`, or
    `frontmatter`.
 4. Resolve and record the latest v0 and latest v1-or-newer CLI refs that will
    be used.
@@ -147,6 +149,13 @@ Update `.scraps.toml` and surrounding automation:
   - `scraps -p <dir> ...` -> `scraps -C <dir> ...`
   - `scraps --path <dir> ...` -> `scraps --directory <dir> ...`
   - `SCRAPS_PROJECT_PATH` -> `SCRAPS_DIRECTORY`
+- Remove template command usage:
+  - Delete `scraps template generate` and `scraps template list` examples from
+    docs, scripts, aliases, CI, and agent instructions.
+  - Do not replace them with another CLI command; v1 authoring is markdown
+    editing plus the `scraps` plugin `/ingest` workflow.
+  - Remove generated template scaffolds only when they are clearly template
+    artifacts. Preserve user-authored markdown content.
 - Update GitHub Pages deployment:
   - Use `boykush/scraps@v1` or a pinned v1 tag/SHA.
   - Ensure the build step runs the v1 CLI, usually `scraps build`.
@@ -195,6 +204,7 @@ End with:
 - files changed
 - tag conversions count
 - config/workflow changes
+- template command removals
 - GitHub Pages workflow changes and repository setting status
 - lint/build result
 - ambiguous references or unresolved items needing human judgment


### PR DESCRIPTION
## Summary

- Document removal of `scraps template generate` / `scraps template list` in the Scraps v0 to v1 migration skill
- Add template command removals to migration reporting and README summary
- Bump the `scraps-migration` plugin manifests to `0.1.1` and marketplace metadata to `1.2.1`
- Remove temporary `scraps-migration` mention from the root README

## Validation

- Parsed updated JSON manifests and marketplace files with `jq`

## Notes

GitHub connector PR creation returned 403, so this PR was created with `gh`.