### PR TITLE
ci: auto-update v{major} and v{major}.{minor} tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,41 @@ jobs:
           git commit -m "scraps ${VERSION}"
           git push
 
+  update-floating-tags:
+    name: Update v{major} and v{major}.{minor} tags
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref, '-') }} # skip prereleases
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Move floating tags to released commit
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Tag '$TAG' is not a vMAJOR.MINOR.PATCH release tag; skipping."
+            exit 1
+          fi
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          MAJOR_TAG="v${MAJOR}"
+          MINOR_TAG="v${MAJOR}.${MINOR}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -f "$MAJOR_TAG" "$SHA"
+          git tag -f "$MINOR_TAG" "$SHA"
+          git push origin -f "refs/tags/$MAJOR_TAG"
+          git push origin -f "refs/tags/$MINOR_TAG"
+
   publish-crate:
     name: Publish to crates.io
     needs: build


### PR DESCRIPTION
## Summary

- Add `update-floating-tags` job to `.github/workflows/release.yml` so `setup-scraps` users can pin `boykush/scraps@v1` or `boykush/scraps@v1.1` like `actions/checkout@v4`.
- On a `release: released` event with a `vMAJOR.MINOR.PATCH` tag, the job force-pushes `v{major}` and `v{major}.{minor}` tags to the released commit.
- Prereleases (e.g. `v1.0.0-rc.2`) are skipped using the same `if: ${{ !contains(github.ref, '-') }}` convention already used by `update-homebrew` / `publish-crate`.
- Tag format is validated with a regex; non-conforming tags fail the job rather than corrupting floating refs.

## Behavior

| Released tag | `v{major}` after | `v{major}.{minor}` after |
| --- | --- | --- |
| `v1.0.0` | `v1` → that commit | `v1.0` → that commit |
| `v1.1.0` | `v1` → that commit | `v1.1` → that commit |
| `v1.0.1` | `v1` → that commit | `v1.0` → that commit |
| `v1.0.0-rc.2` | unchanged (skipped) | unchanged (skipped) |

The docs already reference `boykush/scraps@v1` (`docs/How-to/Deploy to GitHub Pages.md:48`); this CI completes that promise on the next non-prerelease release.

## Test plan

- [ ] Merge and cut the next non-prerelease release; confirm `v{major}` and `v{major}.{minor}` tags appear/move to the release commit.
- [ ] Cut a prerelease; confirm floating tags are not touched.
- [ ] In a downstream repo, run `boykush/scraps@v1` and verify the CLI installs.

https://claude.ai/code/session_01VCFEjJgT8YJh91Xgy5VD8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCFEjJgT8YJh91Xgy5VD8y)_