### PR TITLE
chore: pin scraps to v1.0.0-rc.3 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ experimental = true
 "rust" = { version = "1.93.0", profile = "default" }
 "hk" = "latest"
 "pkl" = "latest"
-"github:boykush/scraps" = "1.0.0-rc.1"
+"github:boykush/scraps" = "1.0.0-rc.3"
 "npm:markdownlint-cli2" = "latest"
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-deny" = "latest"


### PR DESCRIPTION
## Summary

Bumps the `github:boykush/scraps` pin in `mise.toml` from `1.0.0-rc.1` to `1.0.0-rc.3` so the dev environment and the Playwright CI use the v1 RC binary that includes the fuse.js ESM fix from #545.

Without this pin bump, Playwright still installs the old rc.1 binary, and the `CDN libraries are loaded`, `search scraps`, and `fetch OGP data` tests stay red because `window.Fuse` is undefined under rc.1's classic `<script src=".../fuse.js@7">` load.

## Test plan

- [ ] CI: `Playwright Test` succeeds on main after merge.