### PR TITLE
ci(playwright): drop --with-deps + run on pull_request

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,15 @@ on:
       - 'LICENSE.md'
       - 'README.md'
       - 'CLAUDE.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'scraps/**'
+      - 'assets/**'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.md'
+      - 'README.md'
+      - 'CLAUDE.md'
 
 jobs:
   test:
@@ -31,7 +40,11 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       working-directory: ./tests/e2e
-      run: npx playwright install --with-deps
+      # `--with-deps` runs apt-get for system libs and is the slowest step in
+      # this workflow (occasionally tens of minutes). ubuntu-latest already
+      # ships most browser deps; if a future browser fails to launch, fall
+      # back to a targeted `playwright install --with-deps <browser>` step.
+      run: npx playwright install
     - name: Run Playwright tests
       working-directory: ./tests/e2e
       env:


### PR DESCRIPTION
## Summary

- Drop `--with-deps` from `npx playwright install`. The flag runs apt-get for system libs and is by far the slowest, most variable step in this workflow (a recent run spent 32 minutes there). `ubuntu-latest` already ships most browser dependencies; if a future browser fails to launch we can fall back to a targeted `playwright install --with-deps <browser>`.
- Add `pull_request: branches: [main]` trigger so the workflow runs on PRs, not just on push to main. That gives PR authors actual feedback before merge instead of discovering Playwright breakage after the fact (as happened with the fuse.js ESM bug).

## Test plan

- [ ] CI: this PR's `Playwright Test` run passes — verifies that all 3 browsers (chromium, firefox, webkit) launch on `ubuntu-latest` without `--with-deps`.
- [ ] If WebKit (the one most likely to need extra libs) fails, follow-up will add a targeted `playwright install --with-deps webkit` step.