### PR TITLE
ci(playwright): tighten timeouts so hangs fail fast

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,9 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 60
+    # Hard cap so a hang fails fast. Local full suite is ~15s; CI with browser
+    # startup + retries should stay well under this budget.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -40,11 +42,7 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       working-directory: ./tests/e2e
-      # `--with-deps` runs apt-get for system libs and is the slowest step in
-      # this workflow (occasionally tens of minutes). ubuntu-latest already
-      # ships most browser deps; if a future browser fails to launch, fall
-      # back to a targeted `playwright install --with-deps <browser>` step.
-      run: npx playwright install
+      run: npx playwright install --with-deps
     - name: Run Playwright tests
       working-directory: ./tests/e2e
       env:

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -17,8 +17,10 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Retry on CI only. One retry absorbs genuine flakiness without compounding
+   * cost: at retries=2 the worst case (all tests timing out) blew past the
+   * job timeout, masking real failures as `Run Playwright tests` hangs. */
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -56,5 +58,8 @@ export default defineConfig({
     command: 'mise run docs:serve',
     url: 'http://127.0.0.1:1112',
     reuseExistingServer: !process.env.CI,
+    /* `scraps serve` builds + binds in well under a second locally; default
+     * (60s) is too lenient and lets a broken serve eat into test time. */
+    timeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

The mise-pinned-rc.3 Playwright run on main (`25622263116`) sat in `Run Playwright tests` for **24 minutes** before being cancelled, while the local full suite finishes in ~15 seconds. The gap was loose timeout caps compounding on retries:

| Layer | Before | Worst case |
|---|---|---|
| `timeout-minutes` | 60 | ~1 h budget for a hang |
| `retries` (CI) | 2 | 12 tests × 3 browsers × 3 attempts × 30s ≈ 54 min |
| `webServer.timeout` | 60s default | 1 min eaten before tests even start |

This PR caps each layer so a hang fails fast instead of blending into "still running":

- `timeout-minutes: 15` — workflow-level hard kill. ~30× the local runtime, so it never bites a healthy run.
- `retries: 1` — still absorbs genuine flakiness but no longer triples cost. Worst case drops to ~18 min, over the new job cap, so a test-wide failure trips the workflow timeout instead.
- `webServer.timeout: 30_000` — `scraps serve` binds in <1s locally; halving the default surfaces broken serves immediately.

Also restores `--with-deps` on the install step. The previous attempt to drop it (#549) was based on the misread that apt-get caused the 24-minute hang; the actual culprit was retries × default timeouts. `--with-deps` brings stability back.

## Test plan

- [ ] CI: this PR's `Playwright Test` (now triggered on `pull_request` thanks to #549) passes well under 15 minutes.