### PR TITLE
ci(docs): bump deploy setup-action to v1.0.0-rc.3

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0 # For scraps git committed date
 
       - name: Setup Scraps
-        uses: boykush/scraps@v1.0.0-rc.2
+        uses: boykush/scraps@v1.0.0-rc.3
 
       - name: Build docs
         run: scraps build --directory docs


### PR DESCRIPTION
## Summary

The live docs site (https://boykush.github.io/scraps/) ships HTML built by the rc.2 binary, which still has the broken classic `<script src="cdn.jsdelivr.net/npm/fuse.js@7">` load. In Arc and other browsers this surfaces as:

\`\`\`
Search query: ...
Uncaught ReferenceError: search is not defined
    at doSearch (...)
\`\`\`

The failed fuse.js parse leaves `window.search` permanently undefined, and the classic `doSearch()` handler bound to `onkeyup` then throws on every keystroke. The fix landed in scraps source via #545 and shipped as the rc.3 binary; this just bumps the deploy action ref so the next deploy rebuilds docs with rc.3.

Editing this workflow file also matches the deploy `paths:` trigger (`'.github/workflows/deploy-scraps-github-pages.yml'`), so merging alone fires a redeploy — no manual `workflow_dispatch` needed.

## Test plan

- [ ] CI: `Deploy scraps github pages` succeeds after merge.
- [ ] Live: `https://boykush.github.io/scraps/` — typing in the search box returns results, no console error.