### PR TITLE
ci(diag): trace docs:serve task to localize CI hang

### DIFF
--- a/.mise-tasks/docs/serve
+++ b/.mise-tasks/docs/serve
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
 #MISE description="Serve documentation locally with scraps"
-scraps serve --directory docs
+# Diagnostic mode for the CI hang investigation: trace each line, dump PATH /
+# scraps resolution before invoking, and bypass the mise shim by going through
+# `mise exec` so the github:boykush/scraps tool resolves explicitly.
+set -x
+echo "[docs:serve] HOME=$HOME"
+echo "[docs:serve] PWD=$PWD"
+echo "[docs:serve] MISE_AUTO_INSTALL=${MISE_AUTO_INSTALL:-unset}"
+echo "[docs:serve] PATH=$PATH"
+echo "[docs:serve] which scraps:"
+which scraps || true
+echo "[docs:serve] mise current scraps:"
+mise current github:boykush/scraps || true
+echo "[docs:serve] handing off to mise exec scraps serve"
+exec mise exec github:boykush/scraps -- scraps serve --directory docs


### PR DESCRIPTION
## Summary

The most recent Playwright runs hang silently for 14+ minutes after the mise task starts, then get killed by the workflow timeout. The job log effectively contains:

\`\`\`
[WebServer] [docs:serve] $ ~/work/scraps/scraps/.mise-tasks/docs/serve
... (14 minutes of silence) ...
Terminate orphan process: pid (5722) (npm exec playwright test)
\`\`\`

`scraps` itself never prints `📦 Building site...`, so the hang sits **before** scraps's main runs — in either the bash task script or in mise's resolution of the `scraps` shim. Locally the same task completes in ~0.4s.

This PR adds purely diagnostic instrumentation to `.mise-tasks/docs/serve`:

- `set -x` traces every line.
- Echoes `HOME`, `PWD`, `MISE_AUTO_INSTALL`, `PATH`, `which scraps`, `mise current github:boykush/scraps` before invoking.
- Routes the actual invocation through `mise exec github:boykush/scraps -- scraps serve --directory docs`, bypassing the shim path. If the hang is in the shim, this should clear it; if it isn't, we'll see exactly which dump line was the last one logged.

Once we identify the offending step from the next CI run, we revert this script to the minimal one-liner.

## Test plan

- [x] Locally `bash .mise-tasks/docs/serve` traces all dumps and reaches `📦 Building site...`.
- [ ] CI: observe the next `Playwright Test` run on this branch / on main; the logs should pinpoint the hang.