### PR TITLE
docs: fix mermaid diagram preview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ See the [Getting Started tutorial](https://boykush.github.io/scraps/scraps/tutor
 
 ```mermaid
 graph LR
-  Source[Markdown sources] --> IR[Scraps IR — typed graph]
-  IR --> HTML[Static HTML]
-  IR --> JSON[CLI JSON]
+  Source["Markdown sources"] --> IR["Scraps IR — typed graph"]
+  IR --> HTML["Static HTML"]
+  IR --> JSON["CLI JSON"]
 ```
 
 Scraps reads `[[wiki-link]]`, `#[[tag]]`, `![[embed]]`, `[[Page#heading]]`, and `ctx_path` as typed primitives. The same source compiles to an HTML site for human readers and to JSON for scripts and AI agents.


### PR DESCRIPTION
## Summary

The mermaid diagram in the "How it works" section of `README.md` was not rendering on GitHub — it stayed stuck on "Loading" because GitHub's mermaid parser rejected the unquoted em-dash (`—`) inside the label `Scraps IR — typed graph`.

Wrapping each node label in double quotes lets the parser handle the special character, so the diagram now renders as expected.

## Test plan

- [ ] Open the rendered README on this branch and confirm the diagram displays as a graph (not raw code / "Loading")

https://claude.ai/code/session_016UYHfrzkJh5DPxCnTv4Q7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016UYHfrzkJh5DPxCnTv4Q7b)_