### PR TITLE
[codex] Fix performance test wiki directory

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,7 +44,7 @@ jobs:
             Build Time: ${duration} seconds
             Status: ${emoji} ${status.toUpperCase()}
 
-            Executed with: scraps build -v
+            Executed with: scraps --directory scraps build -v
             Repository: boykush/wiki
             Runner: Ubuntu latest`;
 

--- a/.mise-tasks/perf/test
+++ b/.mise-tasks/perf/test
@@ -15,7 +15,7 @@ git clone --depth 1 https://github.com/boykush/wiki.git "$WIKI_DIR"
 echo "⏱️ Running scraps build..."
 cd "$WIKI_DIR"
 START_TIME=$(date +%s%N)
-"$PROJECT_ROOT/target/release/scraps" build -v
+"$PROJECT_ROOT/target/release/scraps" --directory scraps build -v
 END_TIME=$(date +%s%N)
 
 DURATION_NS=$(( END_TIME - START_TIME ))


### PR DESCRIPTION
## Summary

- Update the performance test to build boykush/wiki from its v1 wiki root at scraps/.
- Keep the workflow comment aligned with the command that CI actually runs.

## Root Cause

boykush/wiki now stores its v1 Scraps configuration at scraps/.scraps.toml, but the performance task still ran scraps build -v from the repository root. That made CI look for .scraps.toml at the clone root and fail before measuring build performance.

## Validation

- mise exec -- cargo build --release
- Built a local fixture with repo-root/scraps/.scraps.toml using target/release/scraps --directory scraps build -v