### PR TITLE
[codex] Add get JSON images field

### DIFF
--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -15,6 +15,7 @@ server.
 ❯ scraps get "Getting Started" --json
 ❯ scraps get "Getting Started" --heading "Install" --json body
 ❯ scraps get "Getting Started" --json code_blocks
+❯ scraps get "Getting Started" --json images
 ❯ scraps links "Getting Started" --json
 ❯ scraps backlinks "Configuration" --json
 ❯ scraps tag list --json
@@ -22,7 +23,7 @@ server.
 ```
 
 `scraps get --json` defaults to `title`, `ctx`, and `body`. It can project
-specific fields (`title`, `ctx`, `body`, `headings`, `code_blocks`) so an
+specific fields (`title`, `ctx`, `body`, `headings`, `code_blocks`, `images`) so an
 agent can avoid loading full bodies when it only needs structure or examples.
 `scraps links --json` returns outbound `link` and `embed` references with
 optional heading targets; `backlinks` stays a scrap-level inbound lookup.

--- a/docs/Reference/CLI Overview.md
+++ b/docs/Reference/CLI Overview.md
@@ -36,10 +36,11 @@ no projection it returns `title`, `ctx`, and `body`.
 ```bash
 scraps get "Title" --json title,ctx,body
 scraps get "Title" --json code_blocks
+scraps get "Title" --json images
 scraps get "Title" --heading "Install" --json body,headings
 ```
 
-Allowed fields are `title`, `ctx`, `body`, `headings`, and `code_blocks`.
+Allowed fields are `title`, `ctx`, `body`, `headings`, `code_blocks`, and `images`.
 Reference navigation stays separate: use `scraps links`, `scraps backlinks`,
 and `scraps tag ...`.
 

--- a/docs/Tutorial/Getting Started.md
+++ b/docs/Tutorial/Getting Started.md
@@ -77,7 +77,7 @@ can query the wiki:
 ```
 
 `scraps get --json` returns `title`, `ctx`, and `body` by default. It can also
-project fields such as `headings` or `code_blocks`, and `--heading` narrows
+project fields such as `headings`, `code_blocks`, or `images`, and `--heading` narrows
 the read to one section.
 
 For Claude Code users there is also an official skills bundle. See

--- a/src/cli/cmd/get.rs
+++ b/src/cli/cmd/get.rs
@@ -7,7 +7,7 @@ use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
 use crate::usecase::scrap::get::usecase::GetScrapUsecase;
-use scraps_libs::markdown::query::{code_blocks, heading_slug, headings, section};
+use scraps_libs::markdown::query::{code_blocks, heading_slug, headings, images, section};
 use scraps_libs::model::context::Ctx;
 use scraps_libs::model::title::Title;
 use serde_json::{Map, Value};
@@ -17,6 +17,7 @@ const FIELD_CTX: &str = "ctx";
 const FIELD_BODY: &str = "body";
 const FIELD_HEADINGS: &str = "headings";
 const FIELD_CODE_BLOCKS: &str = "code_blocks";
+const FIELD_IMAGES: &str = "images";
 
 const DEFAULT_FIELDS: &[&str] = &[FIELD_TITLE, FIELD_CTX, FIELD_BODY];
 const ALLOWED_FIELDS: &[&str] = &[
@@ -25,6 +26,7 @@ const ALLOWED_FIELDS: &[&str] = &[
     FIELD_BODY,
     FIELD_HEADINGS,
     FIELD_CODE_BLOCKS,
+    FIELD_IMAGES,
 ];
 
 fn parse_fields(spec: &str) -> ScrapsResult<Vec<&'static str>> {
@@ -121,6 +123,13 @@ pub fn run(
                     FIELD_CODE_BLOCKS => {
                         let v: Vec<CodeBlockJson> =
                             code_blocks(body_text).into_iter().map(Into::into).collect();
+                        out.insert(field.to_string(), serde_json::to_value(v)?);
+                    }
+                    FIELD_IMAGES => {
+                        let v: Vec<String> = images(body_text)
+                            .into_iter()
+                            .map(|url| url.to_string())
+                            .collect();
                         out.insert(field.to_string(), serde_json::to_value(v)?);
                     }
                     _ => unreachable!("validated by parse_fields"),
@@ -236,6 +245,45 @@ mod tests {
         assert_eq!(obj["title"], "Tokio");
         let h = obj["headings"].as_array().unwrap();
         assert_eq!(h.len(), 2);
+    }
+
+    #[rstest]
+    fn run_json_field_projection_supports_images(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_config(b"").add_scrap(
+            "Gallery.md",
+            b"# Gallery\n\n![one](https://example.com/one.png)\n\n![bad](local.png)\n\n## More\n\n![two](https://example.com/two.jpg)\n",
+        );
+
+        let output = run_get("Gallery", None, None, Some("images"), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+
+        assert_eq!(
+            v["images"].as_array().unwrap(),
+            &vec![
+                Value::String("https://example.com/one.png".to_string()),
+                Value::String("https://example.com/two.jpg".to_string()),
+            ]
+        );
+    }
+
+    #[rstest]
+    fn run_json_images_respects_heading_scope(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_config(b"").add_scrap(
+            "Gallery.md",
+            b"# Gallery\n\n![one](https://example.com/one.png)\n\n## More\n\n![two](https://example.com/two.jpg)\n",
+        );
+
+        let output = run_get("Gallery", None, Some("More"), Some("images"), &project).unwrap();
+        let v: Value = serde_json::from_str(output.trim()).unwrap();
+
+        assert_eq!(
+            v["images"].as_array().unwrap(),
+            &vec![Value::String("https://example.com/two.jpg".to_string())]
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Adds an images projection field to scraps get --json, returning Markdown image URLs found in the selected scrap body.

## Details

- Wires the existing Markdown image query helper into the get JSON projection path.
- Keeps --heading behavior consistent by extracting images from the scoped section body.
- Documents the new field in the CLI and AI integration docs.

## Validation

- mise exec -- cargo fmt --check
- mise exec -- cargo test cli::cmd::get
- pre-commit cargo_quality hook passed during commit