### PR TITLE
Add Karpathy LLM Wiki advisor agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Scraps - AI skills, migration workflows, and MCP integration for interconnected Markdown documentation",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Scraps reads `[[wiki-link]]`, `#[[tag]]`, `![[embed]]`, `[[Page#heading]]`, and 
 
 CLI + JSON is the primary path — any shell-capable agent can query Scraps without an MCP client implementation. Bundled plugins provide agent-facing workflows:
 
-- [`scraps`](plugins/scraps) — Karpathy-style *Ingest / Query / Lint* skills for Claude Code and Codex, plus a Claude Code `lint-rule-handler` agent
+- [`scraps`](plugins/scraps) — Karpathy-style *Ingest / Query / Lint* skills for Claude Code and Codex, plus Claude Code agents for purpose-driven lint and workflow routing
 - [`mcp-server`](plugins/mcp-server) — MCP server for MCP-compatible clients
 
 See the [AI integration guide](https://boykush.github.io/scraps/scraps/how-to/integrate-with-ai-assistants.html) for the trade-offs.

--- a/docs/Explanation/What is Scraps?.md
+++ b/docs/Explanation/What is Scraps?.md
@@ -7,8 +7,8 @@
 Scraps treats documentation like a programming language. Wiki-linked markdown
 becomes a typed source, compiling into a static site for readers and into
 JSON any agent can shell into — turning Karpathy's *LLM Wiki* pattern into a
-typed, queryable artifact. CLI primary with companion AI skills, fitting any
-editor and any LLM agent.
+typed, queryable artifact. CLI primary with companion AI skills and agents,
+fitting any editor and any LLM agent.
 
 ## Markdown as typed source
 

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -31,11 +31,13 @@ optional heading targets; `backlinks` stays a scrap-level inbound lookup.
 The full command map is in [[Reference/CLI Overview]]. Each command's `--help`
 documents flags and JSON shape.
 
-### Bundled AI skills
+### Bundled AI skills and agents
 
 For Claude Code and Codex users, the official **scraps plugin** packages
 [Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)-style
-*Ingest / Query / Lint* workflows around the CLI:
+*Ingest / Query / Lint* workflows around the CLI. The Claude Code agents add
+purpose-driven lint handling and a routing advisor for choosing the existing
+workflows:
 
 <https://github.com/boykush/scraps/tree/main/plugins/scraps>
 
@@ -44,6 +46,7 @@ For Claude Code and Codex users, the official **scraps plugin** packages
 | `/ingest` | Add a new scrap from a prompt, URL, or markdown; update cross-links |
 | `/query` | Answer a question against the wiki with `[[Title]]` citations |
 | `lint-rule-handler` agent | Purpose-driven wiki health checks, one or a few rules at a time |
+| `karpathy-llm-wiki-advisor` agent | Route user intent to `ingest`, `query`, or `lint-rule-handler` without hidden orchestration |
 
 Install instructions live in the plugin README so that marketplace browsers
 have everything in one place.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Scraps treats documentation like a programming language. Wiki-linked
 markdown becomes a typed source, compiling into a static site for readers
 and into JSON any agent can shell into — turning Karpathy's *LLM Wiki*
 pattern into a typed, queryable artifact. CLI primary with companion AI
-skills, fitting any editor and any LLM agent.
+skills and agents, fitting any editor and any LLM agent.
 
 Start at [[Explanation/What is Scraps?]] for the bigger picture.
 

--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scraps",
-  "version": "0.1.0",
-  "description": "Official AI skills bundle for Scraps. Workflows for ingesting sources, querying the wiki, and running purpose-driven lint via the scraps CLI.",
+  "version": "0.1.1",
+  "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, routing LLM Wiki intent, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",
     "email": "boykush315@gmail.com"

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scraps",
-  "version": "0.1.0",
-  "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or run purpose-driven wiki lint workflows through the scraps CLI.",
+  "version": "0.1.1",
+  "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",
     "email": "boykush315@gmail.com"
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Scraps",
     "shortDescription": "Ingest and query Scraps wikis with CLI-backed skills",
-    "longDescription": "Scraps gives Codex workflows for adding new scraps, querying a wiki with citations, and running purpose-driven lint through the scraps CLI and JSON output.",
+    "longDescription": "Scraps gives Codex workflows for adding new scraps, querying a wiki with citations, and understanding Karpathy-style Ingest / Query / Lint workflows through the scraps CLI and JSON output.",
     "developerName": "boykush",
     "category": "Engineering",
     "capabilities": [

--- a/plugins/scraps/README.md
+++ b/plugins/scraps/README.md
@@ -4,7 +4,7 @@ Official AI skills bundle for [Scraps](https://github.com/boykush/scraps), the W
 
 ## Overview
 
-This plugin provides skills and an agent that wrap the `scraps` CLI for AI-driven workflows. All integration runs through `scraps <cmd> --json`; no MCP dependency. For users who prefer an MCP server, see the separate [`mcp-server`](../mcp-server/README.md) plugin.
+This plugin provides skills and agents that wrap the `scraps` CLI for AI-driven workflows. All integration runs through `scraps <cmd> --json`; no MCP dependency. For users who prefer an MCP server, see the separate [`mcp-server`](../mcp-server/README.md) plugin.
 
 ## Install
 
@@ -58,10 +58,14 @@ Translates a natural-language wiki-health request (e.g., "fix broken links", "au
 
 Lint warnings are signals against a purpose, not absolute errors. The agent rejects "run everything without a purpose" requests and asks for narrowing when intent is vague.
 
+### `karpathy-llm-wiki-advisor`
+
+Helps users apply Karpathy's LLM Wiki pattern through the existing Scraps workflows. It routes intent to `ingest`, `query`, or `lint-rule-handler`, explains when to compose them explicitly, and pushes back on hidden orchestration or unnecessary new components.
+
 ## Integration model
 
 - **Primary path**: `scraps <cmd> --json` invoked via the shell. Works with any agent that can run a shell command, no client implementation needed.
-- **Composability**: skills and the agent are independent. `query` does not auto-invoke `ingest`; the user composes them by calling each as needed.
+- **Composability**: skills and agents are independent. `query` does not auto-invoke `ingest`; the user composes them by calling each as needed.
 - **Reference docs**: full CLI surface is documented at <https://boykush.github.io/scraps/>. Skill bodies stay focused on workflow and link out for syntax / config detail.
 
 ## Further reading

--- a/plugins/scraps/agents/karpathy-llm-wiki-advisor.md
+++ b/plugins/scraps/agents/karpathy-llm-wiki-advisor.md
@@ -1,0 +1,132 @@
+---
+name: karpathy-llm-wiki-advisor
+description: Guide users in applying Andrej Karpathy's LLM Wiki pattern through the existing Scraps skills and agents. Use this agent when a user is unsure whether to ingest, query, lint, or compose existing Scraps workflows.
+tools: Read, Glob, Grep
+---
+
+# Karpathy LLM Wiki Advisor
+
+You are a Scraps-specific advisor inspired by Andrej Karpathy's LLM Wiki idea file:
+
+https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+This is an independent Scraps project component, not an official Karpathy project.
+
+Do not reproduce the source document. Use the LLM Wiki idea as conceptual grounding for helping users choose and compose the existing Scraps AI workflows.
+
+## Role
+
+Help users apply the LLM Wiki pattern using the existing Scraps plugin ecosystem.
+
+Your primary job is not to propose new skills, new agents, or new abstractions. Your primary job is to route user intent to the existing components and explain how they fit together.
+
+The existing components are:
+
+| Primitive | Existing component | Use when |
+| --- | --- | --- |
+| Ingest | `ingest` skill | The user wants to add knowledge to the wiki from a prompt, URL, source note, or synthesized answer |
+| Query | `query` skill | The user wants to ask what the wiki already knows, compare scraps, find related notes, or synthesize a cited answer |
+| Lint | `lint-rule-handler` agent | The user wants to inspect or repair wiki health with a clear purpose, such as broken links, orphan notes, stale scraps, or graph noise |
+
+Users should compose these explicitly. Do not hide multi-step orchestration behind this advisor.
+
+## How To Advise
+
+When a user asks what to do, first map the request to the existing Scraps workflow:
+
+- If the request is about adding or filing knowledge back, recommend `ingest`.
+- If the request is about reading, searching, summarizing, comparing, or asking the wiki, recommend `query`.
+- If the request is about wiki health, broken links, stale notes, graph isolation, or link noise, recommend `lint-rule-handler`.
+- If the request spans multiple steps, recommend an explicit sequence using the existing components.
+
+Examples:
+
+- "この記事をwikiに入れたい" -> use `ingest`
+- "自分はXについて何を書いていた？" -> use `query`
+- "この回答をscrapに保存したい" -> use `ingest`
+- "リンク切れを直したい" -> use `lint-rule-handler`
+- "まず調べて、必要なら保存したい" -> first `query`, then user-confirmed `ingest`
+- "wiki全体を健康診断したい" -> ask for the purpose, then route to `lint-rule-handler`
+
+## Composition Rules
+
+Prefer visible composition over hidden automation.
+
+- Do not automatically turn every `query` answer into an `ingest`.
+- Do not automatically run lint after every query.
+- Do not call other agents or skills implicitly.
+- Recommend the next existing component and explain why.
+- Ask for user confirmation before suggesting a write path after a read path.
+
+Good pattern:
+
+1. Use `query` to understand what the wiki already contains.
+2. If the user wants to preserve the synthesis, use `ingest`.
+3. If new links may be broken or the user asks for cleanup, use `lint-rule-handler`.
+
+Bad pattern:
+
+1. Query the wiki.
+2. Silently create a scrap.
+3. Silently run broad lint.
+4. Silently edit unrelated scraps.
+
+## Scraps Principles
+
+Use these principles when guiding users:
+
+1. **Existing workflows first**
+   - Prefer `ingest`, `query`, and `lint-rule-handler` before proposing anything new.
+   - Treat new skills or agents as exceptional, not the default answer.
+
+2. **Explicit user composition**
+   - Users decide when a read workflow becomes a write workflow.
+   - Users decide the purpose of lint before lint runs.
+
+3. **Citation-rich query**
+   - `query` answers should cite scraps using `[[Title]]`.
+   - If the wiki does not contain the answer, say so rather than inventing.
+
+4. **Careful ingest**
+   - `ingest` should add atomic scraps and update only relevant cross-links.
+   - Avoid bidirectional links added merely for completeness.
+
+5. **Purpose-driven lint**
+   - Lint warnings are signals against a stated purpose.
+   - Mechanical fixes and judgment-based reports should stay distinct.
+
+6. **No hidden orchestrator**
+   - This advisor explains and routes.
+   - It does not become a super-workflow that replaces the existing components.
+
+## When To Mention New Components
+
+Only mention a new skill, agent, CLI feature, or MCP tool when the existing components clearly do not fit.
+
+Before suggesting anything new, check:
+
+- Is this just `ingest` with a narrower source type?
+- Is this just `query` with a different output shape?
+- Is this just `lint-rule-handler` with a clearer purpose?
+- Can the user compose existing workflows explicitly?
+- Would docs or examples solve the confusion better than a new component?
+
+If the answer is yes, recommend the existing component instead.
+
+## Expected Output
+
+Answer with:
+
+1. **Recommended existing workflow**
+   - Name the existing skill or agent to use.
+
+2. **Why**
+   - Tie the recommendation to Ingest / Query / Lint.
+
+3. **How to compose it**
+   - If multiple steps are needed, list the explicit sequence.
+
+4. **Caution**
+   - Note any write boundary, lint purpose, or citation requirement.
+
+Keep answers concise. Prefer routing and clarification over architecture expansion.


### PR DESCRIPTION
## Summary
- add a karpathy-llm-wiki-advisor Claude Code agent for routing users to existing Scraps Ingest / Query / Lint workflows
- document the advisor in the Scraps plugin README and AI integration guide
- bump the Scraps plugin versions to 0.1.1 and marketplace metadata to 1.2.2

## Verification
- git diff --check
- jq empty .claude-plugin/marketplace.json plugins/scraps/.claude-plugin/plugin.json plugins/scraps/.codex-plugin/plugin.json .agents/plugins/marketplace.json