### PR TITLE
Refine LLM Wiki schema agent and ingest skill

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/agents/lint-rule-handler.md
+++ b/plugins/scraps/agents/lint-rule-handler.md
@@ -110,3 +110,4 @@ Full command details: `scraps <cmd> --help`.
 
 - Scraps lint reference: <https://boykush.github.io/scraps/>
 - Karpathy's *Lint* primitive: <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f>
+- Composition with other primitives, dialogue / catch-up patterns, and primitive boundaries: see the `scraps-llm-wiki-schema` agent.

--- a/plugins/scraps/agents/scraps-llm-wiki-schema.md
+++ b/plugins/scraps/agents/scraps-llm-wiki-schema.md
@@ -85,6 +85,8 @@ Examples:
 - "Should I use MCP or CLI?" -> consult `docs/How-to/Integrate with AI Assistants.md`
 - "Search first, then save it if useful" -> first `query`, then user-confirmed `ingest`
 - "Check overall wiki health" -> ask for the purpose, then route to `lint-rule-handler`
+- "Catch up on X" / "Explore a topic not yet in my scraps" -> `ingest` URLs or topics (it fetches externally and writes scraps for the user to read); `query` to revisit existing scraps
+- "Discuss this article before I file it" -> discuss the source here; the user invokes `ingest` when ready
 
 ## Composition Rules
 
@@ -102,59 +104,20 @@ Good pattern:
 2. If the user wants to preserve the synthesis, use `ingest`.
 3. If new links may be broken or the user asks for cleanup, use `lint-rule-handler`.
 
-Bad pattern:
-
-1. Query the wiki.
-2. Silently create a scrap.
-3. Silently run broad lint.
-4. Silently edit unrelated scraps.
-
 ## Scraps Principles
 
-Use these principles when guiding users:
+1. **Existing workflows first**
+   - Prefer `ingest`, `query`, and `lint-rule-handler` before proposing anything new. Treat new skills or agents as exceptional.
+   - Before suggesting a new component, check: could it be one of the existing primitives with a narrower source or clearer purpose? Could user-side composition (e.g., a catch-up skill) provide it? Would docs or examples solve it?
 
-1. **Official docs first**
-   - Ground tool explanations in the Scraps docs and plugin instructions.
-   - When current behavior matters, read the relevant local docs before answering.
-
-2. **Existing workflows first**
-   - Prefer `ingest`, `query`, and `lint-rule-handler` before proposing anything new.
-   - Treat new skills or agents as exceptional, not the default answer.
-
-3. **Explicit user composition**
-   - Users decide when a read workflow becomes a write workflow.
-   - Users decide the purpose of lint before lint runs.
-
-4. **Citation-rich query**
-   - `query` answers should cite scraps using `[[Title]]`.
-   - If the wiki does not contain the answer, say so rather than inventing.
-
-5. **Careful ingest**
-   - `ingest` should add atomic scraps and update only relevant cross-links.
-   - Avoid bidirectional links added merely for completeness.
-
-6. **Purpose-driven lint**
-   - Lint warnings are signals against a stated purpose.
-   - Mechanical fixes and judgment-based reports should stay distinct.
-
-7. **Local schema extensions**
+2. **Local schema extensions**
    - Project-level `CLAUDE.md`, `AGENTS.md`, or user instructions may add domain-specific conventions.
    - Follow local conventions when present, while preserving Scraps workflow boundaries.
 
-## When To Mention New Components
-
-Only mention a new skill, agent, CLI feature, or MCP tool when the existing components clearly do not fit.
-
-Before suggesting anything new, check:
-
-- Is this just `ingest` with a narrower source type?
-- Is this just `query` with a different output shape?
-- Is this just `lint-rule-handler` with a clearer purpose?
-- Is this a CLI behavior that already exists in the official docs?
-- Can the user compose existing workflows explicitly?
-- Would docs or examples solve the confusion better than a new component?
-
-If the answer is yes, recommend the existing component or documentation path instead.
+3. **Dialogue at the conversation layer**
+   - Dialogue, catch-up sessions, and weighing external sources happen here in the conversation with the schema agent or a user-side skill — not inside the primitives.
+   - The primitives (`ingest`, `query`, `lint-rule-handler`) stay silent, one-shot tools, suitable for both automated CI runs and interactive use.
+   - When tempted to add a `discuss` step inside `ingest`, an iterative mode inside `query`, or an external-fetch inside `query`, route the concern to this conversation layer instead.
 
 ## Expected Output
 

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -22,16 +22,16 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 
 | Source | Provided as | First step |
 | --- | --- | --- |
-| prompt | user's topic or instruction | gather context (search related scraps) |
+| prompt | user's topic, instruction, or ready-to-use content (e.g., a `/query` synthesis) | if the input is complete content, use as-is; otherwise gather context (search related scraps) and ask one clarifying question only when scope is unclear |
 | URL | pasted link | `WebFetch <url>`, extract title and key content |
-| arbitrary markdown | content from prior conversation (e.g., query answer) | use as-is |
+| term | an atomic term surfaced in discussion (often unknown until just now) | treat the term itself as the title; skip clarifying questions |
 
 ## Workflow
 
 1. **Identify source and topic**
    - URL: `WebFetch` → use OGP / heading title as initial title
-   - prompt: ask clarifying questions if scope is unclear
-   - arbitrary markdown: take the content as the source
+   - prompt: if the input is complete content (e.g., a `/query` synthesis), use as-is; if it's a topic, ask one clarifying question only when scope is unclear
+   - term: the term is the title; do not ask clarifying questions (the discussion already established scope). Proceed to step 2 with the term as the search keyword.
 
 2. **Research existing wiki state**
    - `scraps search "<keyword>" --json` to find related scraps
@@ -49,7 +49,8 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
    - Low → 5–7 lines (protect working memory)
    - Medium → 10–12 lines (schema is forming, more detail welcome)
    - High → 5–7 lines (avoid redundant explanation; prefer link-rich brevity)
-   - Skip this step if the user specified max-lines explicitly
+   - Skip this step if the user specified `--max-lines` explicitly (CLI flag is authoritative)
+   - If the user signals depth in conversation ("go deeper" / "longer" / "厚めに" etc.), bump one band upward; "shorter" / "ライトに" etc. bumps downward. Conversation cue overrides the heuristic but stays below the explicit `--max-lines` flag.
 
 5. **Draft the scrap**
    - Plain Markdown with `[[link]]` for references and `#[[tag]]` for tags
@@ -94,3 +95,4 @@ Full command details: `scraps <cmd> --help`.
 
 - Scraps docs: <https://boykush.github.io/scraps/>
 - Karpathy's *Ingest / Query / Lint* framing: <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f>
+- Composition with other primitives, dialogue / catch-up patterns, and primitive boundaries: see the `scraps-llm-wiki-schema` agent.

--- a/plugins/scraps/skills/query/SKILL.md
+++ b/plugins/scraps/skills/query/SKILL.md
@@ -79,3 +79,4 @@ Full command details: `scraps <cmd> --help`.
 
 - Scraps docs: <https://boykush.github.io/scraps/>
 - Karpathy's *Ingest / Query / Lint* framing: <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f>
+- Composition with other primitives, dialogue / catch-up patterns, and primitive boundaries: see the `scraps-llm-wiki-schema` agent.


### PR DESCRIPTION
## Summary

- Compact `scraps-llm-wiki-schema` agent: drop redundant Principles (7→3), remove `When To Mention New Components` section, drop the Bad pattern block
- Add Principle "Dialogue at the conversation layer" — formalize that dialogue / catch-up / external-fetch lives at the conversation layer, not inside primitives
- Add catch-up / discuss examples to `How To Guide Users`, framed for the file-mediated learning model
- Add bidirectional reference: each primitive (`/query`, `/ingest`, `lint-rule-handler`) points back to `scraps-llm-wiki-schema` in Further reading
- Restructure `/ingest` source types: add `term` source for atomic terms surfaced in discussion; fold `arbitrary markdown` into `prompt`
- Add conversation-cue override for `/ingest` max-lines ("go deeper" / "厚めに" etc.)
- Bump plugin version 0.1.2 → 0.1.3 in both `.claude-plugin` and `.codex-plugin` manifests

## Test plan

- [ ] All modified markdown files render correctly
- [ ] `/ingest <term>` in a discussion session skips clarifying question
- [ ] `/ingest` with conversation cue ("厚めに") moves max-lines band upward
- [ ] `scraps-llm-wiki-schema` agent reads cleanly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)