### PR TITLE
Make /ingest cross-link step explicit about plain-text search

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -58,7 +58,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
    - Stay within max-lines
 
 6. **Cross-link update** (Karpathy's "update related entity and concept pages")
-   - For each of 1–5 most related existing scraps, decide if a `[[new title]]` reference fits naturally
+   - For each of the 1–5 most related existing scraps, search the body for plain-text mentions of the new title; convert each mention to `[[new title]]` when the link direction protocol allows. Do not invent new mentions where none exist.
    - **Link direction protocol**: links flow from concrete to abstract
      - new concrete scrap (Book, Project, Tool) → may link to existing abstract scraps it depends on
      - existing abstract scrap → do NOT add a reference back to the new concrete scrap (anti-pattern)


### PR DESCRIPTION
## Summary

- Reframe `/ingest` step 6 (Cross-link update): the operation is now an explicit "search plain-text mentions of the new title in each related scrap, then convert to `[[new title]]` when the direction protocol allows" instead of the vaguer "decide if a reference fits naturally"
- Makes the workflow concrete (search → convert) and conservative (surfaces existing connections only, no fabricated mentions) — aligns with Karpathy's "missing cross-references" framing
- Bump plugin version 0.1.3 → 0.1.4 in both `.claude-plugin` and `.codex-plugin` manifests

## Test plan

- [ ] `/ingest` step 6 reads cleanly
- [ ] Dogfood: invoke `/ingest <topic>` and verify step 6 only converts plain-text mentions in related scraps; no fabricated insertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)