### PR TITLE
ci: add zizmor GitHub Actions audit and harden workflows

### DIFF
--- a/.github/workflows/cargo-test-and-lint.yml
+++ b/.github/workflows/cargo-test-and-lint.yml
@@ -23,14 +23,19 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: jdx/mise-action@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
         cache: false
         install_args: "rust"
@@ -43,8 +48,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: jdx/mise-action@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
         cache: false
         install_args: "rust cargo:cargo-deny"

--- a/.github/workflows/claude-review-from-author.yml
+++ b/.github/workflows/claude-review-from-author.yml
@@ -15,12 +15,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Review PR from Specific Author
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -22,31 +20,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # For scraps git committed date
+          persist-credentials: false
 
       - name: Setup Scraps
-        uses: boykush/scraps@v1.0.0
+        uses: boykush/scraps@66c592b332d46f635340356289582e5463a82453 # v1.0.0
 
       - name: Build docs
         run: scraps build --directory docs
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/_site
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -11,17 +11,25 @@ on:
       - 'README.md'
       - 'CLAUDE.md'
 
+permissions:
+  contents: read
+
 jobs:
   performance:
     name: Scraps Build Performance Test
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: false
           install_args: "rust"
@@ -32,11 +40,14 @@ jobs:
       
       - name: Comment PR
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          BUILD_DURATION: ${{ steps.build.outputs.duration }}
+          BUILD_STATUS: ${{ steps.build.outputs.status }}
         with:
           script: |
-            const duration = parseFloat('${{ steps.build.outputs.duration }}');
-            const status = '${{ steps.build.outputs.status }}';
+            const duration = parseFloat(process.env.BUILD_DURATION);
+            const status = process.env.BUILD_STATUS;
             const emoji = status === 'pass' ? '✅' : '❌';
 
             const comment = `## Performance Test Results 🚀

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,9 @@ on:
       - 'README.md'
       - 'CLAUDE.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # Hard cap so a hang fails fast. Local full suite is ~15s; CI with browser
@@ -26,14 +29,16 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
     - name: Setup mise (install scraps)
-      uses: jdx/mise-action@v4
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
         cache: false
         install_args: "github:boykush/scraps"
     - name: Setup Node.js
-      uses: jdx/mise-action@v4
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
         working_directory: ./tests/e2e
         install_args: "node"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released, prereleased]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -23,9 +26,13 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # upload release assets
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
@@ -40,6 +47,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-') }} # skip prereleases
+    permissions:
+      contents: read
     steps:
       - name: Extract version
         id: version
@@ -129,13 +138,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Move floating tags to released commit
         env:
           TAG: ${{ github.event.release.tag_name }}
           SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -151,27 +162,34 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag -f "$MAJOR_TAG" "$SHA"
           git tag -f "$MINOR_TAG" "$SHA"
-          git push origin -f "refs/tags/$MAJOR_TAG"
-          git push origin -f "refs/tags/$MINOR_TAG"
+          git push "$REMOTE" -f "refs/tags/$MAJOR_TAG"
+          git push "$REMOTE" -f "refs/tags/$MINOR_TAG"
 
   publish-crate:
     name: Publish to crates.io
     needs: build
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-') }} # skip prereleases
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: false
           install_args: "rust"
       - name: Publish libs crate
+        # zizmor: ignore[use-trusted-publishing] crates.io token auth is intentional; OIDC trusted publishing not configured
         run: cargo publish --manifest-path modules/libs/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish main crate
+        # zizmor: ignore[use-trusted-publishing] crates.io token auth is intentional; OIDC trusted publishing not configured
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -10,6 +10,9 @@ on:
       - 'action.yml'
       - '.github/workflows/test-action.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: ${{ matrix.os }}
@@ -22,7 +25,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Run setup-scraps action
         uses: ./
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: Zizmor (GitHub Actions audit)
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/**'
+      - '.mise-tasks/actions/**'
+      - 'mise.toml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/**'
+      - '.mise-tasks/actions/**'
+      - 'mise.toml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: GitHub Actions security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Setup mise (install zizmor)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
+          install_args: "zizmor"
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mise run actions:audit

--- a/.mise-tasks/actions/audit
+++ b/.mise-tasks/actions/audit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+#MISE description="Audit GitHub Actions workflows for security issues with zizmor"
+zizmor .github/workflows/

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ experimental = true
 "npm:markdownlint-cli2" = "latest"
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-deny" = "latest"
+"zizmor" = "1.25.2"
 
 [hooks]
 postinstall = "hk install --mise"


### PR DESCRIPTION
## Summary

Introduce [zizmor](https://docs.zizmor.sh/) to statically audit our GitHub Actions workflows for security issues, run it as a **blocking** CI check on any workflow change, and resolve all pre-existing findings so the check passes today.

## What I did

**Tooling & CI**
- `mise.toml`: add `zizmor` tool, **pinned to `1.25.2`**
- `.mise-tasks/actions/audit`: new mise task running `zizmor .github/workflows/`
- `.github/workflows/zizmor.yml`: new workflow that runs `mise run actions:audit` on push/PR touching `.github/workflows/**`, `.mise-tasks/actions/**`, or `mise.toml` (no `continue-on-error` — it blocks)

**Resolved all High/Medium findings across the 7 existing workflows**
- `unpinned-uses`: pin every action to a commit SHA (original tag kept as a trailing comment; Renovate continues to track updates)
- `excessive-permissions`: add minimal `permissions:` blocks; scope GitHub Pages `pages: write` / `id-token: write` down from workflow level to the `deploy` job only
- `artipacked`: set `persist-credentials: false` on checkouts. The release tag-push job no longer relies on the persisted credential — it pushes via an explicit `x-access-token` remote instead
- `template-injection` (performance.yml `actions/github-script`): pass step outputs through the step `env:` and read them via `process.env` instead of interpolating `${{ ... }}` into the script body

Result: `mise run actions:audit` → **"No findings to report."** (exit 0)

## Notes / Reference

- **2 inline ignores**, both Informational `use-trusted-publishing` on `cargo publish` in `release.yml`: crates.io token auth is intentional and OIDC trusted publishing is not configured. These are annotated with a reason rather than silently suppressed.
- SHA-pinned actions remain Renovate-updatable thanks to the `# vX` tag comments.
- `release.yml`'s `update-homebrew` job pushes to a separate repo via `HOMEBREW_COMMITTER_TOKEN`, so it keeps `contents: read`.