### PR TITLE
fix(action): download binary from the action's own repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,13 @@ runs:
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
         TARGET: ${{ steps.resolve.outputs.target }}
-        REPO: ${{ github.repository }}
+        ACTION_REPOSITORY: ${{ github.action_repository }}
       run: |
         set -euo pipefail
+        # github.action_repository resolves to the action's own repo (boykush/scraps)
+        # where the release assets live, not the consuming repo. It is empty when the
+        # action is run via a local path (uses: ./), so fall back to boykush/scraps.
+        REPO="${ACTION_REPOSITORY:-boykush/scraps}"
         URL="https://github.com/${REPO}/releases/download/v${VERSION}/scraps-${TARGET}.tar.gz"
         DEST="${RUNNER_TEMP}/scraps"
         mkdir -p "$DEST"


### PR DESCRIPTION
## 概要

`Setup Scraps` composite action（`action.yml`）の「Download and install scraps」ステップが、バイナリのダウンロード元に `github.repository`（= action を**利用している側**のリポジトリ）を使っていたため、`boykush/scraps` 以外のリポジトリから利用すると 404 になっていた問題を修正します。

## 変更内容

- `github.repository` → `github.action_repository` に変更
  - `github.action_repository` は action 自身のリポジトリ（`boykush/scraps`）に解決されるため、どの利用側リポジトリからでもリリースアセットを正しく取得できる
- `github.action_repository` はローカルパス参照（`uses: ./`）の場合に空になるため、空のときは `boykush/scraps` にフォールバック
  - これにより `test-action.yml`（`uses: ./` で実行）も引き続き正しく動作する

## 検証

フォールバックロジックをローカルで確認:

| `github.action_repository` | 生成される REPO |
| --- | --- |
| 空（ローカルパス参照） | `boykush/scraps` |
| `boykush/scraps`（外部利用） | `boykush/scraps` |

`test-action.yml` の CI（ubuntu/macos/arm マトリクス）で実際のダウンロードを検証します。

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)