### PR TITLE
feat(lint): add singleton-tag rule

### DIFF
--- a/docs/Reference/Lint Rules.md
+++ b/docs/Reference/Lint Rules.md
@@ -13,6 +13,7 @@ rules with dependencies are opt-in via `--rule` or `[lint.<rule>]` in
 | `overlinking` | same `[[link]]` repeated in one scrap | on |
 | `broken-link` | `[[link]]` that does not resolve | on |
 | `broken-heading-ref` | `[[Page#Heading]]` heading missing | on |
+| `singleton-tag` | `#[[tag]]` used by only one scrap | on |
 | `stale-by-git` | last commit older than threshold (git-dependent) | opt-in |
 
 Output follows the `cargo clippy`-style diagnostic format. For LLM-driven

--- a/plugins/scraps/README.md
+++ b/plugins/scraps/README.md
@@ -53,7 +53,7 @@ Answer a question against the wiki. The skill searches scraps with `scraps searc
 Translates a natural-language wiki-health request (e.g., "fix broken links", "audit orphans") into a small, deliberate set of `scraps lint` rules and runs them. Behavior branches per rule type:
 
 - **Mechanical** (`broken-link`, `broken-heading-ref`, `self-link`) — propose and apply fixes
-- **Judgment** (`dead-end`, `lonely`, `overlinking`) — read affected scraps and report; do not auto-fix
+- **Judgment** (`dead-end`, `lonely`, `overlinking`, `singleton-tag`) — read affected scraps and report; do not auto-fix
 - **Informational** (`stale-by-git`) — list with metadata
 
 Lint warnings are signals against a purpose, not absolute errors. The agent rejects "run everything without a purpose" requests and asks for narrowing when intent is vague.

--- a/plugins/scraps/agents/lint-rule-handler.md
+++ b/plugins/scraps/agents/lint-rule-handler.md
@@ -21,6 +21,7 @@ Pick the smallest rule set that serves the stated purpose.
 | "audit orphans" / "孤立 scrap" | `lonely` |
 | "audit graph isolation" (orphans + dead-ends) | `lonely`, `dead-end` |
 | "trim graph noise" / "link 重複" | `overlinking` |
+| "audit tag usage" / "1 件しか付いてないタグ" | `singleton-tag` |
 | "find stale scraps" / "更新ない scrap" | `stale-by-git` |
 | "wiki health 全般" (vague) | ask for narrowing first |
 
@@ -36,6 +37,7 @@ Reject requests like "run all default rules" without a stated purpose.
 | `dead-end` | judgment | read the scrap, report whether it is a natural atom or genuinely incomplete |
 | `lonely` | judgment | read the scrap, report whether it is a natural root/source note or an orphan that should be linked |
 | `overlinking` | judgment | report which repetitions are structural emphasis vs. noise (graph dedupes; this is about HTML readability) |
+| `singleton-tag` | judgment | read the scrap, report whether `#` was an accidental prefix on a link (propose converting `#[[x]]` to `[[x]]`) or a genuine tag that needs wider use |
 | `stale-by-git` | informational | list stale scraps with last-modified dates |
 
 ## Workflow
@@ -67,7 +69,7 @@ For each violation:
 - Apply on user confirmation (or directly when invoked from a trusted skill context)
 - Re-run the same rule to verify the fix
 
-### Judgment rules (dead-end, lonely, overlinking)
+### Judgment rules (dead-end, lonely, overlinking, singleton-tag)
 
 For each violation:
 - Read the offending scrap via `scraps get <title> [--ctx <ctx>] --json`
@@ -75,6 +77,7 @@ For each violation:
   - `dead-end` → atomic definition (signal: keep) vs. genuinely incomplete (signal: extend)
   - `lonely` → natural root/source note (signal: accept) vs. orphan (signal: link from a related scrap)
   - `overlinking` → structural emphasis (signal: keep) vs. visual noise (signal: trim duplicates)
+  - `singleton-tag` → accidental `#` on a link (signal: convert `#[[x]]` to `[[x]]`) vs. genuine tag concept (signal: apply the tag to more scraps, or accept as intentional)
 - Report findings; do not auto-fix
 - Suggest concrete next actions where appropriate
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,6 +224,8 @@ pub enum CliLintRuleName {
     BrokenLink,
     #[value(name = "broken-heading-ref")]
     BrokenHeadingRef,
+    #[value(name = "singleton-tag")]
+    SingletonTag,
     #[value(name = "stale-by-git")]
     StaleByGit,
 }
@@ -277,6 +279,7 @@ impl From<CliLintRuleName> for LintRuleName {
             CliLintRuleName::Overlinking => LintRuleName::Overlinking,
             CliLintRuleName::BrokenLink => LintRuleName::BrokenLink,
             CliLintRuleName::BrokenHeadingRef => LintRuleName::BrokenHeadingRef,
+            CliLintRuleName::SingletonTag => LintRuleName::SingletonTag,
             CliLintRuleName::StaleByGit => LintRuleName::StaleByGit,
         }
     }

--- a/src/usecase/lint/rule.rs
+++ b/src/usecase/lint/rule.rs
@@ -10,6 +10,7 @@ pub enum LintRuleName {
     Overlinking,
     BrokenLink,
     BrokenHeadingRef,
+    SingletonTag,
     StaleByGit,
 }
 
@@ -22,6 +23,7 @@ impl LintRuleName {
             Self::Overlinking => "overlinking",
             Self::BrokenLink => "broken-link",
             Self::BrokenHeadingRef => "broken-heading-ref",
+            Self::SingletonTag => "singleton-tag",
             Self::StaleByGit => "stale-by-git",
         }
     }
@@ -36,6 +38,7 @@ impl LintRuleName {
             Self::Overlinking,
             Self::BrokenLink,
             Self::BrokenHeadingRef,
+            Self::SingletonTag,
         ]
     }
 

--- a/src/usecase/lint/rules.rs
+++ b/src/usecase/lint/rules.rs
@@ -4,4 +4,5 @@ pub mod dead_end;
 pub mod lonely;
 pub mod overlinking;
 pub mod self_link;
+pub mod singleton_tag;
 pub mod stale_by_git;

--- a/src/usecase/lint/rules/singleton_tag.rs
+++ b/src/usecase/lint/rules/singleton_tag.rs
@@ -1,0 +1,168 @@
+use scraps_libs::model::{scrap::Scrap, tags::Tags};
+
+use crate::usecase::build::model::backlinks_map::BacklinksMap;
+use crate::usecase::lint::rule::{scrap_relative_path, LintRule, LintRuleName, LintWarning};
+
+/// Detect `#[[tag]]` tags that are used by only a single scrap.
+///
+/// A tag is meant to be a concept shared across two or more scraps. A tag that
+/// resolves to just one scrap is usually a mistake: the author likely meant a
+/// regular `[[link]]` and prefixed it with `#` by accident. This rule flags
+/// each explicitly-declared tag whose backlinks resolve to exactly one scrap.
+///
+/// Hierarchical tags are judged per exact tag: `#[[ai/ml]]` and `#[[ai/db]]`
+/// are each singletons even though they share the `ai` ancestor, because
+/// `get_tag` counts a tag together with its descendants but not its siblings.
+/// A parent tag that has descendants in other scraps (e.g. `#[[ai]]` while
+/// another scrap has `#[[ai/ml]]`) is therefore not a singleton.
+pub struct SingletonTagRule;
+
+impl LintRule for SingletonTagRule {
+    fn name(&self) -> LintRuleName {
+        LintRuleName::SingletonTag
+    }
+
+    fn check(
+        &self,
+        scraps: &[Scrap],
+        backlinks_map: &BacklinksMap,
+        _tags: &Tags,
+    ) -> Vec<LintWarning> {
+        scraps
+            .iter()
+            .flat_map(|scrap| {
+                let path = scrap_relative_path(scrap);
+                let md_text = scrap.md_text();
+                scrap
+                    .tags()
+                    .iter()
+                    .filter(|tag| backlinks_map.get_tag(tag).len() == 1)
+                    .map(move |tag| {
+                        let display = tag.to_string();
+                        LintWarning {
+                            rule_name: LintRuleName::SingletonTag,
+                            scrap_path: path.clone(),
+                            message: format!(
+                                "tag #[[{display}]] is used by only one scrap (a tag should connect two or more scraps; did you mean a link [[{display}]]?)"
+                            ),
+                            source: Some(md_text.to_string()),
+                            span: find_tag_span(md_text, &display),
+                        }
+                    })
+            })
+            .collect()
+    }
+}
+
+/// Best-effort byte span of the first `#[[tag]]` occurrence in the scrap body,
+/// used to anchor the rendered warning snippet. Returns `None` when the literal
+/// form can't be located (e.g. unusual whitespace inside the brackets).
+fn find_tag_span(text: &str, display: &str) -> Option<(usize, usize)> {
+    let pattern = format!("#[[{display}]]");
+    text.find(&pattern)
+        .map(|start| (start, start + pattern.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_singleton_tag() {
+        let scrap = Scrap::new("a", &None, "text #[[solo]] more");
+        let scraps = vec![scrap];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].rule_name, LintRuleName::SingletonTag);
+        assert_eq!(warnings[0].scrap_path, "a.md");
+        assert!(warnings[0].message.contains("solo"));
+        assert!(warnings[0].span.is_some());
+    }
+
+    #[test]
+    fn skip_shared_tag() {
+        let scrap1 = Scrap::new("a", &None, "#[[shared]]");
+        let scrap2 = Scrap::new("b", &None, "#[[shared]]");
+        let scraps = vec![scrap1, scrap2];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn flag_only_the_singleton_among_mixed_tags() {
+        let scrap1 = Scrap::new("a", &None, "#[[shared]] #[[only_a]]");
+        let scrap2 = Scrap::new("b", &None, "#[[shared]]");
+        let scraps = vec![scrap1, scrap2];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].scrap_path, "a.md");
+        assert!(warnings[0].message.contains("only_a"));
+    }
+
+    #[test]
+    fn hierarchical_siblings_are_each_singletons() {
+        // Strict semantics: `ai/ml` and `ai/db` each resolve to one scrap, so
+        // both are flagged even though the `ai` ancestor connects two scraps.
+        let scrap1 = Scrap::new("a", &None, "#[[ai/ml]]");
+        let scrap2 = Scrap::new("b", &None, "#[[ai/db]]");
+        let scraps = vec![scrap1, scrap2];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().any(|w| w.message.contains("ai/ml")));
+        assert!(warnings.iter().any(|w| w.message.contains("ai/db")));
+    }
+
+    #[test]
+    fn parent_with_descendant_in_another_scrap_is_not_singleton() {
+        // `get_tag` aggregates descendants: scrap `a` declares `project/alpha`
+        // and scrap `b` declares its descendant `project/alpha/sub`, so
+        // `project/alpha` resolves to two scraps and is not flagged. Only the
+        // leaf `project/alpha/sub` (one scrap) is a singleton.
+        let scrap1 = Scrap::new("a", &None, "#[[project/alpha]]");
+        let scrap2 = Scrap::new("b", &None, "#[[project/alpha/sub]]");
+        let scraps = vec![scrap1, scrap2];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].scrap_path, "b.md");
+        assert!(warnings[0].message.contains("project/alpha/sub"));
+    }
+
+    #[test]
+    fn same_tag_repeated_in_one_scrap_is_a_single_warning() {
+        // Tags are deduped within a scrap, so a tag repeated in the same scrap
+        // still resolves to one scrap and yields exactly one warning.
+        let scrap = Scrap::new("a", &None, "#[[dup]] and again #[[dup]]");
+        let scraps = vec![scrap];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn skip_scrap_without_tags() {
+        let scrap = Scrap::new("a", &None, "[[link]] plain text, no tags");
+        let scraps = vec![scrap];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let tags = Tags::new(&scraps);
+
+        let warnings = SingletonTagRule.check(&scraps, &backlinks_map, &tags);
+        assert!(warnings.is_empty());
+    }
+}

--- a/src/usecase/lint/usecase.rs
+++ b/src/usecase/lint/usecase.rs
@@ -8,7 +8,7 @@ use super::{
     rules::{
         broken_heading_ref::BrokenHeadingRefRule, broken_link::BrokenLinkRule,
         dead_end::DeadEndRule, lonely::LonelyRule, overlinking::OverlinkingRule,
-        self_link::SelfLinkRule,
+        self_link::SelfLinkRule, singleton_tag::SingletonTagRule,
     },
 };
 
@@ -44,6 +44,7 @@ impl LintUsecase {
             Box::new(OverlinkingRule),
             Box::new(BrokenLinkRule),
             Box::new(BrokenHeadingRefRule),
+            Box::new(SingletonTagRule),
         ];
 
         if !rule_names.is_empty() {
@@ -73,12 +74,14 @@ mod tests {
         // - linker_to_unknown: broken_link ([[unknown]] doesn't resolve)
         // - heading_referrer: broken_heading_ref ([[no_links#missing]] - target
         //   exists but heading doesn't)
+        // - tagger: singleton_tag (#[[orphan_tag]] used by only this scrap)
         let scraps = vec![
             Scrap::new("no_links", &None, "plain text"),
             Scrap::new("self_linker", &None, "[[self_linker]] [[no_links]]"),
             Scrap::new("overlinker", &None, "[[no_links]] [[no_links]]"),
             Scrap::new("linker_to_unknown", &None, "[[unknown]]"),
             Scrap::new("heading_referrer", &None, "[[no_links#missing]]"),
+            Scrap::new("tagger", &None, "#[[orphan_tag]]"),
         ];
 
         let usecase = LintUsecase::new();
@@ -91,6 +94,7 @@ mod tests {
         assert!(rule_names.contains(&&LintRuleName::Overlinking));
         assert!(rule_names.contains(&&LintRuleName::BrokenLink));
         assert!(rule_names.contains(&&LintRuleName::BrokenHeadingRef));
+        assert!(rule_names.contains(&&LintRuleName::SingletonTag));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new default lint rule `singleton-tag` that flags `#[[tag]]` tags used by only a single scrap.

In v1, tags use the `#[[...]]` notation. A tag is meant to be a concept that connects **two or more** scraps. A tag that appears in just one scrap is usually a mistake — the author likely meant a regular `[[link]]` and prefixed it with `#` by accident. This rule surfaces that as a signal.

### Detection (strict, per exact tag)
- For each explicitly-declared tag, flag it when `backlinks_map.get_tag(&tag).len() == 1`.
- `get_tag` aggregates **descendants** but not **siblings**:
  - A parent tag with descendants in other scraps (e.g. `#[[project/alpha]]` while another scrap has `#[[project/alpha/sub]]`) is **not** a singleton.
  - Sibling leaf tags (`#[[ai/ml]]` and `#[[ai/db]]`) are **each** flagged even though they share the `ai` ancestor.
- The warning anchors to the `#[[tag]]` span and suggests the `[[link]]` form.

```
warning: singleton-tag: tag #[[orphan]] is used by only one scrap
         (a tag should connect two or more scraps; did you mean a link [[orphan]]?)
 --> alpha.md:3:17
3 | This references #[[orphan]] which only appears here, ...
  |                 -----------
```

### Changes
- `src/usecase/lint/rules/singleton_tag.rs` — new rule (7 unit tests)
- `src/usecase/lint/{rule,rules,usecase}.rs` — `LintRuleName::SingletonTag`, default-on registration, aggregate-test coverage
- `src/cli.rs` — `--rule singleton-tag` + `From` mapping
- `docs/Reference/Lint Rules.md` — rule table row
- `plugins/scraps/{README.md,agents/lint-rule-handler.md}` — registered as a judgment rule

### Testing
- TDD (Red → Green); full `mise run cargo:quality` (build + test + fmt + clippy) passes — 509 tests green, no new warnings.
- Manual CLI smoke test: singleton tag flagged, shared tag ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)