### PR TITLE
docs(ingest): clarify bidirectional link direction in cross-link step

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -59,9 +59,10 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 
 6. **Cross-link update** (Karpathy's "update related entity and concept pages")
    - For each of the 1–5 most related existing scraps, search the body for plain-text mentions of the new title; convert each mention to `[[new title]]` when the link direction protocol allows. Do not invent new mentions where none exist.
-   - **Link direction protocol**: links flow from concrete to abstract
-     - new concrete scrap (Book, Project, Tool) → may link to existing abstract scraps it depends on
-     - existing abstract scrap → do NOT add a reference back to the new concrete scrap (anti-pattern)
+   - **Link direction protocol**: links always flow concrete → abstract. The new scrap can be at either end:
+     - new scrap is concrete (Book, Project, Tool) → edit the NEW scrap to link out to the existing abstract scraps it depends on
+     - new scrap is abstract (a concept/topic) → edit the EXISTING concrete scraps that mention it to link in: convert their plain-text mentions to `[[new title]]`
+     - existing abstract scrap → do NOT add a reference back to a new concrete scrap (anti-pattern)
      - sibling scraps may link only when the relation is direct and asymmetric
    - **Anti-patterns**: bidirectional links between abstract↔concrete, "for completeness" additions, mention-based reflexive linking
    - Backlinks are auto-computed by Scraps; explicit reverse links are redundant


### PR DESCRIPTION
## Summary

- ingest スキルの cross-link update (step 6) の link direction protocol を方向対称に書き換え
- 「新規 scrap が抽象側のとき、既存の具体 scrap を編集して新規へリンクを張る」ケースを明示
- これまでの例が「新規 = concrete」前提に偏っており、既存 scrap への正当な forward link が抜けて見える紛らわしさを解消
- `concrete → abstract` の不変条件は維持。backlink 自動計算の注記 (67 行目) は意図通りなので据え置き
- plugin version 0.1.4 → 0.1.5 (`.claude-plugin` / `.codex-plugin` 両方)

## Test plan

- [ ] SKILL.md の文言確認のみ（挙動変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)