### PR TITLE
feat(plugin): teach link-vs-tag discipline and source spec from official docs

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/agents/scraps-llm-wiki-schema.md
+++ b/plugins/scraps/agents/scraps-llm-wiki-schema.md
@@ -1,7 +1,7 @@
 ---
 name: scraps-llm-wiki-schema
 description: Provide the default LLM Wiki schema for Scraps, grounded in the official Scraps docs and inspired by Andrej Karpathy's LLM Wiki pattern. Use this agent when a user needs disciplined guidance for ingesting, querying, maintaining, or composing existing Scraps workflows without first writing project-specific CLAUDE.md or AGENTS.md rules.
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, WebFetch
 ---
 
 # Scraps LLM Wiki Schema
@@ -36,20 +36,21 @@ Your primary job is not to propose new skills, new agents, or new abstractions. 
 
 ## Official Sources
 
-Use these repository sources as the local Scraps schema and tool reference:
+The spec lives in the official published docs — `WebFetch` them so guidance reflects current Scraps behavior in any repo the plugin is installed in. Do not rely on a local `docs/` copy: it does not ship with the plugin and is absent in other repos.
 
 | Source | Use for |
 | --- | --- |
-| `docs/How-to/Integrate with AI Assistants.md` | CLI + JSON vs MCP integration guidance |
-| `docs/Reference/CLI Overview.md` | Available commands and JSON-capable surfaces |
-| `docs/Reference/Wiki-link Notation.md` | Wiki-link, ctx, tag, heading, and embed syntax |
-| `docs/Reference/Lint Rules.md` | Lint rule meanings and when to use them |
+| <https://boykush.github.io/scraps/scraps/how-to/integrate-with-ai-assistants.html> | CLI + JSON vs MCP integration guidance |
+| <https://boykush.github.io/scraps/scraps/reference/cli-overview.html> | Available commands and JSON-capable surfaces |
+| <https://boykush.github.io/scraps/scraps/reference/wiki-link-notation.html> | Wiki-link, ctx, tag, heading, and embed syntax |
+| <https://boykush.github.io/scraps/scraps/reference/wiki-link/normal-link.html> vs <https://boykush.github.io/scraps/scraps/reference/wiki-link/tag.html> | The `[[link]]` vs `#[[tag]]` distinction — disjoint namespaces |
+| <https://boykush.github.io/scraps/scraps/reference/lint-rules.html> | Lint rule meanings and when to use them |
 | `plugins/scraps/README.md` | Official Scraps skills and agents overview |
 | `plugins/scraps/skills/ingest/SKILL.md` | Ingest workflow details |
 | `plugins/scraps/skills/query/SKILL.md` | Query workflow details |
 | `plugins/scraps/agents/lint-rule-handler.md` | Purpose-driven lint workflow details |
 
-Prefer these local docs over memory. When the user's question depends on current Scraps behavior, read the relevant docs before answering.
+Prefer the official docs over memory. When the user's question depends on current Scraps behavior — especially syntax like the `[[link]]` vs `#[[tag]]` distinction — `WebFetch` the relevant page before answering.
 
 ## Schema Mapping
 

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -54,6 +54,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 
 5. **Draft the scrap**
    - Plain Markdown with `[[link]]` for references and `#[[tag]]` for tags
+   - **Link vs tag** (the most common mistake): to point at any scrap — one that exists or one that *should* exist — always use `[[Title]]`. `#[[Tag]]` is ONLY for a cross-cutting category that already appears in the `scraps tag list` from step 2. Never reach for `#[[ ]]` to reference a scrap. When unsure, it is a link, not a tag.
    - Include source autolink if URL: `<https://...>`
    - Stay within max-lines
 
@@ -67,6 +68,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
    - Backlinks are auto-computed by Scraps; explicit reverse links are redundant
 
 7. **Post-write sanity check**
+   - **Tag check**: list every `#[[tag]]` you wrote and confirm each already appeared in the `scraps tag list --json` from step 2. A tag that was not in that list was almost certainly meant to be a `[[link]]` — convert it. Add a genuinely new tag only when you deliberately intend a new cross-cutting category. (Broken-link lint cannot catch this: a stray tag is valid syntax, it just creates a single-use tag.)
    - `scraps lint --rule broken-link` (purpose: confirm the new scrap introduced no broken references)
    - For non-trivial violations, hand off to the `lint-rule-handler` agent
 
@@ -81,6 +83,8 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 | `#[[Tag]]` | tag |
 | `<https://...>` | autolink (renders as OGP card) |
 
+`[[ ]]` and `#[[ ]]` are disjoint namespaces: `[[Title]]` references a scrap; `#[[Tag]]` declares or joins a tag. Using `#[[ ]]` to point at a scrap does not link — it silently creates a stray single-use tag.
+
 ## CLI used
 
 - `scraps search <query> --json`
@@ -89,7 +93,7 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 - `scraps tag backlinks <tag> --json`
 - `scraps lint --rule <rule>`
 
-Full command details: `scraps <cmd> --help`.
+These commands are shown with `--json` because this skill consumes structured output — without it Scraps prints human-formatted text that is unstable to parse, so `--json` is part of the command, not an option. Use `scraps <cmd> --help` only as a fallback for a rare flag not listed here, not as a routine discovery step; for deeper syntax or spec questions, consult the `scraps-llm-wiki-schema` agent (it reads the official docs).
 
 ## Further reading
 

--- a/plugins/scraps/skills/query/SKILL.md
+++ b/plugins/scraps/skills/query/SKILL.md
@@ -73,7 +73,7 @@ Implements Karpathy's *Query* primitive for Scraps: search the wiki, read releva
 - `scraps tag backlinks <tag> --json`
 - `scraps todo [--status open|done|deferred|all] --json`
 
-Full command details: `scraps <cmd> --help`.
+These commands are shown with `--json` because this skill consumes structured output — without it Scraps prints human-formatted text that is unstable to parse, so `--json` is part of the command, not an option. Use `scraps <cmd> --help` only as a fallback for a rare flag not listed here, not as a routine discovery step; for deeper syntax or spec questions, consult the `scraps-llm-wiki-schema` agent (it reads the official docs).
 
 ## Further reading
 


### PR DESCRIPTION
## Summary
- Fix agents misusing `#[[tag]]` for `[[link]]` when the ingest skill runs in other repos — this silently creates stray single-use tags that broken-link lint cannot detect.
- `scraps-llm-wiki-schema` agent now sources the spec from the official published docs via `WebFetch` (claude-code-guide style), instead of local `docs/` that do not ship with the plugin and are absent in other repos.
- ingest skill gains an inline **link-vs-tag** decision rule and a post-write **tag self-check**.
- both skills demote reactive `scraps --help` and explain `--json` once, grounded in its reason (not by repetition).
- bump scraps plugin 0.1.4 → 0.1.5.

## Why not revive the singleton-tag lint
The failure is a v1-notation misunderstanding, not a missing check. The fix is prevention (sharper skill instructions) plus the agent reading the canonical spec — keeping lint purpose-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)