### PR TITLE
fix(ingest): widen cross-link coverage beyond top 1-2 scraps

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -59,13 +59,13 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
    - Stay within max-lines
 
 6. **Cross-link update** (Karpathy's "update related entity and concept pages")
-   - For each of the 1–5 most related existing scraps, search the body for plain-text mentions of the new title; convert each mention to `[[new title]]` when the link direction protocol allows. Do not invent new mentions where none exist.
+   - Link **every genuinely-related** existing scrap (typically 3–5, up to ~5); skip only weakly or tangentially related ones — do not stop at the first one or two obvious hits. For each, search the body for plain-text mentions of the new title and convert each mention to `[[new title]]` when the link direction protocol allows. Do not invent new mentions where none exist.
    - **Link direction protocol**: links always flow concrete → abstract. The new scrap can be at either end:
      - new scrap is concrete (Book, Project, Tool) → edit the NEW scrap to link out to the existing abstract scraps it depends on
      - new scrap is abstract (a concept/topic) → edit the EXISTING concrete scraps that mention it to link in: convert their plain-text mentions to `[[new title]]`
      - existing abstract scrap → do NOT add a reference back to a new concrete scrap (anti-pattern)
      - sibling scraps may link only when the relation is direct and asymmetric
-   - **Anti-patterns**: bidirectional links between abstract↔concrete, "for completeness" additions, mention-based reflexive linking
+   - **Anti-patterns**: any link that violates concrete → abstract — a bidirectional abstract↔concrete pair, or an abstract scrap linking out to a concrete one
    - Backlinks are auto-computed by Scraps; explicit reverse links are redundant
 
 7. **Post-write sanity check**


### PR DESCRIPTION
## Summary

The ingest skill's cross-link step (Step 6) was under-linking: even when several related scraps existed, it tended to link only the top one or two and stop. Two suppressors in the skill text drove this:

- **"1–5 most related" range** — the floor of 1 got satisfied under a prohibition-heavy frame (anti-patterns ×3, "do not invent", "redundant"), with no positive pull toward the upper end.
- **"for completeness" anti-pattern** — intended to block spurious links, but over-applied to genuine 3rd–5th links, collapsing coverage to 1–2.

## Changes

- **Step 6 / cross-link instruction**: reframed from a numeric range to an *inclusion-first* rule — link **every genuinely-related** scrap (typically 3–5), skip only weakly/tangentially related ones, and explicitly "do not stop at the first one or two obvious hits." The spurious-link filter moves into this positive instruction.
- **Step 6 / anti-patterns**: trimmed to the direction rule only — `any link that violates concrete → abstract`. Dropped `"for completeness"` (the over-suppressor) and `mention-based reflexive linking` (redundant with the direction protocol), absorbing the latter as an abstract-scrap-linking-out-to-concrete violation.
- **Version**: scraps plugin `0.1.5` → `0.1.6` (`.claude-plugin` + `.codex-plugin`). Marketplace version left unchanged per convention.

The concrete → abstract link direction protocol is unchanged — that constraint was working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)