### PR TITLE
fix(ingest): split inbound mention conversion from outbound links

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/skills/ingest/SKILL.md
+++ b/plugins/scraps/skills/ingest/SKILL.md
@@ -55,17 +55,16 @@ Implements Karpathy's *Ingest* primitive for Scraps: read a source, draft a new 
 5. **Draft the scrap**
    - Plain Markdown with `[[link]]` for references and `#[[tag]]` for tags
    - **Link vs tag** (the most common mistake): to point at any scrap — one that exists or one that *should* exist — always use `[[Title]]`. `#[[Tag]]` is ONLY for a cross-cutting category that already appears in the `scraps tag list` from step 2. Never reach for `#[[ ]]` to reference a scrap. When unsure, it is a link, not a tag.
+   - **Link direction (outbound)**: the new scrap's own links flow concrete → abstract. A concrete new scrap (Book, Project, Tool) links out to the abstract scraps it depends on; an abstract new scrap rarely links out to a concrete one — those concrete scraps link IN to it instead (handled in step 6). An abstract scrap linking out to a concrete one is an anti-pattern. Sibling scraps may link only when the relation is direct and asymmetric.
    - Include source autolink if URL: `<https://...>`
    - Stay within max-lines
 
-6. **Cross-link update** (Karpathy's "update related entity and concept pages")
-   - Link **every genuinely-related** existing scrap (typically 3–5, up to ~5); skip only weakly or tangentially related ones — do not stop at the first one or two obvious hits. For each, search the body for plain-text mentions of the new title and convert each mention to `[[new title]]` when the link direction protocol allows. Do not invent new mentions where none exist.
-   - **Link direction protocol**: links always flow concrete → abstract. The new scrap can be at either end:
-     - new scrap is concrete (Book, Project, Tool) → edit the NEW scrap to link out to the existing abstract scraps it depends on
-     - new scrap is abstract (a concept/topic) → edit the EXISTING concrete scraps that mention it to link in: convert their plain-text mentions to `[[new title]]`
-     - existing abstract scrap → do NOT add a reference back to a new concrete scrap (anti-pattern)
-     - sibling scraps may link only when the relation is direct and asymmetric
-   - **Anti-patterns**: any link that violates concrete → abstract — a bidirectional abstract↔concrete pair, or an abstract scrap linking out to a concrete one
+6. **Cross-link inbound mentions** (Karpathy's "update related entity and concept pages")
+   - Existing scraps that already name the new title in plain text should link IN to it. This is the reverse of step 5's outbound links — here you edit the *existing* scraps. Discover candidates with Grep, judge each in context, then convert.
+   - **Discover (Grep, high recall)**: now that the title is fixed (step 3), `Grep` the wiki for the literal title across `*.md`, with surrounding context. `scraps search` is fuzzy over title+body and returns no match location, so it misses and mislocates mentions — do not use it for discovery.
+   - **Judge each hit (review, high precision)**: Grep is a substring match, so review every hit in context and keep only a *standalone-term* occurrence of the title. Skip a hit that is merely part of a longer term — title `GitHub` inside `GitHub App` / `GitHub Actions`, or title `状態` inside `状態管理` (Japanese has no word boundaries, so context judgement is mandatory, not a regex `\b`). If that longer term is itself a scrap or should be one, leave it intact rather than splitting it.
+   - **Convert**: turn each surviving plain-text mention into `[[new title]]` (use `[[new title|surface form]]` for an inflected or aliased form). Skip occurrences already inside `[[...]]`/`#[[...]]` and skip the new scrap's own file. Do not invent mentions Grep did not find.
+   - Cover **every** scrap that survives review — do not stop at the first one or two.
    - Backlinks are auto-computed by Scraps; explicit reverse links are redundant
 
 7. **Post-write sanity check**


### PR DESCRIPTION
## Summary

The ingest skill's behavior of converting an existing scrap's plain-text mention of a new title into `[[new title]]` was weak and unreliable. Root cause: Step 6 ("Cross-link update") conflated two genuinely distinct operations and suppressed the one users care about.

- **A — outbound**: links the *new* scrap itself writes (concrete → abstract).
- **B — inbound**: converting *existing* scraps' plain-text mentions into links to the new scrap.

These were merged under one direction-protocol branch, so B was treated as a side effect of A, gated by "when the link direction protocol allows," and — critically — had **no discovery mechanism** (the only search, `scraps search`, is fuzzy over title+body and returns no match location).

## Changes

- **Step 5 (drafting)** now owns outbound link direction (concrete → abstract, anti-patterns, sibling rule) — the home for the new scrap's own links.
- **Step 6** is rewritten as inbound-only mention conversion with a two-stage design:
  - **Discover (Grep, high recall)** — literal-title search across `*.md` with context; `scraps search` explicitly excluded from discovery.
  - **Judge (review, high precision)** — Grep is a substring match, so each hit is reviewed in context; substring hits like `GitHub` inside `GitHub App` or `状態` inside `状態管理` are skipped (Japanese has no word boundaries, so `\b` can't help).
  - **Convert** — standalone-term mentions only; skip occurrences already inside `[[...]]`/`#[[...]]` and the new scrap's own file.
  - Direction-protocol gate removed from conversion (surfacing an existing prose reference isn't authoring a new directional link).
- Bump scraps plugin `0.1.6` → `0.1.7`.

## Test plan

- [ ] Skill-only change (Markdown + plugin manifests); no code paths affected.
- [ ] Manually verify an ingest converts plain-text mentions while leaving compound-term substrings intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)