### PR TITLE
ci(plugins): guard plugin.json version bumps in pre-commit

### DIFF
--- a/.mise-tasks/plugins/check-version
+++ b/.mise-tasks/plugins/check-version
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Guard: block commit if plugin content changed without updating its plugin.json"
+set -euo pipefail
+
+# Staged changes under plugins/ (added/copied/modified/renamed)
+staged="$(git diff --cached --name-only --diff-filter=ACMR -- 'plugins/')"
+[ -z "$staged" ] && exit 0
+
+# Plugin names with staged changes (plugins/<name>/...)
+plugins="$(printf '%s\n' "$staged" | awk -F/ 'NF>=2 {print $2}' | sort -u)"
+
+errors=()
+for name in $plugins; do
+  base="plugins/$name"
+  files="$(printf '%s\n' "$staged" | grep -E "^${base}/" || true)"
+
+  # Skip when only plugin.json itself changed (no content change)
+  content="$(printf '%s\n' "$files" | grep -vE "/\.(claude|codex)-plugin/plugin\.json$" || true)"
+  [ -z "$content" ] && continue
+
+  # Each existing plugin.json must be staged alongside the content change
+  for pj in "$base/.claude-plugin/plugin.json" "$base/.codex-plugin/plugin.json"; do
+    [ -f "$pj" ] || continue
+    printf '%s\n' "$staged" | grep -qxF "$pj" ||
+      errors+=("$name: content changed but $pj was not updated (bump its \"version\")")
+  done
+done
+
+if [ "${#errors[@]}" -gt 0 ]; then
+  echo "Plugin version check failed:" >&2
+  for e in "${errors[@]}"; do echo "  - $e" >&2; done
+  echo "Update the plugin.json version(s) above, re-stage, and commit again." >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ The pre-commit hook runs quality checks on staged files:
   - Code formatting check (rustfmt)
   - Linter checks (clippy)
 - **PKL files (*.pkl)**: Validates configuration syntax
+- **Plugin sources (`plugins/**`)**: Runs `mise run plugins:check-version`, which blocks the commit when a plugin's content (skills, agents, etc.) changes without also updating its `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` (i.e. bumping the `version`).
 
 If any check fails, the commit will be blocked. Fix the issues and try again.
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,6 +15,13 @@ local linters = new Mapping<String, Step> {
         glob = "*.pkl"
         check = "pkl eval {{files}} >/dev/null"
     }
+
+    // Plugin distribution version guard: if a plugin's content changes,
+    // its .claude-plugin / .codex-plugin plugin.json must be updated too.
+    ["plugin_version"] = new Step {
+        glob = "plugins/**/*"
+        check = "mise run plugins:check-version"
+    }
 }
 
 hooks {


### PR DESCRIPTION
## Summary

Adds an `hk` pre-commit step that blocks a commit when a plugin's content (skills, agents, etc.) under `plugins/<name>/` changes **without** also updating its `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json`.

Claude and Codex plugin distributions are versioned per-plugin and were bumped by hand on every content change; forgetting to bump them (or bumping only one of the two files) was easy to miss in review. This turns it into an enforced check.

Changes:
- **`hk.pkl`**: new `plugin_version` step (`glob = "plugins/**/*"`, `check = "mise run plugins:check-version"`)
- **`.mise-tasks/plugins/check-version`**: bash task holding the detection logic
- **`CONTRIBUTING.md`**: documents the new pre-commit check

## Related Issues

_None_

## Additional Notes

- **Detection is intentionally simple**: it only flags a plugin whose content is staged while its existing `plugin.json` is **not** re-staged, and skips `plugin.json`-only commits. It does not parse/compare the version number — bumping the version naturally puts the file in the diff.
- **Asymmetry handled**: `mcp-server` is Claude-only, so its missing `.codex-plugin/plugin.json` is skipped automatically.
- **Why a script instead of pure hk config**: hk has no declarative "co-change" rule (its `condition` only gates whether a step runs), so the comparison has to live in a `check` command. It is extracted into a mise task to keep `hk.pkl` a one-liner and to allow `mise run plugins:check-version` for manual debugging.
- **Verified**: content-only change → blocked; content + both plugin.json bumped → passes; plugin.json-only → passes; content + only one side bumped → blocked. Also confirmed end-to-end via `hk run pre-commit`.