### PR TITLE
chore(plugins): bump scraps plugin to 0.1.8

### DIFF
--- a/plugins/scraps/.claude-plugin/plugin.json
+++ b/plugins/scraps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Official AI skills and agents bundle for Scraps. Workflows for ingesting sources, querying the wiki, applying the default Scraps LLM Wiki schema, and running purpose-driven lint via the scraps CLI.",
   "author": {
     "name": "boykush",

--- a/plugins/scraps/.codex-plugin/plugin.json
+++ b/plugins/scraps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scraps",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Official AI skills bundle for Scraps. Use this plugin when a user wants to ingest sources into a Scraps wiki, query existing scraps, synthesize wiki-backed answers, or understand the Karpathy-style Ingest / Query / Lint workflow model through the scraps CLI.",
   "author": {
     "name": "boykush",


### PR DESCRIPTION
## Summary
Catch-up version bump for the `scraps` plugin: `0.1.7` → `0.1.8` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.

## Why
`a40fe56` (`fix(ingest): require links to resolve and stay source-faithful`) changed `plugins/scraps/skills/ingest/SKILL.md` without bumping the plugin version — it merged before the plugin version guard (#585) was in place, so the guard never caught it. This bump brings the published version in line with the current skill content.

Per repo convention every `scraps` content change is a +0.0.1 patch bump (the prior ingest fixes went 0.1.5 → 0.1.6 → 0.1.7), so this is 0.1.7 → 0.1.8.

## Scope
- `scraps` only. `scraps-migration` and `mcp-server` also have pre-guard content drift (v1-rewrite-era README / `.mcp.json` edits) but are intentionally left out of this catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
