### PR TITLE
ci: resolve all zizmor findings to unblock the audit workflow

### DIFF
--- a/.github/workflows/cargo-test-and-lint.yml
+++ b/.github/workflows/cargo-test-and-lint.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
-    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         cache: false
         install_args: "rust"
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
-    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         cache: false
         install_args: "rust cargo:cargo-deny"

--- a/.github/workflows/claude-review-from-author.yml
+++ b/.github/workflows/claude-review-from-author.yml
@@ -21,11 +21,11 @@ jobs:
           persist-credentials: false
 
       - name: Review PR from Specific Author
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
+        timeout-minutes: 60
+        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1.0.153
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          timeout_minutes: "60"
-          direct_prompt: |
+          prompt: |
             Please provide a thorough review of this pull request.
 
             Since this is from a specific author that requires careful review,

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: false
           install_args: "rust"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,12 +24,12 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup mise (install scraps)
-      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         cache: false
         install_args: "github:boykush/scraps"
     - name: Setup Node.js
-      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         working_directory: ./tests/e2e
         install_args: "node"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: false
           install_args: "rust"

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,14 @@ runs:
         # action is run via a local path (uses: ./), so fall back to boykush/scraps.
         REPO="${ACTION_REPOSITORY:-boykush/scraps}"
         URL="https://github.com/${REPO}/releases/download/v${VERSION}/scraps-${TARGET}.tar.gz"
-        DEST="${RUNNER_TEMP}/scraps"
-        mkdir -p "$DEST"
+        WORKDIR="${RUNNER_TEMP}/scraps"
+        mkdir -p "$WORKDIR"
         echo "Downloading scraps v${VERSION} (${TARGET}) from ${URL}"
-        curl -fsSL "$URL" | tar xz -C "$DEST"
-        echo "$DEST" >> "$GITHUB_PATH"
+        curl -fsSL "$URL" | tar xz -C "$WORKDIR"
+        # Install into /usr/local/bin (already on PATH for GitHub-hosted Linux/macOS
+        # runners) instead of appending to $GITHUB_PATH, which the github-env audit
+        # flags as a code-execution risk.
+        sudo install -m 0755 "$WORKDIR/scraps" /usr/local/bin/scraps
 
     - name: Verify installation
       shell: bash


### PR DESCRIPTION
## Summary

The Terraform-managed **zizmor** workflow runs in plain mode (fails the job on *any* finding). Since `52a661f` re-added it to `main`, the zizmor check has been red. This PR fixes every reported finding so the audit passes.

| File(s) | Audit | Fix |
|---------|-------|-----|
| `action.yml` | `github-env` (high) | Install the `scraps` binary into `/usr/local/bin` (already on PATH for GitHub-hosted Linux/macOS runners) instead of appending to `$GITHUB_PATH`, which zizmor flags as a code-execution vector. |
| `cargo-test-and-lint.yml`, `performance.yml`, `playwright.yml`, `release.yml` | `ref-version-mismatch` (×6) | Correct the `jdx/mise-action` version comment to `# v4.1.0` so it matches the pinned SHA. **SHA pin unchanged.** |
| `claude-review-from-author.yml` | `known-vulnerable-actions` (CVE-2026-47751) | Bump `anthropics/claude-code-action` from `# beta` to `v1.0.153` (`>= 1.0.74` is patched) and migrate inputs to v1. |

## Related Issues

<!-- none -->

## Additional Notes

- **Verified locally** with the exact image CI uses (`ghcr.io/zizmorcore/zizmor` v1.25.2), online audits enabled, full tree → `No findings to report`, exit 0.
- **`action.yml`**: GitHub-hosted Linux/macOS runners both provide passwordless `sudo` and have `/usr/local/bin` on PATH, so the new `sudo install` is functionally equivalent to the old `$GITHUB_PATH` append. The release tarball ships the `scraps` binary at its top level (`taiki-e/upload-rust-binary-action` + Homebrew `bin.install "scraps"`).
- **claude-code-action v1 migration**: `direct_prompt` → `prompt`; the removed `timeout_minutes` input is replaced by a step-level `timeout-minutes: 60` to preserve the original cap.
- The `zizmor.yml` workflow itself is Terraform-managed (`boykush/github-management`) and intentionally untouched — all fixes are in the scraps-owned files it audits.