### PR TITLE
chore(deps): bump anyhow to 1.0.103 and crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.92"
 version = "1.0.1"
 path = "modules/libs"
 [workspace.dependencies]
-anyhow = "=1.0.102"
+anyhow = "=1.0.103"
 thiserror = "=2.0.18"
 url = { version = "=2.5.8", features = ["serde"] }
 itertools = "=0.14.0"


### PR DESCRIPTION
## Summary

The `deny` (cargo-deny) CI check is currently failing on **every** open PR because two new RustSec advisories flag dependencies in `Cargo.lock`. The `build`/test job passes — the red check is `advisories`, not the test suite. This PR bumps both crates past their fixed versions to get CI green again:

- **RUSTSEC-2026-0190** — `anyhow < 1.0.103`: unsoundness in `Error::downcast_mut()` (UB when mutating context added via `Error::context`). Fixed in `1.0.103`.
- **RUSTSEC-2026-0204** — `crossbeam-epoch < 0.9.20`: invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`. Fixed in `0.9.20`.

## Related Issues

<!-- none -->

## Additional Notes

- `anyhow` is a direct workspace dependency pinned with `=`, so the pin is bumped in `Cargo.toml` (`=1.0.102` → `=1.0.103`) alongside `Cargo.lock`.
- `crossbeam-epoch` is a transitive dependency (via `crossbeam-deque` ← `ignore`/`rayon-core`), so it is updated in `Cargo.lock` only.
- Both are semver-patch releases with no public API changes, and the lockfile diff is limited to these two version + checksum bumps — no new transitive dependencies, so `licenses`/`bans`/`sources` are unaffected.
- The `deny` job will validate the advisory fix on CI (the sandbox this was prepared in blocks the crate download CDN, so a local `cargo deny` run wasn't possible).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4XsK9ofxzrpebVYmtkyuD)_