### PR TITLE
ci: pin action version comments to exact tags

### DIFF
--- a/.github/workflows/cargo-test-and-lint.yml
+++ b/.github/workflows/cargo-test-and-lint.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1

--- a/.github/workflows/claude-review-from-author.yml
+++ b/.github/workflows/claude-review-from-author.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # For scraps git committed date
           persist-credentials: false
@@ -32,10 +32,10 @@ jobs:
         run: scraps build --directory docs
 
       - name: Configure Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/_site
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -40,7 +40,7 @@ jobs:
       
       - name: Comment PR
         if: always()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_DURATION: ${{ steps.build.outputs.duration }}
           BUILD_STATUS: ${{ steps.build.outputs.status }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - name: Setup mise (install scraps)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
     permissions:
       contents: write # upload release assets
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
@@ -138,7 +138,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -176,7 +176,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Run setup-scraps action


### PR DESCRIPTION
<!-- 🙏 Thanks for your contribution! -->

## Summary

zizmor が全ワークフロー実行で落ちていたのを修正します。`ref-version-mismatch` が 10 件、すべて `actions/checkout` でした。

pin 自体は正しく、`actions/checkout` は `df4cb1c`（= **v6.0.3**）に固定されていましたが、末尾コメントが `# v6` というメジャータグ表記でした。上流で v6.1.0 がリリースされて `v6` タグが `d23441a` へ移動した結果、「コメントが指すコミット ≠ pin されている SHA」となり zizmor が検出しました。**このリポジトリ側は何も変えていないのに、上流のタグ移動だけで CI が赤くなる**状態です。

各 digest が実際に指しているタグ名をコメントに書くことで解消しました（zizmor 自身の auto-fix と同じ方針）。**digest は 1 つも変更していない**ため、ワークフローは完全に同一のアクションコードを実行します。

```diff
- uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
```

あわせて、メジャーのみのコメントが残っていた 5 つのアクションも同様に修正しました。これらは「たまたま今メジャータグが pin 先を指している」だけで通っており、上流が次の minor を切った瞬間に同じ落ち方をします。

| アクション | 変更 |
|---|---|
| `actions/github-script` | `# v9` → `# v9.0.0` |
| `taiki-e/upload-rust-binary-action` | `# v1` → `# v1.30.2` |
| `actions/configure-pages` | `# v6` → `# v6.0.0` |
| `actions/upload-pages-artifact` | `# v5` → `# v5.0.0` |
| `actions/deploy-pages` | `# v5` → `# v5.0.0` |

## Related Issues

<!-- なし -->

## Additional Notes

**検証**

- CI と同じ `zizmor 1.28.0 --persona=regular` をローカル実行し `No findings to report` を確認
- 全 pin のコメントが実在タグと一致することを GitHub API で照合（11 件すべて一致）
- 変更ファイル 7 件すべてで digest 一覧が変更前後で不変であることを確認。差分はコメント文字列と、2 ファイルの行末改行追加（zizmor の書き換えによる副産物）のみ

**`zizmor.yml` に触れていない理由**

[.github/workflows/zizmor.yml](.github/workflows/zizmor.yml) は Terraform (`boykush/github-management`) が配布するファイルで、直接編集すると次の `terraform apply` で上書きされます。もともと `# v7.0.0` `# v0.5.7` と正確なバージョンを使っており、今回の修正はこのテンプレート側の流儀に揃えた形です。

**レビュー時の注意: #609 との関係**

renovate の #609（`actions/checkout` を v7.0.1 へ）は、差分を見るとコメントを `# v7` とメジャーのみで書いています。このままマージすると同じ再発の種が戻るため、マージ前に `# v7.0.1` へ直すことをおすすめします。なお本 PR は digest を据え置いているのでバージョン更新自体は競合せず、引き続き renovate 側に任せられます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)