### PR TITLE
feat(mcp): serve over Streamable HTTP so one server backs every repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Scraps - AI skills, migration workflows, and MCP integration for interconnected Markdown documentation",
-    "version": "1.2.3"
+    "version": "1.2.4"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +456,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -844,8 +864,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1559,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1569,7 +1601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1682,6 +1714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,7 +1727,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1699,7 +1748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1710,6 +1759,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1803,19 +1858,27 @@ checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2103,7 +2166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2174,6 +2237,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2258,7 +2334,7 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -2597,6 +2673,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ tracing = "=0.1.44"
 tracing-subscriber = "=0.3.23"
 clap-verbosity-flag = "=3.0.4"
 indicatif = "=0.18.4"
-rmcp = { version = "=1.7.0", features = ["server"] }
+rmcp = { version = "=1.7.0", features = [
+    "server",
+    "transport-streamable-http-server",
+] }
 schemars = "=1.2.1"
 rstest = "=0.26.1"
 tempfile = "=3.27.0"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Scraps reads `[[wiki-link]]`, `#[[tag]]`, `![[embed]]`, `[[Page#heading]]`, and 
 CLI + JSON is the primary path — any shell-capable agent can query Scraps without an MCP client implementation. Bundled plugins provide agent-facing workflows:
 
 - [`scraps`](plugins/scraps) — Karpathy-style *Ingest / Query / Lint* skills for Claude Code and Codex, plus Claude Code agents for purpose-driven lint and the default Scraps LLM Wiki schema
-- [`mcp-server`](plugins/mcp-server) — MCP server for MCP-compatible clients
+- [`mcp-server`](plugins/mcp-server) — MCP server for MCP-compatible clients, shared across repositories via `scraps mcp serve --http`
 
 See the [AI integration guide](https://boykush.github.io/scraps/scraps/how-to/integrate-with-ai-assistants.html) for the trade-offs.
 

--- a/design/v1/vision.md
+++ b/design/v1/vision.md
@@ -51,7 +51,7 @@ explicit design decision, not an emergent property.
 | **CLI** | Primary agent integration. Deterministic, typed primitives. Read-centric. `--json` is a first-class output. | `build`, `lint`, `get --json`, `search --json`, `log`, `todo --json` |
 | **Skill** | LLM-driven workflows. Authoring (write) lives here. Bundled and distributed *pup*-style as official AI-facing docs. | ingest, query, file-back |
 | **Core libs** | Trait-based plugin points. | `GitCommand`, future `MetadataProvider` |
-| **MCP** | De-emphasized in narrative; code is kept. v1 does not deprecate the existing `scraps mcp serve` / `plugins/mcp-server/`; v2+ revisits. | (kept as-is) |
+| **MCP** | De-emphasized in narrative; code is kept. v1 does not deprecate the existing `scraps mcp serve` / `plugins/mcp-server/`; v2+ revisits. | `mcp serve`, `mcp serve --http` (loopback only) |
 
 CLI + JSON is the agent-integration primary path because shell + JSON is the
 half-century-old contract: every agent that can run a shell can use it, no MCP

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -54,20 +54,42 @@ have everything in one place.
 ## MCP (for MCP-compatible clients)
 
 Scraps ships an MCP server for clients that prefer the Model Context
-Protocol. The server is bundled as a plugin so installation and tool
-specifications stay together:
+Protocol. It serves over stdio by default, or over Streamable HTTP with
+`--http` so a single process can back every repository on your machine:
+
+```bash
+❯ scraps -C ~/path/to/your/wiki mcp serve --http
+```
+
+This listens on `127.0.0.1:1113` and serves MCP at
+`http://127.0.0.1:1113/mcp`. Every repository points its client at that one
+URL, so the wiki path is configured once — on the server — instead of in
+each repository. One process serves one wiki; run a second process on
+another port to serve another.
+
+The server is bundled as a plugin so installation and tool specifications
+stay together:
 
 <https://github.com/boykush/scraps/tree/main/plugins/mcp-server>
 
-To wire the MCP server into Claude Code manually without the plugin:
+To register the running server with Claude Code manually, without the
+plugin:
 
 ```bash
-claude mcp add scraps -- scraps -C ~/path/to/your/wiki mcp serve
+❯ claude mcp add --transport http scraps http://127.0.0.1:1113/mcp
+```
+
+For a single repository, stdio needs nothing running — the client spawns
+Scraps itself:
+
+```bash
+❯ claude mcp add scraps -- scraps -C ~/path/to/your/wiki mcp serve
 ```
 
 Replace `~/path/to/your/wiki` with the directory containing `.scraps.toml`.
 
 For most read-shaped agent workflows, the CLI + JSON path above is simpler:
-no long-running process, no MCP client implementation required, works with
+nothing to keep running, no MCP client implementation required, works with
 any shell-capable agent. MCP is the right choice when your agent already
-expects MCP tools as its integration surface.
+expects MCP tools as its integration surface, and `--http` is the right
+transport when several repositories share one wiki.

--- a/docs/Reference/CLI Overview.md
+++ b/docs/Reference/CLI Overview.md
@@ -17,7 +17,7 @@ the authoritative reference for flags and arguments. This page is the
 | `scraps tag list` | List all tags with backlink counts | ✓ |
 | `scraps tag backlinks <tag>` | Scraps referencing a tag | ✓ |
 | `scraps todo` | Aggregate GFM task list items wiki-wide | ✓ |
-| `scraps mcp serve` | Start an MCP server | – |
+| `scraps mcp serve` | Start an MCP server over stdio, or `--http` | – |
 
 `-C` / `--directory` (or `SCRAPS_DIRECTORY` env) runs as if started in the
 given directory.

--- a/plugins/mcp-server/.claude-plugin/plugin.json
+++ b/plugins/mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-server",
-  "version": "1.1.0",
-  "description": "MCP server for Scraps - Manage interconnected Markdown documentation with Wiki-link notation",
+  "version": "2.0.0",
+  "description": "MCP server for Scraps - Connect to a locally running scraps MCP server (scraps mcp serve --http) to browse and search interconnected Markdown documentation with Wiki-link notation",
   "author": {
     "name": "boykush",
     "email": "boykush315@gmail.com"

--- a/plugins/mcp-server/.mcp.json
+++ b/plugins/mcp-server/.mcp.json
@@ -1,11 +1,8 @@
 {
   "mcpServers": {
     "scraps": {
-      "command": "scraps",
-      "args": ["mcp", "serve"],
-      "env": {
-        "SCRAPS_DIRECTORY": "${SCRAPS_DIRECTORY:-.}"
-      }
+      "type": "http",
+      "url": "${SCRAPS_MCP_URL:-http://127.0.0.1:1113/mcp}"
     }
   }
 }

--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -2,17 +2,37 @@
 
 MCP server for browsing and searching [Scraps](https://github.com/boykush/scraps) wikis.
 
-This plugin packages `scraps mcp serve` as a Claude Code plugin so MCP-compatible clients can call Scraps tools directly. For most read-shaped agent workflows the simpler path is `scraps <cmd> --json` via the shell — see the [`scraps` plugin](../scraps/README.md) for the bundled CLI + JSON skills.
+This plugin points MCP-compatible clients at a locally running `scraps mcp serve --http`, so Scraps tools can be called from any repository on your machine. For most read-shaped agent workflows the simpler path is `scraps <cmd> --json` via the shell — see the [`scraps` plugin](../scraps/README.md) for the bundled CLI + JSON skills.
+
+```text
+ scraps -C ~/wiki mcp serve --http    ← one local server, holds the wiki
+        │  /mcp
+        ├── repo A  (mcp-server plugin)
+        ├── repo B  (mcp-server plugin)
+        └── repo C  (mcp-server plugin)
+```
+
+One server backs every repo: no per-repo wiki path, no MCP subprocess per client. The wiki is read per request, so edits are served live.
 
 ## Install
 
-### Step 1: Add the marketplace
+### Step 1: Run the server
+
+From anywhere, pointing at the directory that contains `.scraps.toml` (one long-running process):
+
+```bash
+scraps -C ~/path/to/your/wiki mcp serve --http
+```
+
+It listens on `127.0.0.1:1113` and serves MCP at `http://127.0.0.1:1113/mcp`. Pass an address to `--http` to use a different port or host.
+
+### Step 2: Add the marketplace
 
 ```bash
 claude plugin marketplace add boykush/scraps
 ```
 
-### Step 2: Enable the plugin
+### Step 3: Enable the plugin
 
 Add this to your project's `.claude/settings.json`:
 
@@ -24,18 +44,16 @@ Add this to your project's `.claude/settings.json`:
 }
 ```
 
-The plugin uses the current directory as the Scraps wiki root. To target a different wiki, set `SCRAPS_DIRECTORY`:
+## Configuration
 
-```json
-{
-  "env": {
-    "SCRAPS_DIRECTORY": "/path/to/your/wiki"
-  },
-  "enabledPlugins": {
-    "mcp-server@scraps-claude-code-plugins": true
-  }
-}
+The plugin connects to `http://127.0.0.1:1113/mcp`. To point at another address — a different port, or a second wiki served by its own process — set `SCRAPS_MCP_URL` before launching your agent:
+
+```bash
+scraps -C ~/path/to/another/wiki mcp serve --http 127.0.0.1:1114
+export SCRAPS_MCP_URL=http://127.0.0.1:1114/mcp
 ```
+
+One process serves one wiki. The server binds loopback with no authentication; it is not meant to be exposed to a network.
 
 ## MCP tools
 
@@ -117,13 +135,21 @@ Returns: `{ results: [{ title, ctx }], count }`.
 
 ## Manual setup (without the plugin)
 
-For other MCP-compatible clients, run the server directly:
+Register the shared server with any MCP-compatible client:
+
+```bash
+claude mcp add --transport http scraps http://127.0.0.1:1113/mcp
+```
+
+### stdio (no server to run)
+
+For a single repository, the client can spawn `scraps mcp serve` as a subprocess instead:
 
 ```bash
 claude mcp add scraps -- scraps -C ~/path/to/your/wiki mcp serve
 ```
 
-Replace `~/path/to/your/wiki` with the directory containing `.scraps.toml`.
+Replace `~/path/to/your/wiki` with the directory containing `.scraps.toml`. stdio needs that path per repository, so — unlike the shared HTTP URL — it cannot ship as a turnkey plugin config. Plugin versions before 2.0.0 bundled this stdio setup; if you relied on it, either start the server (see [Install](#install)) or add the command above.
 
 ## Further reading
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -204,10 +204,23 @@ pub enum TagSubCommands {
     },
 }
 
+/// Loopback IPv4 rather than `localhost`, which resolves to `::1` first on some
+/// systems and would leave IPv4 clients unable to connect.
+const DEFAULT_MCP_HTTP_ADDR: &str = "127.0.0.1:1113";
+
 #[derive(Subcommand)]
 pub enum McpSubCommands {
-    #[command(about = "Start MCP server with stdio transport")]
-    Serve,
+    #[command(about = "Start MCP server with stdio transport, or Streamable HTTP with --http")]
+    Serve {
+        #[arg(
+            long,
+            value_name = "ADDR",
+            num_args = 0..=1,
+            default_missing_value = DEFAULT_MCP_HTTP_ADDR,
+            help = "Serve over Streamable HTTP at this address instead of stdio; the MCP endpoint is <addr>/mcp"
+        )]
+        http: Option<String>,
+    },
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -1,39 +1,58 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{
     cli::config::scrap_config::ScrapConfig,
     cli::path_resolver::PathResolver,
     error::{McpError, ScrapsResult},
-    mcp::server::ScrapsServer,
+    mcp::{self, server::ScrapsServer},
 };
 use rmcp::ServiceExt;
 use tokio::io::{stdin, stdout};
+use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
-    // Initialize tracing
+pub async fn run(project_path: Option<&Path>, http_addr: Option<&str>) -> ScrapsResult<()> {
+    init_tracing()?;
+
+    let (scraps_dir, exclude_dirs) = resolve_dirs(project_path)?;
+
+    match http_addr {
+        Some(addr) => serve_http(addr, scraps_dir, exclude_dirs).await,
+        None => serve_stdio(scraps_dir, exclude_dirs).await,
+    }
+}
+
+/// Logs go to stderr because the stdio transport owns stdout for JSON-RPC.
+fn init_tracing() -> ScrapsResult<()> {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::INFO)
+        .with_writer(std::io::stderr)
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|e| McpError::TracingSetup(e.to_string()))?;
+    Ok(())
+}
 
-    info!("Starting Scraps MCP server...");
-
-    // Set up path resolver. The wiki root is the directory containing
-    // `.scraps.toml` (i.e. the project root). Config is loaded only to resolve
-    // the configured `output_dir` so it can be excluded from scrap traversal.
+/// Resolve the wiki root. The root is the directory containing `.scraps.toml`
+/// (i.e. the project root). Config is loaded only to resolve the configured
+/// `output_dir` so it can be excluded from scrap traversal.
+fn resolve_dirs(project_path: Option<&Path>) -> ScrapsResult<(PathBuf, Vec<PathBuf>)> {
     let path_resolver = PathResolver::new(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to resolve paths: {e}")))?;
     let config = ScrapConfig::from_path(project_path)
         .map_err(|e| McpError::ServiceError(format!("Failed to load config: {e}")))?;
 
-    let scraps_dir = path_resolver.scraps_dir();
     let exclude_dirs = vec![
         path_resolver.static_dir(),
         path_resolver.output_dir(&config),
     ];
+
+    Ok((path_resolver.scraps_dir(), exclude_dirs))
+}
+
+async fn serve_stdio(scraps_dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> ScrapsResult<()> {
+    info!("Starting Scraps MCP server...");
 
     let service = ScrapsServer::new(scraps_dir, exclude_dirs)
         .serve((stdin(), stdout()))
@@ -47,5 +66,37 @@ pub async fn run(project_path: Option<&Path>) -> ScrapsResult<()> {
         .waiting()
         .await
         .map_err(|e| McpError::ServiceError(e.to_string()))?;
+    Ok(())
+}
+
+async fn serve_http(
+    addr: &str,
+    scraps_dir: PathBuf,
+    exclude_dirs: Vec<PathBuf>,
+) -> ScrapsResult<()> {
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| McpError::Bind(format!("{addr}: {e}")))?;
+
+    // Report the bound address rather than the requested one: a hostname can
+    // resolve to an address family the client does not use.
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| McpError::Bind(format!("{addr}: {e}")))?;
+    info!(
+        "Scraps MCP server listening on http://{local_addr}{} (wiki: {})",
+        mcp::http::ENDPOINT_PATH,
+        scraps_dir.display()
+    );
+
+    let service = mcp::http::build_service(scraps_dir, exclude_dirs);
+    tokio::select! {
+        result = mcp::http::serve(listener, service) => {
+            result.map_err(|e| McpError::ServiceError(e.to_string()))?;
+        }
+        _ = tokio::signal::ctrl_c() => {
+            info!("Shutting down Scraps MCP server");
+        }
+    }
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,4 +90,7 @@ pub enum McpError {
 
     #[error("Failed to create tokio runtime: {0}")]
     RuntimeCreation(String),
+
+    #[error("Failed to bind MCP server to {0}")]
+    Bind(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,10 +81,10 @@ fn main() -> error::ScrapsResult<()> {
             cli::cmd::todo::run(status.into(), json, directory, &mut std::io::stdout())
         }
         cli::SubCommands::Mcp { mcp_command } => match mcp_command {
-            cli::McpSubCommands::Serve => {
+            cli::McpSubCommands::Serve { http } => {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|e| McpError::RuntimeCreation(e.to_string()))?;
-                runtime.block_on(cli::cmd::mcp::serve::run(directory))
+                runtime.block_on(cli::cmd::mcp::serve::run(directory, http.as_deref()))
             }
         },
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,3 +1,4 @@
+pub mod http;
 pub mod json;
 pub mod server;
 mod tools;

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -1,0 +1,214 @@
+use std::convert::Infallible;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
+use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
+use tokio::net::TcpListener;
+
+use crate::mcp::server::ScrapsServer;
+
+/// Path the MCP endpoint is served at, relative to the bind address.
+pub const ENDPOINT_PATH: &str = "/mcp";
+
+type McpService = StreamableHttpService<ScrapsServer, NeverSessionManager>;
+
+/// Build the MCP service in stateless mode, so one long-running process can
+/// back any number of clients without retaining per-client sessions. The cost
+/// is server-initiated notifications, which the read-only tools never send.
+pub fn build_service(scraps_dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> McpService {
+    StreamableHttpService::new(
+        move || Ok(ScrapsServer::new(scraps_dir.clone(), exclude_dirs.clone())),
+        Arc::new(NeverSessionManager::default()),
+        StreamableHttpServerConfig::default()
+            .with_stateful_mode(false)
+            .with_json_response(true),
+    )
+}
+
+pub async fn serve(listener: TcpListener, service: McpService) -> std::io::Result<()> {
+    let service = Arc::new(service);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+        let service = service.clone();
+
+        tokio::spawn(async move {
+            let handler = service_fn(move |request| route(service.clone(), request));
+            if let Err(err) = http1::Builder::new().serve_connection(io, handler).await {
+                tracing::debug!("Failed to serve MCP connection: {err:?}");
+            }
+        });
+    }
+}
+
+/// rmcp handles any path it is given, so the endpoint is routed here.
+async fn route(
+    service: Arc<McpService>,
+    request: Request<Incoming>,
+) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    if request.uri().path() != ENDPOINT_PATH {
+        return Ok(not_found());
+    }
+
+    Ok(service.handle(request).await)
+}
+
+fn not_found() -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Full::new(Bytes::from_static(b"Not Found")).boxed())
+        .expect("valid response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use http_body_util::{BodyExt, Full};
+    use hyper::header::{ACCEPT, CONTENT_TYPE, HOST};
+    use hyper::{Method, Request, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use rstest::rstest;
+    use std::net::SocketAddr;
+    use tokio::net::TcpStream;
+    use tokio::task::JoinHandle;
+
+    async fn spawn_server(
+        project: &TempScrapProject,
+    ) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let service = build_service(
+            project.scraps_dir.clone(),
+            vec![project.static_dir.clone(), project.output_dir.clone()],
+        );
+
+        (addr, tokio::spawn(serve(listener, service)))
+    }
+
+    async fn post(addr: SocketAddr, path: &str, body: serde_json::Value) -> (StatusCode, String) {
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let (mut sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+            .await
+            .unwrap();
+        tokio::spawn(connection);
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(path)
+            .header(HOST, addr.to_string())
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
+            .body(Full::new(Bytes::from(body.to_string())))
+            .unwrap();
+
+        let response = sender.send_request(request).await.unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_list_tools(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, body) = post(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let response: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let tools = response["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 6);
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_initialize(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, body) = post(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": serde_json::to_value(rmcp::model::ClientInfo::default()).unwrap(),
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let response: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            response["result"]["instructions"],
+            "This is a Scraps MCP server"
+        );
+        assert!(response["result"]["capabilities"]["tools"].is_object());
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_search_scraps(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("test.md", b"# Test Scrap\n\nContent here");
+
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, body) = post(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "search_scraps", "arguments": {"query": "test"}},
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let response: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let text = response["result"]["content"][0]["text"].as_str().unwrap();
+        let result: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(result["count"].as_u64().unwrap() > 0);
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_unknown_path_returns_not_found(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, _) = post(
+            addr,
+            "/",
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        server_handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary

`scraps mcp serve` only spoke stdio, so every repository that wanted to read a wiki spawned its own subprocess and configured the wiki path locally. This adds `--http`, so one long-running process holds the wiki and any number of clients connect to `<addr>/mcp` — the same pattern [boykush/livt](https://github.com/boykush/livt) uses for its discovery master.

```text
 scraps -C ~/wiki mcp serve --http    ← one local server, holds the wiki
        │  /mcp
        ├── repo A  (mcp-server plugin)
        ├── repo B  (mcp-server plugin)
        └── repo C  (mcp-server plugin)
```

- **CLI**: `scraps mcp serve --http [ADDR]`, defaulting to `127.0.0.1:1113`. Without the flag, stdio is unchanged.
- **Plugin**: `mcp-server` now points at `${SCRAPS_MCP_URL:-http://127.0.0.1:1113/mcp}` (2.0.0); stdio moves to the README's manual setup.
- **Docs**: the How-to explains when HTTP is the right transport, with CLI + JSON still the primary agent path.

## Additional Notes

**Breaking for existing `mcp-server` installs.** Without a running server the MCP entry is dead, hence the major bump. The README documents both the migration and the stdio fallback. Note this repository's own `.claude/settings.json` enables the plugin, so local MCP use here now needs `scraps -C docs mcp serve --http`.

**Design decisions worth a look:**

- *Stateless + JSON response* (`with_stateful_mode(false)`, `with_json_response(true)`): a process meant to live for weeks retains nothing per client, and the read-only tools never needed server-initiated notifications. Same choice livt made.
- *Default host is `127.0.0.1`, not `localhost`*: `localhost` resolves to `::1` first on macOS — verified that `--http localhost:1113` really binds `[::1]:1113`. The startup log reports the bound address rather than the requested one for that reason.
- *No new HTTP stack*: rmcp's `StreamableHttpService::handle()` is an inherent method, so it plugs into the same hyper accept loop `scraps serve` already uses. No axum, no tower. rmcp handles any path it is given, so `/mcp` is routed in `src/mcp/http.rs`.
- *Drive-by fix*: tracing wrote to stdout, interleaving log lines into the stdio transport's JSON-RPC stream. It now writes to stderr.
- Graceful shutdown is Ctrl-C stopping the accept loop; in-flight connections are not drained (a full drain would promote `tokio-util` to a normal dependency).

**Verification**

- `mise run cargo:quality` ✅ and `mise run cargo:deny` (advisories / bans / licenses / sources ok)
- 4 new medium tests bind `127.0.0.1:0` and drive the endpoint with a hyper client — no new dev-dependency (rmcp's streamable-HTTP client would pull reqwest + rustls + aws-lc-sys)
- Manual: `tools/list` returns the 6 tools, `search_scraps` queries `docs/`, a non-`/mcp` path returns 404, SIGINT shuts down cleanly, and stdio still emits pure JSON-RPC on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)