### PR TITLE
feat!: remove the deprecated -p/--path flag

### DIFF
--- a/design/v1/vision.md
+++ b/design/v1/vision.md
@@ -217,8 +217,8 @@ under that directory is a scrap; `ctx` is the relative path.
   / `.mise.toml` up the tree), scraps does not search upward — the compose
   motivation does not exist for documentation.
 - **`-C` / `--directory`** replaces `-p` / `--path` (#510), aligning with
-  `git -C`, `make -C`, `pnpm -C`. The old flag stays as a deprecated alias for
-  one release.
+  `git -C`, `make -C`, `pnpm -C`. The old flag stayed as a deprecated alias for
+  one release and was removed in v1.1.
 - **`output_dir`** defaults to `_site/` instead of `public/` (#508), aligning
   with Jekyll / Hakyll and avoiding ctx collisions with a `public/` directory
   in the source tree.

--- a/docs/Reference/Configuration.md
+++ b/docs/Reference/Configuration.md
@@ -97,6 +97,6 @@ and run commands with `-C`:
 Each `.scraps.toml` is its own independent wiki — they do not cross-link, and
 each builds to its own `output_dir`.
 
-The old `-p` / `--path` flag is still accepted as a deprecated alias for one
-release. Prefer `-C` / `--directory` or the `SCRAPS_DIRECTORY` environment
-variable.
+The old `-p` / `--path` flag and `SCRAPS_PROJECT_PATH` were removed in v1.1
+after one deprecated release. Use `-C` / `--directory` or the
+`SCRAPS_DIRECTORY` environment variable.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,37 +26,8 @@ pub struct Cli {
     )]
     pub directory: Option<PathBuf>,
 
-    #[arg(
-        short = 'p',
-        long = "path",
-        global = true,
-        env = "SCRAPS_PROJECT_PATH",
-        value_name = "DIR",
-        hide = true,
-        help = "[DEPRECATED] Use -C/--directory instead. Will be removed in v1.1."
-    )]
-    pub path: Option<PathBuf>,
-
     #[command(subcommand)]
     pub command: SubCommands,
-}
-
-impl Cli {
-    /// Resolve the effective working directory, preferring `-C/--directory`.
-    ///
-    /// Emits a deprecation warning to stderr when `-p/--path` (or
-    /// `SCRAPS_PROJECT_PATH`) is used.
-    pub fn resolve_directory<'a>(
-        directory: Option<&'a std::path::Path>,
-        path: Option<&'a std::path::Path>,
-    ) -> Option<&'a std::path::Path> {
-        if path.is_some() {
-            eprintln!(
-                "warning: -p/--path (and SCRAPS_PROJECT_PATH) is deprecated and will be removed in v1.1. Use -C/--directory (or SCRAPS_DIRECTORY) instead."
-            );
-        }
-        directory.or(path)
-    }
 }
 
 #[derive(Subcommand)]
@@ -292,39 +263,5 @@ impl From<CliLintRuleName> for LintRuleName {
             CliLintRuleName::BrokenHeadingRef => LintRuleName::BrokenHeadingRef,
             CliLintRuleName::StaleByGit => LintRuleName::StaleByGit,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn resolve_directory_prefers_directory_over_path() {
-        let directory = PathBuf::from("/dir");
-        let path = PathBuf::from("/path");
-        let resolved = Cli::resolve_directory(Some(&directory), Some(&path));
-        assert_eq!(resolved, Some(Path::new("/dir")));
-    }
-
-    #[test]
-    fn resolve_directory_falls_back_to_path_when_directory_absent() {
-        let path = PathBuf::from("/path");
-        let resolved = Cli::resolve_directory(None, Some(&path));
-        assert_eq!(resolved, Some(Path::new("/path")));
-    }
-
-    #[test]
-    fn resolve_directory_uses_directory_when_path_absent() {
-        let directory = PathBuf::from("/dir");
-        let resolved = Cli::resolve_directory(Some(&directory), None);
-        assert_eq!(resolved, Some(Path::new("/dir")));
-    }
-
-    #[test]
-    fn resolve_directory_returns_none_when_both_absent() {
-        let resolved = Cli::resolve_directory(None, None);
-        assert_eq!(resolved, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,8 @@ use clap::Parser;
 use error::McpError;
 
 fn main() -> error::ScrapsResult<()> {
-    let cli::Cli {
-        directory,
-        path,
-        command,
-    } = cli::Cli::parse();
-    let directory = cli::Cli::resolve_directory(directory.as_deref(), path.as_deref());
+    let cli::Cli { directory, command } = cli::Cli::parse();
+    let directory = directory.as_deref();
 
     match command {
         cli::SubCommands::Init => cli::cmd::init::run(directory),


### PR DESCRIPTION
## Summary

v1.0 shipped `-p` / `--path` and `SCRAPS_PROJECT_PATH` as deprecated aliases of `-C` / `--directory`, with the help text and the runtime warning both promising removal in v1.1. This removes them on schedule, ahead of the v1.1.0 release.

- `src/cli.rs` — drops the `path` field and `Cli::resolve_directory` (the flag was the only reason it existed), along with its four tests
- `src/main.rs` — reads `directory` directly
- `docs/Reference/Configuration.md` and `design/v1/vision.md` — state that the alias was removed in v1.1 rather than "accepted for one release"

## Additional Notes

**BREAKING CHANGE**: `scraps -p <dir>` now fails with `error: unexpected argument '-p' found`, and `SCRAPS_PROJECT_PATH` is ignored. Use `-C` / `--directory` or `SCRAPS_DIRECTORY`.

The v0 → v1 migration skill (`plugins/scraps-migration`) already tells users to rewrite these, so it needed no change.

Verified with `mise run cargo:quality` (502 tests, fmt, clippy) plus a manual check that `-C` still works and `-p` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)