### PR TITLE
v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "1.0.1"
+version = "1.1.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "1.0.1"
+version = "1.1.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "1.0.1"
+version = "1.1.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
## Summary

Version bump to 1.1.0 ahead of the release: `Cargo.toml`, `modules/libs/Cargo.toml`, and `Cargo.lock`.

## Additional Notes

The `/release-tag-create` skill pushes this commit straight to `main`, but the branch now rejects that (`GH013: Changes must be made through a pull request`, plus required `build` / `zizmor` checks), so it goes through a PR instead. Once merged, `v1.1.0` gets tagged on the resulting `main` commit and the GitHub Release follows.

Contents of the release (v1.0.1...v1.1.0): the Streamable HTTP MCP server (#613), removal of the deprecated `-p`/`--path` flag (#614), the ingest skill fixes, and the accumulated dependency updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)