### PR TITLE
docs(release): match release commands to main's branch rules

### DIFF
--- a/.claude/commands/release-create.md
+++ b/.claude/commands/release-create.md
@@ -1,6 +1,6 @@
 ---
 description: Create a GitHub Release for an existing git tag
-allowed-tools: ["Bash(git tag:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(gh pr view:*)", "Bash(gh api:*)", "Read", "Grep"]
+allowed-tools: ["Bash(git tag:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git fetch:*)", "Bash(git merge-base:*)", "Bash(gh pr view:*)", "Bash(gh api:*)", "Bash(gh release create:*)", "Bash(gh release view:*)", "Bash(gh run list:*)", "Bash(gh run view:*)", "Bash(gh run watch:*)", "Read", "Grep"]
 ---
 
 Create a GitHub Release for the Scraps project using the following workflow:
@@ -10,9 +10,11 @@ Create a GitHub Release for the Scraps project using the following workflow:
 
 **Workflow**:
 
-1. **Verify tag exists**:
+1. **Verify tag exists and points at main**:
    - Check if tag `v$ARGUMENTS` exists with `git tag --list v$ARGUMENTS`
    - If tag doesn't exist, inform user to run `/release-tag-create` first
+   - Check the tag is an ancestor of main: `git fetch origin main` then `git merge-base --is-ancestor v$ARGUMENTS origin/main`
+   - If it isn't, stop: the tag must be deleted (`git push origin :refs/tags/v$ARGUMENTS`) and recreated on main via `/release-tag-create`
 
 2. **Find previous version tag**:
    - Get sorted list of tags: `git tag --sort=-v:refname`
@@ -71,6 +73,8 @@ Create a GitHub Release for the Scraps project using the following workflow:
 8. **Verify**:
    - Confirm release creation with `gh release view v$ARGUMENTS`
    - Display release URL
+   - Follow the triggered workflow: `gh run list --workflow=release.yml --limit 1`, then `gh run watch <run_id> --exit-status`
+   - Report each job: `publish-crate`, `update-homebrew`, and `update-floating-tags` run after `build` and can fail independently, leaving the release half-published
 
 **Usage**: `/release-create 0.27.0`
 
@@ -81,7 +85,8 @@ Create a GitHub Release for the Scraps project using the following workflow:
 ```
 
 **Notes**:
-- This command requires that the git tag already exists (created by `/release-tag-create`)
+- This command requires that the git tag already exists (created by `/release-tag-create`) and is an ancestor of main
+- Creating the Release triggers the crates.io publish, the homebrew-tap update, and the floating v{major}/v{major}.{minor} tag moves (see `.github/workflows/release.yml`); a tag off main would ship a build that is not on main
 - The version format should be semver without 'v' prefix in arguments
 - Release notes are automatically generated from PR information
 - User confirmation is required before creating the GitHub Release

--- a/.claude/commands/release-tag-create.md
+++ b/.claude/commands/release-tag-create.md
@@ -1,6 +1,6 @@
 ---
 description: Create a release tag with version bump
-allowed-tools: ["Bash(git branch:*)", "Bash(git stash:*)", "Bash(git checkout:*)", "Bash(git pull:*)", "Bash(git status:*)", "Bash(git add:*)", "Bash(git commit:*)", "Bash(git tag:*)", "Read", "Edit"]
+allowed-tools: ["Bash(git branch:*)", "Bash(git stash:*)", "Bash(git checkout:*)", "Bash(git fetch:*)", "Bash(git pull:*)", "Bash(git status:*)", "Bash(git log:*)", "Bash(git add:*)", "Bash(git commit:*)", "Bash(git push:*)", "Bash(git tag:*)", "Bash(git merge-base:*)", "Bash(mise run cargo:build)", "Bash(gh pr create:*)", "Bash(gh pr checks:*)", "Bash(gh pr view:*)", "Read", "Edit"]
 ---
 
 Create a release tag for the Scraps project using the following workflow:
@@ -10,34 +10,43 @@ Create a release tag for the Scraps project using the following workflow:
 
 **Workflow**:
 
-1. **Verify current branch is main**:
+1. **Create a release branch from up-to-date main**:
    - Check current branch with `git branch --show-current`
    - If not on main, stash changes with `git stash` and checkout main with `git checkout main`
    - Pull latest changes with `git pull`
+   - Create the release branch: `git checkout -b release/v$ARGUMENTS`
+   - Never commit the version bump on main: main rejects direct pushes
 
 2. **Update version in Cargo.toml files**:
-   - Update `version = "X.Y.Z"` in `/Cargo.toml` (replace all occurrences)
+   - Update `version = "X.Y.Z"` in `/Cargo.toml` (two occurrences: `[workspace.package]` and `[workspace.dependencies.scraps_libs]`)
    - Update `version = "X.Y.Z"` in `/modules/libs/Cargo.toml`
+   - Run `mise run cargo:build` so `Cargo.lock` picks up both `scraps` and `scraps_libs`
 
-3. **Commit version bump**:
+3. **Commit version bump and push the branch**:
    - Add all changed files: `Cargo.toml`, `Cargo.lock`, `modules/libs/Cargo.toml`
    - Commit with message format: `v$ARGUMENTS` (e.g., "v0.27.0")
    - Include Claude Code attribution in commit body
+   - Push the branch: `git push -u origin release/v$ARGUMENTS`
 
-4. **Request confirmation before push**:
-   - Show the commit details
-   - Ask user to confirm before proceeding with push
+4. **Open the release PR**:
+   - `gh pr create --base main --title "v$ARGUMENTS" --body "<summary>"`
+   - Show the PR URL to the user
 
-5. **Push commit to remote** (requires user approval):
-   - Push to origin main: `git push`
+5. **Wait for required checks and merge**:
+   - Watch required checks with `gh pr checks --watch` (`build` and `zizmor`)
+   - main also requires an approving review, and the agent cannot approve or merge its own PR: ask the user to merge
+   - Do not continue until `gh pr view --json state,mergedAt` reports the PR as `MERGED`
 
-6. **Create and push git tag**:
+6. **Tag the merged commit** (only after the merge is confirmed):
+   - `git checkout main && git pull`
+   - Verify `version` in `Cargo.toml` matches `$ARGUMENTS` and `git log -1 --oneline` is the merged version bump
    - Create tag: `git tag v$ARGUMENTS`
    - Request confirmation before pushing tag
    - Push tag: `git push origin v$ARGUMENTS` (requires user approval)
 
 7. **Verify**:
    - Confirm tag creation with `git tag --sort=-v:refname | head -5`
+   - Confirm the tag is on main with `git merge-base --is-ancestor v$ARGUMENTS origin/main`
 
 **Usage**: `/release-tag-create 0.27.0`
 
@@ -48,8 +57,8 @@ Create a release tag for the Scraps project using the following workflow:
 ```
 
 **Notes**:
-- This command should only be run from main branch
-- Ensure all changes for the release are already merged to main
+- The version bump must go through a PR: main blocks direct pushes and requires the `build` and `zizmor` checks plus a review approval
+- Never create or push the tag before the PR is merged; a tag that is not an ancestor of main has to be deleted with `git push origin :refs/tags/v$ARGUMENTS` and recreated
 - The version format should be semver without 'v' prefix in arguments
 - Tag will be created with 'v' prefix (e.g., v0.27.0)
-- User confirmation is required before pushing commits and tags
+- User confirmation is required before pushing the tag: publishing a GitHub Release from it triggers the crates.io publish, the homebrew-tap update, and the floating v{major}/v{major}.{minor} tag moves (see `.github/workflows/release.yml`)


### PR DESCRIPTION
## Summary

Fixes the `/release-tag-create` and `/release-create` command definitions, which no longer described a workflow that works against main's current ruleset.

**`/release-tag-create`** told the agent to commit the version bump on main and `git push` it. During the v1.1.0 release that push was rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "build" is expected.
remote: - Required status check "zizmor" is expected.
```

The tag step then ran anyway, so `v1.1.0` briefly pointed at a commit that was not an ancestor of main and had to be deleted and recreated. The workflow is now **branch → PR → user merge → tag**, with the tag step explicitly gated on `gh pr view --json state,mergedAt` reporting `MERGED`. Step 2 also spells out the two `version` occurrences in `/Cargo.toml` and adds `mise run cargo:build` so `Cargo.lock` picks up both `scraps` and `scraps_libs`.

**`/release-create`** verified nothing about where the tag pointed, and stopped at "release created". It now checks the tag is an ancestor of main before creating the Release, and follows the triggered workflow to completion.

Both `allowed-tools` lists were missing tools their own steps already call (`git push`, `gh release create`/`view`); those are added along with the new `gh` and `mise` commands.

## Related Issues

Follow-up to the v1.1.0 release (#615).

## Additional Notes

Wording was checked against the live repo rather than assumed:

- The `main` ruleset requires exactly two status checks, `build` and `zizmor` (PRs also run `deny` and `Scraps Build Performance Test`, which are **not** required).
- `required_approving_review_count: 1`, with admin bypass set to `bypass_mode: pull_request` — which is why a direct push is rejected but the owner could merge #615 with no reviews. Hence the step 5 wording "the agent cannot approve or merge its own PR: ask the user to merge".

The new "follow the workflow run" step in `/release-create` is not hypothetical — tracking the v1.1.0 run surfaced a real failure that the old steps would have missed:

| Job | Result |
| --- | --- |
| Build ×5, `publish-crate`, `update-floating-tags` | ✅ (crates.io at 1.1.0, `v1`/`v1.1` moved) |
| `update-homebrew` | ❌ `Invalid username or token` pushing to homebrew-tap |

**`HOMEBREW_COMMITTER_TOKEN` appears to be expired** — the formula is still on 1.0.1, so v1.1.0 is published everywhere except `brew`. That needs the secret rotated and `gh run rerun 30692154152 --failed`; it is not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)