### PR TITLE
Automerge non-major cargo updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,20 @@
       "rangeStrategy": "pin"
     },
     {
+      "description": "Automerge non-major cargo updates once required CI passes. The gate is the required check `build` (cargo-test-and-lint.yml), which covers every Cargo change since nothing Cargo-related is in its paths-ignore. Majors stay manual: they have consistently needed code changes (tera v2 reworked the Tera::new() signature and dropped Tera::context). addLabels is mandatory alongside automerge — this repository requires one approving review and Renovate cannot approve its own PR, so renovate-runner's approve-bot-prs workflow keys off the automerge label. Without the label no approval arrives and automerge waits forever.",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "addLabels": [
+        "automerge"
+      ]
+    },
+    {
       "groupName": "Rust toolchain",
       "matchManagers": [
         "mise"


### PR DESCRIPTION
## Summary

A sweep across every Renovate PR in this owner turned up a clean split in this repository: non-major cargo updates always sail through, majors always need code. This hands the non-major half to automerge and leaves majors manual.

The record over the last four weeks:

| Update type | PRs | Outcome |
| --- | --- | --- |
| non-major | 20 | all merged, none needed a fix |
| major | 4 | all failed — `tera` v2, `rmcp` v3 and `comfy-table` v8 are still red, `rmcp` v2 was autoclosed |

Every major failure is an API break rather than a flake. `tera` v2 reworked the `Tera::new()` signature and dropped `Tera::context`, so `search_index_tera.rs`, `css_tera.rs` and `index_tera.rs` all stop compiling.

## Additional Notes

**Gate.** The required check `build` (`cargo-test-and-lint.yml`) — nothing Cargo-related sits in its `paths-ignore`, so it runs on every cargo update. Renovate's own automerge additionally waits for the whole branch status to go green, which pulls `Scraps Build Performance Test` and `deny` into the gate as well.

**Placement.** `.github/renovate.json` rather than the runner's `config.js`, since cargo is specific to this repository — a global cargo rule would be dead config everywhere else.

**`addLabels` is not optional.** This repository requires one approving review and Renovate cannot approve its own PR. The approving App keys off the `automerge` label, so dropping it would leave automerge waiting forever.

Verify after merge with a debug run — INFO level prints no automerge decisions at all:

```
gh workflow run renovate.yml --repo boykush/renovate-runner -f logLevel=debug
```

Look for `PR is configured for automerge`, `Branch status green` and `PR automerged` against a cargo branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
