### PR TITLE
fix(build): make tag ordering deterministic across builds

### DIFF
--- a/modules/libs/src/model/tags.rs
+++ b/modules/libs/src/model/tags.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use super::{scrap::Scrap, tag::Tag};
 
@@ -6,12 +6,16 @@ use super::{scrap::Scrap, tag::Tag};
 /// occurrences across all scraps. Hierarchical tags are auto-aggregated:
 /// a `#[[a/b/c]]` occurrence implicitly creates `a/b` and `a` as well
 /// (Logseq-style).
+///
+/// Ordered rather than hashed so iteration is reproducible across builds:
+/// generated sites are committed to git, and a randomly seeded set turned
+/// every build into a diff.
 #[derive(PartialEq, Debug, Clone)]
-pub struct Tags(HashSet<Tag>);
+pub struct Tags(BTreeSet<Tag>);
 
 impl IntoIterator for Tags {
     type Item = Tag;
-    type IntoIter = std::collections::hash_set::IntoIter<Tag>;
+    type IntoIter = std::collections::btree_set::IntoIter<Tag>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -23,7 +27,7 @@ impl Tags {
     /// declarations and folding in their proper ancestors for hierarchical
     /// tags.
     pub fn new(scraps: &[Scrap]) -> Tags {
-        let mut all = HashSet::new();
+        let mut all = BTreeSet::new();
         for scrap in scraps {
             for tag in scrap.tags() {
                 all.insert(tag.clone());
@@ -35,7 +39,7 @@ impl Tags {
         Tags(all)
     }
 
-    pub fn iter(&self) -> std::collections::hash_set::Iter<'_, Tag> {
+    pub fn iter(&self) -> std::collections::btree_set::Iter<'_, Tag> {
         self.0.iter()
     }
 
@@ -120,6 +124,31 @@ mod tests {
                 "a/b/d".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn it_iterates_in_tag_order_regardless_of_scrap_order() {
+        // Regression: a hashed set iterated in a per-instance random order,
+        // which leaked into generated HTML and made builds non-reproducible.
+        let scraps = [
+            Scrap::new("s1", &None, "#[[delta]]"),
+            Scrap::new("s2", &None, "#[[charlie]]"),
+            Scrap::new("s3", &None, "#[[bravo]] #[[bravo/nested]]"),
+            Scrap::new("s4", &None, "#[[alpha]]"),
+        ];
+        let expected = vec!["alpha", "bravo", "bravo/nested", "charlie", "delta"];
+
+        let observed: Vec<String> = Tags::new(&scraps).iter().map(|t| t.to_string()).collect();
+        assert_eq!(observed, expected);
+
+        // Same tags, different declaration order, and repeated construction:
+        // all must agree.
+        let reversed: [Scrap; 4] = std::array::from_fn(|i| scraps[3 - i].clone());
+        for _ in 0..100 {
+            let observed: Vec<String> =
+                Tags::new(&reversed).iter().map(|t| t.to_string()).collect();
+            assert_eq!(observed, expected);
+        }
     }
 
     #[test]

--- a/src/usecase/build/html/serde/tag.rs
+++ b/src/usecase/build/html/serde/tag.rs
@@ -4,7 +4,7 @@ use scraps_libs::{model::tag::Tag, slugify};
 #[derive(serde::Serialize, Clone, PartialEq, Debug)]
 pub struct TagTera {
     /// Full hierarchical tag path for display, e.g. `ai/ml`.
-    title: String,
+    pub title: String,
     /// Slug-form path with each segment slugified, joined by `/`.
     /// Used to build the tag's HTML URL: `/tags/<slug>.html`.
     slug: String,

--- a/src/usecase/build/html/serde/tags.rs
+++ b/src/usecase/build/html/serde/tags.rs
@@ -14,7 +14,72 @@ impl TagsTera {
             .clone()
             .into_iter()
             .map(|tag| TagTera::new(&tag, backlinks_map));
-        let sorted = stags.sorted_by_key(|s| s.backlinks_count).rev();
+        // Title breaks ties so the order is total: index pages slice the top-N
+        // tags, and an arbitrary tie-break would reshuffle them between builds.
+        let sorted = stags.sorted_by(|a, b| {
+            b.backlinks_count
+                .cmp(&a.backlinks_count)
+                .then_with(|| a.title.cmp(&b.title))
+        });
         TagsTera(sorted.collect_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scraps_libs::model::scrap::Scrap;
+
+    fn titles(stags: &TagsTera) -> Vec<&str> {
+        stags.0.iter().map(|s| s.title.as_str()).collect()
+    }
+
+    fn tags_tera(scraps: &[Scrap]) -> TagsTera {
+        TagsTera::new(&Tags::new(scraps), &BacklinksMap::new(scraps))
+    }
+
+    #[test]
+    fn it_orders_by_backlinks_count_desc_then_title_asc() {
+        // `delta`..`alpha` all tie at 1 backlink and are declared in reverse
+        // alphabetical order, so insertion order cannot be what breaks the tie.
+        let scraps = [
+            Scrap::new("s1", &None, "#[[popular]] #[[delta]]"),
+            Scrap::new("s2", &None, "#[[popular]] #[[charlie]]"),
+            Scrap::new("s3", &None, "#[[popular]] #[[bravo]]"),
+            Scrap::new("s4", &None, "#[[alpha]]"),
+        ];
+
+        assert_eq!(
+            titles(&tags_tera(&scraps)),
+            vec!["popular", "alpha", "bravo", "charlie", "delta"]
+        );
+    }
+
+    #[test]
+    fn it_orders_tied_tags_the_same_way_on_every_build() {
+        // Regression: `Tags` used to be a HashSet, whose per-instance random
+        // seed made tied tags swap places between builds and produced noisy
+        // diffs in committed sites.
+        let scraps = [
+            Scrap::new("s1", &None, "#[[delta]]"),
+            Scrap::new("s2", &None, "#[[charlie]]"),
+            Scrap::new("s3", &None, "#[[bravo]]"),
+            Scrap::new("s4", &None, "#[[alpha]]"),
+        ];
+
+        let first = tags_tera(&scraps);
+        for _ in 0..100 {
+            assert_eq!(titles(&tags_tera(&scraps)), titles(&first));
+        }
+    }
+
+    #[test]
+    fn it_orders_hierarchical_tags_by_full_path() {
+        let scraps = [
+            Scrap::new("s1", &None, "#[[ai/ml]]"),
+            Scrap::new("s2", &None, "#[[ai/agent]]"),
+        ];
+
+        assert_eq!(titles(&tags_tera(&scraps)), vec!["ai", "ai/agent", "ai/ml"]);
     }
 }


### PR DESCRIPTION
## Summary

`scraps build` was non-deterministic: tags with the same `backlinks_count` were ordered arbitrarily, so building the same wiki twice produced different HTML.

Two things combined to cause it:

- [`modules/libs/src/model/tags.rs`](https://github.com/boykush/scraps/blob/96bef42322a6fdddaef77067095481e377b5c92c/modules/libs/src/model/tags.rs) — `Tags` wrapped a `HashSet<Tag>`. Rust's default hasher is randomly seeded, so iteration order changed between runs.
- [`src/usecase/build/html/serde/tags.rs`](https://github.com/boykush/scraps/blob/96bef42322a6fdddaef77067095481e377b5c92c/src/usecase/build/html/serde/tags.rs) — `sorted_by_key(|s| s.backlinks_count)` is a stable sort, so it preserved that random order for ties.

Index pages render the top 15 tags via `tag_links(..., slice_size = 15)`. When two tags tie at the cutoff, which one appears flipped between builds — a noisy diff on every build for anyone committing their generated site.

The fix works at two levels:

1. **`Tags` is backed by a `BTreeSet`.** `Tag` already derived `Ord`, so this was a drop-in swap. Iteration is now reproducible for every consumer, not just the one that happened to surface the bug.
2. **`TagsTera` sorts by a total key** — `(backlinks_count desc, title asc)`. Worth noting the old `.rev()` was doubly wrong: besides preserving the arbitrary order, it *reversed* ties. An explicit descending comparator replaces it.

## Related Issues

<!-- none -->

## Additional Notes

**Regression tests.** Four added, each mutation-checked — I reverted the fix and confirmed every one fails without it:

- `it_iterates_in_tag_order_regardless_of_scrap_order` — reverses scrap order and rebuilds 100×. Under `HashSet` it failed immediately with `["charlie", "delta", "alpha", ...]`.
- `it_orders_by_backlinks_count_desc_then_title_asc` — ties are declared in reverse-alphabetical order, so insertion order cannot be what sorts them.
- `it_orders_tied_tags_the_same_way_on_every_build` — this one reproduces the bug at unit level: two `TagsTera` builds *in the same process* disagreed. Each `HashSet` instance gets its own seed, so the randomness is per-instance, not merely per-process.
- `it_orders_hierarchical_tags_by_full_path` — ties among hierarchical tags break on full path, not leaf name.

**Verification.** I built a pre-fix binary and a fixed one and compared them on 749 real scraps:

| | run1 vs run2 | run1 vs run3 |
|---|---|---|
| pre-fix | 20 files differ | 20 files differ |
| fixed | identical | identical |

The pre-fix diffs are exactly the `tag-links` block (e.g. "Data Engineering" ↔ "Cloud Native", both at 41 backlinks). I also built a synthetic wiki with a deliberate three-way tie straddling the top-15 cutoff — byte-identical across 5 runs after the fix.

**Build time** is unchanged: 0.18–0.19s before and after on the same 749-scrap wiki, well under the 3s budget. The `BTreeSet` swap costs nothing at this scale.

**One API change:** `TagTera::title` became `pub` so the comparator can read it. This matches `backlinks_count`, which was already `pub` for the same reason.

**Caveat on the benchmark:** I could not run the real perf test against a `boykush/wiki` checkout — the local one has no `.scraps.toml`. I copied its markdown into a scratch project with a synthetic config instead. Committed dates are absent there (no git repo), which does not affect the ordering comparison but makes the timing a slight under-estimate of a full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
