### PR TITLE
feat(mcp): add --allowed-host to serve behind a reverse proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -67,6 +67,21 @@ URL, so the wiki path is configured once — on the server — instead of in
 each repository. One process serves one wiki; run a second process on
 another port to serve another.
 
+Only loopback `Host` headers are accepted by default, which is what stops
+DNS rebinding attacks against a server running on your machine. Reaching
+it through a reverse proxy or tunnel under a real hostname means naming
+that hostname:
+
+```bash
+❯ scraps -C ~/path/to/your/wiki mcp serve --http 0.0.0.0:1113 \
+    --allowed-host mcp.example.com
+```
+
+`--allowed-host` is repeatable, and it adds to the loopback default rather
+than replacing it, so a port-forward or a local `curl` still reaches the
+same process. Scraps itself has no authentication: whatever can reach the
+endpoint can read the wiki, so the access control belongs in the proxy.
+
 The server is bundled as a plugin so installation and tool specifications
 stay together:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,6 +191,14 @@ pub enum McpSubCommands {
             help = "Serve over Streamable HTTP at this address instead of stdio; the MCP endpoint is <addr>/mcp"
         )]
         http: Option<String>,
+
+        #[arg(
+            long = "allowed-host",
+            value_name = "HOST",
+            requires = "http",
+            help = "Accept this Host header in addition to the loopback default, for serving behind a reverse proxy or tunnel; repeatable"
+        )]
+        allowed_host: Vec<String>,
     },
 }
 

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -12,13 +12,17 @@ use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-pub async fn run(project_path: Option<&Path>, http_addr: Option<&str>) -> ScrapsResult<()> {
+pub async fn run(
+    project_path: Option<&Path>,
+    http_addr: Option<&str>,
+    allowed_hosts: Vec<String>,
+) -> ScrapsResult<()> {
     init_tracing()?;
 
     let (scraps_dir, exclude_dirs) = resolve_dirs(project_path)?;
 
     match http_addr {
-        Some(addr) => serve_http(addr, scraps_dir, exclude_dirs).await,
+        Some(addr) => serve_http(addr, scraps_dir, exclude_dirs, allowed_hosts).await,
         None => serve_stdio(scraps_dir, exclude_dirs).await,
     }
 }
@@ -73,6 +77,7 @@ async fn serve_http(
     addr: &str,
     scraps_dir: PathBuf,
     exclude_dirs: Vec<PathBuf>,
+    allowed_hosts: Vec<String>,
 ) -> ScrapsResult<()> {
     let listener = TcpListener::bind(addr)
         .await
@@ -89,7 +94,7 @@ async fn serve_http(
         scraps_dir.display()
     );
 
-    let service = mcp::http::build_service(scraps_dir, exclude_dirs);
+    let service = mcp::http::build_service(scraps_dir, exclude_dirs, allowed_hosts);
     tokio::select! {
         result = mcp::http::serve(listener, service) => {
             result.map_err(|e| McpError::ServiceError(e.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,14 @@ fn main() -> error::ScrapsResult<()> {
             cli::cmd::todo::run(status.into(), json, directory, &mut std::io::stdout())
         }
         cli::SubCommands::Mcp { mcp_command } => match mcp_command {
-            cli::McpSubCommands::Serve { http } => {
+            cli::McpSubCommands::Serve { http, allowed_host } => {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|e| McpError::RuntimeCreation(e.to_string()))?;
-                runtime.block_on(cli::cmd::mcp::serve::run(directory, http.as_deref()))
+                runtime.block_on(cli::cmd::mcp::serve::run(
+                    directory,
+                    http.as_deref(),
+                    allowed_host,
+                ))
             }
         },
     }

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -22,13 +22,30 @@ type McpService = StreamableHttpService<ScrapsServer, NeverSessionManager>;
 /// Build the MCP service in stateless mode, so one long-running process can
 /// back any number of clients without retaining per-client sessions. The cost
 /// is server-initiated notifications, which the read-only tools never send.
-pub fn build_service(scraps_dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> McpService {
+pub fn build_service(
+    scraps_dir: PathBuf,
+    exclude_dirs: Vec<PathBuf>,
+    allowed_hosts: Vec<String>,
+) -> McpService {
+    let config = StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_json_response(true);
+
+    // Extend rmcp's loopback default instead of replacing it, so a port-forward
+    // or local curl still reaches a server published under a public hostname.
+    // The list is never empty, which rmcp would read as "allow any host".
+    let allowed_hosts = config
+        .allowed_hosts
+        .iter()
+        .cloned()
+        .chain(allowed_hosts)
+        .collect::<Vec<_>>();
+    let config = config.with_allowed_hosts(allowed_hosts);
+
     StreamableHttpService::new(
         move || Ok(ScrapsServer::new(scraps_dir.clone(), exclude_dirs.clone())),
         Arc::new(NeverSessionManager::default()),
-        StreamableHttpServerConfig::default()
-            .with_legacy_session_mode(false)
-            .with_json_response(true),
+        config,
     )
 }
 
@@ -84,17 +101,34 @@ mod tests {
     async fn spawn_server(
         project: &TempScrapProject,
     ) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
+        spawn_server_with_allowed_hosts(project, vec![]).await
+    }
+
+    async fn spawn_server_with_allowed_hosts(
+        project: &TempScrapProject,
+        allowed_hosts: Vec<String>,
+    ) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let service = build_service(
             project.scraps_dir.clone(),
             vec![project.static_dir.clone(), project.output_dir.clone()],
+            allowed_hosts,
         );
 
         (addr, tokio::spawn(serve(listener, service)))
     }
 
     async fn post(addr: SocketAddr, path: &str, body: serde_json::Value) -> (StatusCode, String) {
+        post_with_host(addr, path, &addr.to_string(), body).await
+    }
+
+    async fn post_with_host(
+        addr: SocketAddr,
+        path: &str,
+        host: &str,
+        body: serde_json::Value,
+    ) -> (StatusCode, String) {
         let stream = TcpStream::connect(addr).await.unwrap();
         let (mut sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
             .await
@@ -104,7 +138,7 @@ mod tests {
         let request = Request::builder()
             .method(Method::POST)
             .uri(path)
-            .header(HOST, addr.to_string())
+            .header(HOST, host)
             .header(CONTENT_TYPE, "application/json")
             .header(ACCEPT, "application/json, text/event-stream")
             .body(Full::new(Bytes::from(body.to_string())))
@@ -189,6 +223,70 @@ mod tests {
         let text = response["result"]["content"][0]["text"].as_str().unwrap();
         let result: serde_json::Value = serde_json::from_str(text).unwrap();
         assert!(result["count"].as_u64().unwrap() > 0);
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_unconfigured_host_is_forbidden(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, _) = post_with_host(
+            addr,
+            ENDPOINT_PATH,
+            "mcp.example.com",
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_configured_host_is_allowed(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let (addr, server_handle) =
+            spawn_server_with_allowed_hosts(&project, vec!["mcp.example.com".to_string()]).await;
+
+        let (status, _) = post_with_host(
+            addr,
+            ENDPOINT_PATH,
+            "mcp.example.com",
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        server_handle.abort();
+    }
+
+    /// The flag extends the loopback default instead of replacing it, so a
+    /// port-forward keeps reaching a server published under a public hostname.
+    #[rstest]
+    #[tokio::test]
+    async fn test_loopback_still_allowed_alongside_configured_host(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let (addr, server_handle) =
+            spawn_server_with_allowed_hosts(&project, vec!["mcp.example.com".to_string()]).await;
+
+        let (status, _) = post_with_host(
+            addr,
+            ENDPOINT_PATH,
+            &addr.to_string(),
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
 
         server_handle.abort();
     }


### PR DESCRIPTION
Closes #647

## Summary

`scraps mcp serve --http` could not be reached under its real hostname through a reverse proxy or tunnel: since the [GHSA-89vp-x53w-74fx](https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx) fix, rmcp validates the `Host` header against a loopback-only allowlist, and that list was not configurable.

```bash
scraps mcp serve --http 0.0.0.0:1113 --allowed-host mcp.example.com
```

The flag is repeatable and accepts either a bare hostname or `host:port`.

## Decisions from the issue

Both open questions were resolved the way the issue leaned:

- **Extends, does not replace.** The configured hosts are appended to rmcp's loopback default, so a `port-forward` or a local `curl` still reaches the same process that answers under the public hostname. `test_loopback_still_allowed_alongside_configured_host` pins this.
- **`disable_allowed_hosts()` is not exposed.** There is no escape hatch flag. Because the default entries are always present, the list handed to rmcp is never empty — which rmcp would otherwise interpret as "allow any host".

`--allowed-host` is declared `requires = "http"`, so passing it to the stdio transport is a parse error rather than a silent no-op.

## Changes

- `src/cli.rs` — repeatable `--allowed-host <HOST>` on `mcp serve`
- `src/cli/cmd/mcp/serve.rs`, `src/main.rs` — thread the list to `serve_http`
- `src/mcp/http.rs` — `build_service` extends the allowlist
- `docs/How-to/Integrate with AI Assistants.md` — document the flag, and note that Scraps has no authentication of its own so access control belongs in the proxy

## Testing

Three tests added in `src/mcp/http.rs` (unconfigured host → 403, configured host → 200, loopback still 200 alongside a configured host). `mise run cargo:quality` passes.

Also verified against a running server:

| `Host` | Result |
|---|---|
| `a.example.com` (configured) | 200 |
| `b.example.com:8443` (configured with port) | 200 |
| `b.example.com` (port entry, no port sent) | 403 |
| `z.example.com` | 403 |
| `127.0.0.1:<port>` (loopback default) | 200 |

## Note

`plugins/mcp-server/README.md` still says the server "binds loopback ... not meant to be exposed to a network". That stays accurate for the plugin's local setup, and editing it would require a plugin version bump, so it is left out of this PR — happy to fold it in if you'd rather it be reworded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)