### PR TITLE
feat(mcp): add --allowed-host for serving behind a proxy

### DIFF
--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -67,6 +67,26 @@ URL, so the wiki path is configured once — on the server — instead of in
 each repository. One process serves one wiki; run a second process on
 another port to serve another.
 
+### Behind a proxy or tunnel
+
+The HTTP transport accepts only loopback `Host` headers, which is what keeps
+a browser on a visited page from reaching a server bound to your machine. A
+reverse proxy or tunnel forwarding under its own hostname is refused with
+`403 Forbidden: Host header is not allowed`, so name that hostname when
+starting the server:
+
+```bash
+❯ scraps -C ~/path/to/your/wiki mcp serve --http 0.0.0.0:1113 \
+    --allowed-host wiki.example.com
+```
+
+Repeat `--allowed-host` for each hostname. Loopback stays allowed either
+way, so a port-forward or a local `curl` against the same process keeps
+working. Naming the hostname here is preferable to having the proxy rewrite
+`Host`: the allowlist stays as narrow as the deployment actually needs, and
+it stays next to the server it applies to rather than in proxy
+configuration.
+
 The server is bundled as a plugin so installation and tool specifications
 stay together:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,6 +191,14 @@ pub enum McpSubCommands {
             help = "Serve over Streamable HTTP at this address instead of stdio; the MCP endpoint is <addr>/mcp"
         )]
         http: Option<String>,
+
+        #[arg(
+            long = "allowed-host",
+            value_name = "HOST",
+            requires = "http",
+            help = "Accept this Host header in addition to loopback; repeat for more. Needed when a proxy forwards under its own hostname"
+        )]
+        allowed_host: Vec<String>,
     },
 }
 

--- a/src/cli/cmd/mcp/serve.rs
+++ b/src/cli/cmd/mcp/serve.rs
@@ -12,13 +12,17 @@ use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-pub async fn run(project_path: Option<&Path>, http_addr: Option<&str>) -> ScrapsResult<()> {
+pub async fn run(
+    project_path: Option<&Path>,
+    http_addr: Option<&str>,
+    allowed_hosts: &[String],
+) -> ScrapsResult<()> {
     init_tracing()?;
 
     let (scraps_dir, exclude_dirs) = resolve_dirs(project_path)?;
 
     match http_addr {
-        Some(addr) => serve_http(addr, scraps_dir, exclude_dirs).await,
+        Some(addr) => serve_http(addr, scraps_dir, exclude_dirs, allowed_hosts).await,
         None => serve_stdio(scraps_dir, exclude_dirs).await,
     }
 }
@@ -73,6 +77,7 @@ async fn serve_http(
     addr: &str,
     scraps_dir: PathBuf,
     exclude_dirs: Vec<PathBuf>,
+    allowed_hosts: &[String],
 ) -> ScrapsResult<()> {
     let listener = TcpListener::bind(addr)
         .await
@@ -89,7 +94,11 @@ async fn serve_http(
         scraps_dir.display()
     );
 
-    let service = mcp::http::build_service(scraps_dir, exclude_dirs);
+    if !allowed_hosts.is_empty() {
+        info!("Also accepting Host: {}", allowed_hosts.join(", "));
+    }
+
+    let service = mcp::http::build_service(scraps_dir, exclude_dirs, allowed_hosts);
     tokio::select! {
         result = mcp::http::serve(listener, service) => {
             result.map_err(|e| McpError::ServiceError(e.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,14 @@ fn main() -> error::ScrapsResult<()> {
             cli::cmd::todo::run(status.into(), json, directory, &mut std::io::stdout())
         }
         cli::SubCommands::Mcp { mcp_command } => match mcp_command {
-            cli::McpSubCommands::Serve { http } => {
+            cli::McpSubCommands::Serve { http, allowed_host } => {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|e| McpError::RuntimeCreation(e.to_string()))?;
-                runtime.block_on(cli::cmd::mcp::serve::run(directory, http.as_deref()))
+                runtime.block_on(cli::cmd::mcp::serve::run(
+                    directory,
+                    http.as_deref(),
+                    &allowed_host,
+                ))
             }
         },
     }

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -19,16 +19,37 @@ pub const ENDPOINT_PATH: &str = "/mcp";
 
 type McpService = StreamableHttpService<ScrapsServer, NeverSessionManager>;
 
+/// rmcp's own default allowlist, repeated because `with_allowed_hosts` replaces
+/// the list rather than extending it. An entry without a port matches any port.
+const LOOPBACK_HOSTS: [&str; 3] = ["localhost", "127.0.0.1", "::1"];
+
 /// Build the MCP service in stateless mode, so one long-running process can
 /// back any number of clients without retaining per-client sessions. The cost
 /// is server-initiated notifications, which the read-only tools never send.
-pub fn build_service(scraps_dir: PathBuf, exclude_dirs: Vec<PathBuf>) -> McpService {
+///
+/// `allowed_hosts` names the Host headers to accept on top of loopback, for
+/// servers reached through a proxy under its own hostname. Host validation is
+/// what stops DNS rebinding, so this extends the allowlist rather than lifting
+/// it — and loopback stays in regardless, because a deployed server is still
+/// reached directly when something needs debugging.
+pub fn build_service(
+    scraps_dir: PathBuf,
+    exclude_dirs: Vec<PathBuf>,
+    allowed_hosts: &[String],
+) -> McpService {
+    let allowed_hosts: Vec<String> = LOOPBACK_HOSTS
+        .iter()
+        .map(|host| (*host).to_string())
+        .chain(allowed_hosts.iter().cloned())
+        .collect();
+
     StreamableHttpService::new(
         move || Ok(ScrapsServer::new(scraps_dir.clone(), exclude_dirs.clone())),
         Arc::new(NeverSessionManager::default()),
         StreamableHttpServerConfig::default()
             .with_legacy_session_mode(false)
-            .with_json_response(true),
+            .with_json_response(true)
+            .with_allowed_hosts(allowed_hosts),
     )
 }
 
@@ -84,17 +105,34 @@ mod tests {
     async fn spawn_server(
         project: &TempScrapProject,
     ) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
+        spawn_server_with_allowed_hosts(project, &[]).await
+    }
+
+    async fn spawn_server_with_allowed_hosts(
+        project: &TempScrapProject,
+        allowed_hosts: &[String],
+    ) -> (SocketAddr, JoinHandle<std::io::Result<()>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let service = build_service(
             project.scraps_dir.clone(),
             vec![project.static_dir.clone(), project.output_dir.clone()],
+            allowed_hosts,
         );
 
         (addr, tokio::spawn(serve(listener, service)))
     }
 
     async fn post(addr: SocketAddr, path: &str, body: serde_json::Value) -> (StatusCode, String) {
+        post_with_host(addr, path, body, &addr.to_string()).await
+    }
+
+    async fn post_with_host(
+        addr: SocketAddr,
+        path: &str,
+        body: serde_json::Value,
+        host: &str,
+    ) -> (StatusCode, String) {
         let stream = TcpStream::connect(addr).await.unwrap();
         let (mut sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
             .await
@@ -104,7 +142,7 @@ mod tests {
         let request = Request::builder()
             .method(Method::POST)
             .uri(path)
-            .header(HOST, addr.to_string())
+            .header(HOST, host)
             .header(CONTENT_TYPE, "application/json")
             .header(ACCEPT, "application/json, text/event-stream")
             .body(Full::new(Bytes::from(body.to_string())))
@@ -189,6 +227,66 @@ mod tests {
         let text = response["result"]["content"][0]["text"].as_str().unwrap();
         let result: serde_json::Value = serde_json::from_str(text).unwrap();
         assert!(result["count"].as_u64().unwrap() > 0);
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_unknown_host_is_forbidden(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let (addr, server_handle) = spawn_server(&project).await;
+
+        let (status, body) = post_with_host(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+            "wiki.example.com",
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(body.contains("Host header is not allowed"));
+
+        server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_allowed_host_is_accepted(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let (addr, server_handle) =
+            spawn_server_with_allowed_hosts(&project, &["wiki.example.com".to_string()]).await;
+
+        let (status, _) = post_with_host(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+            "wiki.example.com",
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        server_handle.abort();
+    }
+
+    /// Naming a host extends the allowlist; it does not take loopback out, so
+    /// the deployed server stays reachable through a port-forward.
+    #[rstest]
+    #[tokio::test]
+    async fn test_loopback_survives_allowed_hosts(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let (addr, server_handle) =
+            spawn_server_with_allowed_hosts(&project, &["wiki.example.com".to_string()]).await;
+
+        let (status, _) = post(
+            addr,
+            ENDPOINT_PATH,
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
 
         server_handle.abort();
     }


### PR DESCRIPTION
## Summary

Adds a repeatable `--allowed-host` flag to `scraps mcp serve --http`, so the server can be reached through a reverse proxy or tunnel that forwards under its own hostname.

`src/mcp/http.rs` built the service with `StreamableHttpServerConfig::default()`, whose `allowed_hosts` is the loopback-only list `["localhost", "127.0.0.1", "::1"]` (rmcp's fix for [GHSA-89vp-x53w-74fx](https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx)). That default is correct, but it was not reachable from the CLI, so any hostname other than loopback came back `403 Forbidden: Host header is not allowed`.

```bash
❯ scraps -C ~/wiki mcp serve --http 0.0.0.0:1113 --allowed-host wiki.example.com
```

Two decisions, both raised in the issue:

- **The flag extends the allowlist, it does not replace it.** Loopback stays allowed whatever else is named, so a port-forward or a local `curl` against a deployed server keeps working while the public hostname is being served. This is also why `LOOPBACK_HOSTS` is repeated in the source — `with_allowed_hosts` replaces rmcp's list rather than appending, so dropping them would have been silent.
- **`disable_allowed_hosts()` is not exposed.** An explicit hostname is barely more typing, and a blanket opt-out is the kind of flag that gets copied into a deployment nobody revisits.

`--allowed-host` carries `requires = "http"`, since it means nothing for the stdio transport.

## Related Issues

Addresses #647

## Additional Notes

Tests added in `src/mcp/http.rs`:

- an unlisted host is refused with 403 and the message body
- a named host is accepted
- loopback still works on a server that names another host (pins the extend-not-replace decision)

The existing `post` helper now delegates to `post_with_host`, so the other tests are unchanged in behaviour.

Docs: `docs/How-to/Integrate with AI Assistants.md` gains a "Behind a proxy or tunnel" section explaining the 403 and why naming the hostname is preferable to having the proxy rewrite `Host`.

**Not verified locally.** The sandbox this was written in cannot reach `static.crates.io`, so `cargo build` / `cargo test` / `clippy` could not run — only `cargo fmt` did. The rmcp API used (`StreamableHttpServerConfig::with_allowed_hosts`, taking `impl IntoIterator<Item = impl Into<String>>`) was read from the upstream source rather than from a successful compile. CI is the first real check; I'll follow up on whatever it reports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQH4oFJHaFzZiSiW66xWFs)_