### PR TITLE
v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "1.1.0"
+version = "1.2.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "1.1.0"
+version = "1.2.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "1.1.0"
+version = "1.2.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
Version bump for the v1.2.0 release.

- `Cargo.toml` (`[workspace.package]` and `[workspace.dependencies.scraps_libs]`)
- `modules/libs/Cargo.toml`
- `Cargo.lock`

## Notable since v1.1.0

**Feature**
- feat(mcp): add `--allowed-host` to serve behind a reverse proxy (#648, closes #647) — `scraps mcp serve --http` can now be reached under a real hostname through a proxy or tunnel. Repeatable, and extends rmcp's loopback allowlist rather than replacing it.

**Fix**
- fix(build): make tag ordering deterministic across builds (#642)

**Dependencies** — a large maintenance batch, including major migrations
- rmcp v1 → v3 (#605, #632), tera v1 → v2 (#611), comfy-table v7 → v8 (#631)
- h2 → 0.4.17 for [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (#648)
- actions/checkout v7 (#609), plus the usual Renovate crate and CDN updates

Full list: https://github.com/boykush/scraps/compare/v1.1.0...release/v1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)