### PR TITLE
Speed up CI workflows

### DIFF
--- a/.github/workflows/cargo-test-and-lint.yml
+++ b/.github/workflows/cargo-test-and-lint.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'scraps/**'
       - 'assets/**'
+      - '.github/workflows/claude-review-from-author.yml'
       - 'CONTRIBUTING.md'
       - 'LICENSE.md'
       - 'README.md'
@@ -15,6 +16,7 @@ on:
     paths-ignore:
       - 'scraps/**'
       - 'assets/**'
+      - '.github/workflows/claude-review-from-author.yml'
       - 'CONTRIBUTING.md'
       - 'LICENSE.md'
       - 'README.md'
@@ -22,6 +24,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MISE_AUTO_INSTALL: "false"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -39,9 +46,10 @@ jobs:
       with:
         cache: false
         install_args: "rust"
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - name: Run quality checks
       run: mise run cargo:quality
-      # Runs cargo:build, cargo:test, cargo:fmt, cargo:clippy
+      # Runs cargo:test, cargo:fmt, cargo:clippy
 
   deny:
 
@@ -53,7 +61,7 @@ jobs:
         persist-credentials: false
     - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       with:
-        cache: false
+        cache: true
         install_args: "rust cargo:cargo-deny"
     - name: Run cargo-deny checks
       run: mise run cargo:deny

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'scraps/**'
       - 'assets/**'
+      - '.github/workflows/claude-review-from-author.yml'
       - 'CONTRIBUTING.md'
       - 'LICENSE.md'
       - 'README.md'
@@ -13,6 +14,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   performance:
@@ -33,6 +38,8 @@ jobs:
         with:
           cache: false
           install_args: "rust"
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Run performance test
         id: build
@@ -69,3 +76,4 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  MISE_AUTO_INSTALL: "false"

--- a/.mise-tasks/cargo/quality
+++ b/.mise-tasks/cargo/quality
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-#MISE description="Run pre-commit quality checks (build, test, fmt, clippy)"
-#MISE depends=["cargo:build", "cargo:test", "cargo:fmt", "cargo:clippy"]
+#MISE description="Run pre-commit quality checks (test, fmt, clippy)"
+#MISE depends=["cargo:test", "cargo:fmt", "cargo:clippy"]
 echo '✅ All quality checks passed!'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,5 +15,5 @@ For comprehensive guidelines, see @CONTRIBUTING.md
 1. **Plan**: Start in Plan mode to analyze requirements and design approach
 2. **Implement**: One TODO at a time, following TDD (Red -> Green -> Refactor)
    - PostToolUse hook auto-formats `.rs` files on Edit/Write
-   - Pre-commit hook runs `cargo:quality` (build + test + fmt + clippy) automatically
+   - Pre-commit hook runs `cargo:quality` (test + fmt + clippy) automatically
 3. **Commit & PR**: Use `/commit` or `/commit-push-pr` skill (see @CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ This project uses [hk](https://hk.jdx.dev/) for managing git hooks. Pre-commit h
 
 The pre-commit hook runs quality checks on staged files:
 - **Rust files (*.rs)**: Runs `mise run cargo:quality` which includes:
-  - Build verification
   - All tests
   - Code formatting check (rustfmt)
   - Linter checks (clippy)


### PR DESCRIPTION
## Summary

- prevent mise from auto-installing unrelated tools in Rust CI jobs
- cache Rust build artifacts and the cargo-deny installation
- remove the redundant cargo build task from quality checks
- cancel superseded runs and skip Rust CI for Claude review workflow-only changes

## Validation

- MISE_AUTO_INSTALL=false mise run cargo:quality
- workflow YAML parsing
- git diff --check

## Baseline

Measured before this change: Cargo test & lint took about 5 minutes and Performance Test took about 4 minutes. The workflows were spending more than 2 minutes installing tools unrelated to each job.