### PR TITLE
fix(build): restore raw HTML output so iframes render again

### DIFF
--- a/modules/libs/src/html.rs
+++ b/modules/libs/src/html.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use comrak::{
     format_html,
     nodes::{AstNode, NodeCodeBlock, NodeLink, NodeValue, NodeWikiLink},
-    options::Extension,
+    options::{Extension, Render},
     parse_document, Arena, Options,
 };
 use url::Url;
@@ -35,6 +35,12 @@ fn options() -> Options<'static> {
             superscript: true,
             math_dollars: true,
             ..Extension::default()
+        },
+        render: Render {
+            // Scraps are authored by the site owner, so raw HTML such as
+            // <iframe> embeds is passed through rather than stripped.
+            r#unsafe: true,
+            ..Render::default()
         },
         ..Options::default()
     }
@@ -431,6 +437,17 @@ mod tests {
 
         assert!(content.to_string().contains("wanted"));
         assert!(!content.to_string().contains("ignored"));
+    }
+
+    #[rstest]
+    #[case::iframe(
+        "<iframe src=\"https://example.com\"></iframe>",
+        "<iframe src=\"https://example.com\"></iframe>\n"
+    )]
+    #[case::inline_html("text with <br> break", "<p>text with <br> break</p>\n")]
+    fn it_to_html_raw_html(base_url: BaseUrl, #[case] input: &str, #[case] expected: &str) {
+        let content = to_content(input, &base_url, EmbedMode::Preserve);
+        assert_eq!(content.to_string(), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

生成サイトから `<iframe>` が消えていた回帰を修正しました。

comrak の `render.unsafe` はデフォルト `false` で、生 HTML ノードを全て `<!-- raw HTML omitted -->` に置換します。差し替え前の pulldown-cmark は `push_html` が `Event::Html` をそのまま出力していたため生 HTML が通っていましたが、690b2fd（pulldown-cmark → comrak、v1.0.0-rc.1 に含まれる）の移植時にこのオプションが漏れていました。

`modules/libs/src/html.rs` の `options()` で `render.r#unsafe = true` を有効化し、回帰テストを追加しています。

影響していたのは iframe だけではなく、`<details>` / `<summary>` やインライン HTML（`<br>`, `<b>` など）も同じ原因で落ちていました。本 PR でまとめて復旧します。

## Related Issues

<!-- なし -->

## Additional Notes

### 検証

まず失敗するテストで再現を確認（`<!-- raw HTML omitted -->` が出力されることを確認）してから修正しました。

- 追加した回帰テスト `it_to_html_raw_html`（iframe / インライン生 HTML）
- `mise run cargo:quality`（test + fmt + clippy）: 534 tests all pass
- 実際に `scraps build` した出力でも確認:

```html
<h1>iframe demo</h1>
<iframe width="560" height="315" src="https://www.youtube.com/embed/..." allowfullscreen></iframe>
<p>Inline <b>bold</b> raw html too.</p>
<details>
<summary>toggle</summary>
<p>hidden body</p>
</details>
```

### レビュー観点

- `r#unsafe` という名前ですが、scraps の markdown は site owner 自身が書くもので、外部からの untrusted input を描画する経路ではありません。信頼モデルは pulldown-cmark 時代と同じです。その意図をコード側にもコメントで残しています。
- テンプレート側は `{{ element.raw | safe }}` なので二重エスケープは発生しません。
- `to_content` の呼び出し元3箇所（`usecase.rs` / `scrap_detail.rs` / `link_scraps.rs`）は全て同じ `options()` を通るため、挙動は一貫して v1.0.0-rc.1 以前に戻ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
