### PR TITLE
feat(build): rebuild the site design system on generated design tokens

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -5,6 +5,13 @@ on:
       - main
     paths:
       - 'docs/**'
+      # The site is built by the binary from this checkout, so a change to the
+      # compiler or its templates changes the published docs too.
+      - 'src/**'
+      - 'modules/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.mise-tasks/docs/**'
       - '.github/workflows/deploy-scraps-github-pages.yml'
   workflow_dispatch:
 
@@ -25,11 +32,19 @@ jobs:
           fetch-depth: 0 # For scraps git committed date
           persist-credentials: false
 
-      - name: Setup Scraps
-        uses: boykush/scraps@b8da11e2943a9c20bbc444a3061aab5ce7dbb752 # v1.1.0
+      - name: Setup mise
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache: false
+          install_args: "rust"
 
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      # Built from source rather than from a release, so docs changes and
+      # compiler changes reach the published site in the same push instead of
+      # waiting on a release to cut a new binary.
       - name: Build docs
-        run: scraps build --directory docs
+        run: mise run docs:build
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ _site
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
+# Design tokens
+/tokens/node_modules
+
 # Playwright
 /tests/e2e/node_modules
 /tests/e2e/playwright-report

--- a/.mise-tasks/docs/build
+++ b/.mise-tasks/docs/build
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Build documentation with scraps"
-scraps build --directory docs
+#MISE description="Build documentation with the scraps binary from this checkout"
+set -euo pipefail
+cargo build --release
+./target/release/scraps build --directory docs

--- a/.mise-tasks/docs/serve
+++ b/.mise-tasks/docs/serve
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Serve documentation locally with scraps"
-scraps serve --directory docs
+#MISE description="Serve documentation locally with the scraps binary from this checkout"
+set -euo pipefail
+cargo build --release
+./target/release/scraps serve --directory docs

--- a/.mise-tasks/tokens/build
+++ b/.mise-tasks/tokens/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Generate the site's CSS custom properties from the design tokens"
+#MISE dir="tokens"
+set -euo pipefail
+npm install --no-fund --no-audit
+npm run build

--- a/.mise-tasks/tokens/check
+++ b/.mise-tasks/tokens/check
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#MISE description="Fail if the generated token CSS is stale, or a colour role misses WCAG AA"
+#MISE dir="tokens"
+set -euo pipefail
+
+python3 check-contrast.py
+
+generated="../src/usecase/build/css/builtins/_tokens.css"
+before="$(mktemp)"
+trap 'rm -f "$before"' EXIT
+cp "$generated" "$before"
+
+npm install --no-fund --no-audit
+npm run build
+
+# Compared against the file itself rather than against git, so the check also
+# holds before the generated CSS is first committed.
+if ! diff -q "$before" "$generated" >/dev/null; then
+  echo "error: $generated is out of date. Run 'mise run tokens:build' and commit the result." >&2
+  diff "$before" "$generated" >&2
+  exit 1
+fi

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ experimental = true
 
 [tools]
 "rust" = { version = "1.97.1", profile = "default" }
+"node" = "24.19.0"
 "hk" = "latest"
 "pkl" = "latest"
 "github:boykush/scraps" = "v1.1.0"

--- a/src/usecase/build/css/builtins/_tokens.css
+++ b/src/usecase/build/css/builtins/_tokens.css
@@ -1,0 +1,58 @@
+    /* Generated from tokens/*.tokens.json — do not edit. `mise run tokens:build` */
+
+    --nord0: #2e3440;
+    --nord1: #3b4252;
+    --nord2: #434c5e;
+    --nord3: #4c566a;
+    --nord4: #d8dee9;
+    --nord5: #e5e9f0;
+    --nord6: #eceff4;
+    --nord7: #8fbcbb;
+    --nord8: #88c0d0;
+    --nord9: #81a1c1;
+    --nord10: #5e81ac;
+    --nord11: #bf616a;
+    --nord12: #d08770;
+    --nord13: #ebcb8b;
+    --nord14: #a3be8c;
+    --nord15: #b48ead;
+    --ext-frost-deep: #47698f;
+    --ext-slate-mid: #5d6a80;
+
+    --color-surface: light-dark(var(--nord6), var(--nord0));
+    --color-surface-raised: light-dark(#ffffff, var(--nord1));
+    --color-text: light-dark(var(--nord3), var(--nord6));
+    --color-text-muted: light-dark(var(--ext-slate-mid), var(--nord9));
+    --color-rule: light-dark(var(--nord4), var(--nord2));
+    --color-accent: light-dark(var(--ext-frost-deep), var(--nord8));
+
+    --font-family-sans: "Rubik", "Noto Sans JP", sans-serif;
+    --font-family-mono: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace;
+
+    --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-bold: 700;
+
+    --font-size-xs: 12px;
+    --font-size-sm: 14px;
+    --font-size-base: 16px;
+    --font-size-lg: 20px;
+    --font-size-xl: 26px;
+    --font-size-2xl: 34px;
+
+    --font-line-height-tight: 1.25;
+    --font-line-height-body: 1.7;
+
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 24px;
+    --space-6: 32px;
+    --space-7: 48px;
+
+    --radius-none: 0px;
+    --radius-sm: 2px;
+    --radius-md: 4px;
+
+    --border-hairline: 1px;

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -1,134 +1,156 @@
 :root {
     color-scheme: {{ color_scheme }};
 
-    --nord0: #2e3440;
-    --nord1: #3b4252;
-    --nord2: #434c5e;
-    --nord3: #4c566a;
-    --nord4: #d8dee9;
-    --nord5: #e5e9f0;
-    --nord6: #eceff4;
-    --nord7: #8fbcbb;
-    --nord8: #88c0d0;
-    --nord9: #81a1c1;
-    --nord10: #5e81ac;
-    --nord11: #bf616a;
-    --nord12: #d08770;
-    --nord13: #ebcb8b;
-    --nord14: #a3be8c;
-    --nord15: #b48ead;
-
-    --primary-background-color: light-dark(var(--nord6), var(--nord0));
-    --secondary-background-color: light-dark(white, var(--nord1));
-    --text-color: light-dark(var(--nord3), var(--nord6));
-    --horizontal-rule-color: var(--nord5);
-    --shadow-color: light-dark(rgba(184, 194, 215, 0.3), rgba(15, 17, 21, 0.3));
-    --gray-color: light-dark(rgb(123, 136, 161) ,rgb(171, 185, 207));
-
-    --link-highlight-color: var(--nord8);
+{% include "__builtins/_tokens.css" %}
 }
 
 /* html tag */
 body {
-  background-color: var(--primary-background-color);
-  color: var(--text-color);
-  font-family: 'Rubik', 'Noto Sans JP', sans-serif;
+    margin: 0;
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-base);
+    line-height: var(--font-line-height-body);
 }
 
-pre code {
-    border-radius: 4px;
-}
+a {
+    color: var(--color-accent);
+    text-decoration: none;
 
-p code {
-    background-color: var(--primary-background-color);
-    padding: 1px 2px;
-    border-radius: 2px;
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 hr {
     border: none;
-    border-bottom: 1px solid var(--horizontal-rule-color);
+    border-bottom: var(--border-hairline) solid var(--color-rule);
+    margin: var(--space-6) 0;
 }
 
-a {
-    color: var(--text-color);
-    text-decoration: none;
+code {
+    font-family: var(--font-family-mono);
+    font-size: 0.92em;
+}
 
-    &:visited {
-        color: var(--text-color);
+pre code {
+    border-radius: var(--radius-md);
+}
+
+p code {
+    background-color: var(--color-surface-raised);
+    border: var(--border-hairline) solid var(--color-rule);
+    border-radius: var(--radius-sm);
+    padding: 1px 4px;
+}
+
+blockquote {
+    margin: var(--space-4) 0;
+    padding-left: var(--space-4);
+    border-left: 2px solid var(--color-rule);
+    color: var(--color-text-muted);
+}
+
+table {
+    border-collapse: collapse;
+
+    th,
+    td {
+        border: var(--border-hairline) solid var(--color-rule);
+        padding: var(--space-2) var(--space-3);
+        text-align: left;
+    }
+
+    th {
+        font-weight: var(--font-weight-medium);
     }
 }
 
 /* header */
 header {
-    padding-top: 32px;
-    text-align: center;
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: var(--space-7) var(--space-5) var(--space-4);
+
+    a {
+        color: var(--color-text);
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
 
     h1 {
-        display: inline-block;
-        font-size: 40px;
+        margin: 0;
+        font-size: var(--font-size-xl);
+        font-weight: var(--font-weight-bold);
+        line-height: var(--font-line-height-tight);
     }
 }
 
 /* main */
 main {
-    width: 90%;
-    margin: 32px auto;
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 0 var(--space-5);
 }
 
 /* footer */
 footer {
-    text-align: center;
-    font-size: 12.8px;
-    color: var(--gray-color);
-    margin-bottom: 32px;
-
-    a {
-        color: var(--link-highlight-color);
-    }
+    max-width: 1040px;
+    margin: var(--space-7) auto 0;
+    padding: var(--space-4) var(--space-5) var(--space-7);
+    border-top: var(--border-hairline) solid var(--color-rule);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
 }
 
 /* scrap */
 div.scrap {
-    background-color: var(--secondary-background-color);
-    border-radius: 4px;
-    padding: 32px;
-    box-shadow: var(--shadow-color) 0px 6px 9px 0px;
-
     .context {
-        color: var(--gray-color);
-
-        &::before {
-            content: "\1F5C2";
-            margin-right: 8px;
-        }
+        margin: 0 0 var(--space-2);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-regular);
+        color: var(--color-text-muted);
     }
 
     h1.title {
-        font-size: 36px;
+        margin: 0;
+        font-size: var(--font-size-2xl);
+        line-height: var(--font-line-height-tight);
     }
 
     .commited-date {
-        font-size: 12.8px;
-        color: var(--gray-color);
+        margin: var(--space-3) 0 0;
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
     }
 
     .content {
-        margin: 32px 0;
-        line-height: 1.5;
-        word-break: break-all;
+        margin: var(--space-5) 0 0;
+        padding-top: var(--space-5);
+        border-top: var(--border-hairline) solid var(--color-rule);
+        word-break: break-word;
 
         .ogp-card {
-            background-color: var(--primary-background-color);
-            border-radius: 8px;
-            box-shadow: var(--shadow-color) 0px 6px 9px 0px;
-            margin: 16px 0;
+            background-color: var(--color-surface-raised);
+            border: var(--border-hairline) solid var(--color-rule);
+            border-radius: var(--radius-md);
+            margin: var(--space-4) 0;
             height: 120px;
             overflow: hidden;
 
             .ogp-card-link {
                 display: flex;
                 flex-direction: row;
+
+                &:hover {
+                    text-decoration: none;
+                }
             }
 
             .ogp-image {
@@ -141,42 +163,42 @@ div.scrap {
 
             .ogp-content {
                 height: 96px;
-                margin: 12px 16px;
+                margin: var(--space-3) var(--space-4);
                 overflow: hidden;
 
                 .ogp-title {
                     max-height: 48px;
                     overflow: hidden;
-                    font-weight: bold;
+                    font-weight: var(--font-weight-medium);
+                    color: var(--color-text);
                 }
 
                 .ogp-description {
-                    color: var(--gray-color);
-                    font-size: 12px;
+                    color: var(--color-text-muted);
+                    font-size: var(--font-size-xs);
                 }
             }
         }
     }
 
-    a {
-        text-decoration: none;
-        color: var(--link-highlight-color);
-
-        &:hover {
-            background-color: none;
-        }
-    }
-
     img {
-        max-width: 60%;
+        max-width: 100%;
     }
 }
 
 /* tag */
 div.tag {
-    h1.title::before {
-        content: "\1F3F7";
-        margin-right: 8px;
+    h1.title {
+        margin: 0;
+        font-size: var(--font-size-2xl);
+        line-height: var(--font-line-height-tight);
+
+        &::before {
+            content: "#";
+            font-family: var(--font-family-mono);
+            color: var(--color-text-muted);
+            margin-right: var(--space-2);
+        }
     }
 }
 
@@ -184,212 +206,269 @@ div.tag {
 div.index {
     /* readme block */
     div.readme-block {
-        padding: 0 40px;
-
-        a {
-            color: var(--link-highlight-color);
-        }
-
         hr {
-            margin: 64px 0;
+            margin: var(--space-7) 0;
         }
     }
 
     /* search block */
     div.search-block {
-        margin-bottom: 32px;
-        text-align: center;
+        margin-bottom: var(--space-5);
 
         input {
-            color: var(--text-color);
-            border: 1px solid transparent;
-            background-color: var(--secondary-background-color);
-            border-color: var(--secondary-background-color);
-            border-radius: 4px;
-            width: 240px;
-            height: 20px;
-            padding: 4px 8px;
-            display: inline-block;
+            box-sizing: border-box;
+            width: 100%;
+            color: var(--color-text);
+            background-color: var(--color-surface-raised);
+            border: var(--border-hairline) solid var(--color-rule);
+            border-radius: var(--radius-md);
+            padding: var(--space-3) var(--space-4);
+            font-family: var(--font-family-mono);
+            font-size: var(--font-size-sm);
 
             &:focus {
                 outline: none;
+                border-color: var(--color-accent);
             }
         }
 
-        .icon::before {
-            content: "\1F50D";
-            margin-right: 8px;
-        }
-
+        /* doSearch() positions each result with an inline `top`, the first at
+           -16px; the matching margin lands it just under the input. */
         ul {
-            list-style-position: inside;
-            width: 240px;
             position: relative;
-            left: 50%;
-            transform: translateX(-50%);
+            margin: var(--space-4) 0 0;
+            padding: 0;
+            list-style: none;
         }
 
         li {
             position: absolute;
-            left: 25px;
-            list-style: none;
-            display: block;
-            border: 1px solid transparent;
-            border-radius: 4px;
+            left: 0;
+            width: 100%;
             height: 28px;
-            width: 256px;
-            background-color: var(--secondary-background-color);
-            padding: 0;
-            margin: 0;
             overflow: hidden;
+            background-color: var(--color-surface-raised);
+            border: var(--border-hairline) solid var(--color-rule);
+            border-radius: var(--radius-sm);
             text-wrap: nowrap;
             text-overflow: ellipsis;
 
             &:hover {
-                background-color: var(--link-highlight-color);
+                border-color: var(--color-accent);
             }
 
             a {
                 display: block;
+                box-sizing: border-box;
                 width: 100%;
                 height: 100%;
-                padding: 4px 8px;
-                margin: 0;
-                color: var(--text-color);
-                text-decoration: none;
-                cursor: pointer;
-                box-sizing: border-box;
-                line-height: 20px;
+                padding: 0 var(--space-3);
+                color: var(--color-text);
+                line-height: 26px;
+                font-size: var(--font-size-sm);
+
+                &:hover {
+                    text-decoration: none;
+                }
             }
         }
     }
 
     /* tags block */
     div.tags-block {
-        margin-bottom: 64px;
+        margin-bottom: var(--space-6);
     }
 
     /* links block */
     div.links-block {
-        p.sort-key {
-            color: var(--gray-color);
-            font-size: 16px;
+        p.list-head {
+            display: flex;
+            justify-content: space-between;
+            gap: var(--space-4);
+            margin: 0 0 var(--space-2);
+            padding-bottom: var(--space-2);
+            border-bottom: var(--border-hairline) solid var(--color-rule);
+            font-family: var(--font-family-mono);
+            font-size: var(--font-size-xs);
+            color: var(--color-text-muted);
         }
     }
 
     /* paging arrows */
     div.paging-arrows {
-        margin-top: 32px;
-        text-align: center;
-
-        a {
-            margin-right: 16px;
-            color: var(--gray-color);
-            font-size: 20px;
-
-            &.prev::before {
-                content: "\2B05";
-                font-size: 16px;
-                line-height: 16px;
-                margin-right: 8px;
-            }
-
-            &.next::after {
-                content: "\27A1";
-                font-size: 16px;
-                line-height: 16px;
-                margin-left: 8px;
-            }
-        }
+        display: flex;
+        justify-content: center;
+        gap: var(--space-5);
+        margin-top: var(--space-6);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-sm);
     }
 }
 
-/* scrap links */
-ul.scrap-links {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, 200px);
-    gap: 32px;
-    width: 100%;
-    padding-top: 16px;
-    padding-left: 0;
+/* scrap rows — the index listing */
+ul.scrap-rows {
+    margin: 0;
+    padding: 0;
     list-style: none;
-    justify-content: center;
 
     li.item {
-        a {
-            display: flex;
-            flex-direction: column;
-            background-color: var(--secondary-background-color);
-            padding: 16px;
-            height: 168px;
-            border-radius: 4px;
-            box-shadow: var(--shadow-color) 0px 6px 9px 0px;
-        }
+        border-bottom: var(--border-hairline) solid var(--color-rule);
+    }
 
-        div.header {
-            padding: 8px 0;
-        }
+    a.row {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-5);
+        padding: var(--space-3) 0;
 
-        div.context {
-            font-size: 12px;
-            color: var(--gray-color);
+        &:hover {
+            text-decoration: none;
 
-            &::before {
-                content: "\1F5C2";
-                margin-right: 4px;
+            .title {
+                text-decoration: underline;
             }
         }
+    }
 
-        div.title {
-            font-size: 18px;
-            color: var(--link-highlight-color);
-        }
+    img.thumbnail {
+        align-self: center;
+        flex-shrink: 0;
+        width: 40px;
+        height: 40px;
+        object-fit: cover;
+        border-radius: var(--radius-sm);
+    }
 
-        div.thumbnail {
-            overflow: hidden;
-        }
+    span.body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        flex-grow: 1;
+        min-width: 0;
+    }
 
-        img.thumbnail-image {
-            max-height: 128px;
-            width: 168px;
-            object-fit: contain;
-        }
+    span.head {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+    }
 
-        div.summary {
-            overflow: hidden;
-            display: -webkit-box;
-            line-clamp: 4;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 4;
+    span.title {
+        font-size: var(--font-size-base);
+        font-weight: var(--font-weight-medium);
+        line-height: var(--font-line-height-tight);
+        color: var(--color-accent);
+    }
+
+    span.ctx {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+    }
+
+    span.summary {
+        font-size: var(--font-size-sm);
+        line-height: 1.45;
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    span.graph {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: var(--space-1);
+        flex-shrink: 0;
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        line-height: 1.3;
+        color: var(--color-text-muted);
+    }
+}
+
+/* scrap links — compact list on scrap and tag pages */
+ul.scrap-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 0 var(--space-6);
+    margin: var(--space-5) 0 0;
+    padding: 0;
+    list-style: none;
+
+    li.item {
+        border-bottom: var(--border-hairline) solid var(--color-rule);
+    }
+
+    a.link {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-3);
+        padding: var(--space-2) 0;
+
+        &:hover {
+            text-decoration: none;
+
+            .title {
+                text-decoration: underline;
+            }
         }
+    }
+
+    span.title {
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-medium);
+        color: var(--color-accent);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    span.ctx {
+        flex-shrink: 0;
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
     }
 }
 
 /* tag links */
 ul.tag-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+    padding: 0;
     list-style: none;
 
-    li.item {
-        display: inline-block;
-        margin-right: 8px;
-        margin-bottom: 8px;
+    a.link {
+        display: inline-flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-sm);
+    }
 
-        a {
-            color: var(--link-highlight-color);
+    span.count {
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
+    }
+}
+
+@media (max-width: 640px) {
+    header {
+        padding-top: var(--space-6);
+    }
+
+    ul.scrap-rows {
+        a.row {
+            gap: var(--space-3);
         }
 
-        span.title {
-            margin-right: 2px;
-
-            &::before {
-                content: "\1F3F7";
-                margin-right: 8px;
-            }
-        }
-
-        span.more-link {
-            color: var(--link-highlight-color);
-            margin-right: 8px;
+        span.graph {
+            display: none;
         }
     }
 }

--- a/src/usecase/build/css/css_tera.rs
+++ b/src/usecase/build/css/css_tera.rs
@@ -9,10 +9,13 @@ use super::serde::color_scheme::ColorSchemeTera;
 static CSS_TERA: Lazy<Tera> = Lazy::new(|| {
     let mut tera = Tera::default();
     crate::service::tera_filters::register(&mut tera);
-    tera.add_raw_templates(vec![(
-        "__builtins/main.css",
-        include_str!("builtins/main.css"),
-    )])
+    tera.add_raw_templates(vec![
+        (
+            "__builtins/_tokens.css",
+            include_str!("builtins/_tokens.css"),
+        ),
+        ("__builtins/main.css", include_str!("builtins/main.css")),
+    ])
     .expect("builtin templates are compiled into the binary");
     tera
 });

--- a/src/usecase/build/html/builtins/index.html
+++ b/src/usecase/build/html/builtins/index.html
@@ -10,7 +10,6 @@
         {% endif %}
         {% if build_search_index == true %}
           <div class="search-block">
-              <span class="icon" />
               <input
                 type="text"
                 id="search-input"
@@ -24,15 +23,18 @@
             {{ <tag_links tags={tags} base_url={base_url} slice_size={15} /> }}
         </div>
         <div class="links-block">
-            <p class="sort-key">Sort by - {{ sort_key }}</p>
-            {{ <scrap_links scraps={scraps} base_url={base_url} /> }}
+            <p class="list-head">
+                <span class="sort-key">sorted by {{ sort_key }}</span>
+                <span class="legend">namespace &#183; graph</span>
+            </p>
+            {{ <scrap_rows scraps={scraps} base_url={base_url} /> }}
         </div>
         <div class="paging-arrows">
             {% if prev %}
-                <a class="prev" href="{{ prev }}">prev</a>
+                <a class="prev" href="{{ prev }}">&#8249; prev</a>
             {% endif %}
             {% if next %}
-                <a class="next" href="{{ next }}">next</a>
+                <a class="next" href="{{ next }}">next &#8250;</a>
             {% endif %}
         </div>
     </div>

--- a/src/usecase/build/html/builtins/macros.html
+++ b/src/usecase/build/html/builtins/macros.html
@@ -1,25 +1,35 @@
+{% component scrap_rows(scraps, base_url) %}
+    <ul class="scrap-rows">
+        {% for scrap in scraps %}
+            <li class="item">
+                <a class="row" href="{{ base_url }}scraps/{{ scrap.html_file_name }}">
+                    {% if scrap.thumbnail %}
+                        <img class="thumbnail" alt="" src="{{ scrap.thumbnail }}" loading="lazy" />
+                    {% endif %}
+                    <span class="body">
+                        <span class="head">
+                            <span class="title">{{ scrap.title }}</span>
+                            {% if scrap.ctx %}<span class="ctx">{{ scrap.ctx }}</span>{% endif %}
+                        </span>
+                        {% if scrap.summary %}<span class="summary">{{ scrap.summary }}</span>{% endif %}
+                    </span>
+                    <span class="graph">
+                        <span class="metric">{{ scrap.links_count }} ref{% if scrap.links_count != 1 %}s{% endif %}</span>
+                        <span class="metric">{{ scrap.backlinks_count }} backlink{% if scrap.backlinks_count != 1 %}s{% endif %}</span>
+                    </span>
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endcomponent scrap_rows %}
+
 {% component scrap_links(scraps, base_url) %}
     <ul class="scrap-links">
         {% for scrap in scraps %}
             <li class="item">
-                <a href="{{ base_url }}scraps/{{ scrap.html_file_name }}">
-                    {% if scrap.ctx %}
-                        <div class="header">
-                            <div class="context">{{ scrap.ctx }}&#47;</div>
-                            <div class="title">{{ scrap.title }}</div>
-                        </div>
-                    {% else %}
-                        <div class="header">
-                            <div class="title">{{ scrap.title }}</div>
-                        </div>
-                    {% endif %}
-                    {% if scrap.thumbnail %}
-                        <div class="thumbnail">
-                            <img class="thumbnail-image" alt="thumbnail" src="{{ scrap.thumbnail }}" loading="lazy" />
-                        </div>
-                    {% else %}
-                        <div class="summary">{{ scrap.html_text | striptags }}</div>
-                    {% endif %}
+                <a class="link" href="{{ base_url }}scraps/{{ scrap.html_file_name }}">
+                    <span class="title">{{ scrap.title }}</span>
+                    {% if scrap.ctx %}<span class="ctx">{{ scrap.ctx }}</span>{% endif %}
                 </a>
             </li>
         {% endfor %}
@@ -30,16 +40,14 @@
     <ul class="tag-links">
         {% for tag in tags | slice(end=slice_size) %}
             <li class="item">
-                <a href="{{ base_url }}tags/{{ tag.slug }}.html">
-                    <span class="title">{{ tag.title }}</span>&nbsp;<span>({{ tag.backlinks_count }})</span>
+                <a class="link" href="{{ base_url }}tags/{{ tag.slug }}.html">
+                    <span class="title">#{{ tag.title }}</span><span class="count">{{ tag.backlinks_count }}</span>
                 </a>
             </li>
         {% endfor %}
         {% if tags | length > slice_size %}
             <li class="item">
-                <a href="{{ base_url }}tags/">
-                    <span class="more-link">More...</span>
-                </a>
+                <a class="link more" href="{{ base_url }}tags/">More&#8230;</a>
             </li>
         {% endif %}
     </ul>

--- a/src/usecase/build/html/serde/index_scraps.rs
+++ b/src/usecase/build/html/serde/index_scraps.rs
@@ -6,7 +6,12 @@ use crate::usecase::build::model::{
     backlinks_map::BacklinksMap,
     scrap_detail::{ScrapDetail, ScrapDetails},
     sort::SortKey,
+    summary::Summary,
 };
+
+/// Long enough to be a useful gloss on an index row, short enough to stay on
+/// one line at the narrowest supported width.
+const SUMMARY_MAX_CHARS: usize = 90;
 
 #[derive(serde::Serialize, Clone, PartialEq, Debug)]
 struct SerializeIndexScrap {
@@ -15,8 +20,10 @@ struct SerializeIndexScrap {
     html_file_name: String,
     html_text: String,
     thumbnail: Option<Url>,
+    summary: Option<String>,
     pub commited_ts: Option<i64>,
     pub backlinks_count: usize,
+    pub links_count: usize,
 }
 
 impl SerializeIndexScrap {
@@ -25,6 +32,9 @@ impl SerializeIndexScrap {
         let content = scrap_detail.content();
         let commited_ts = scrap_detail.commited_ts();
         let backlinks_count = backlinks_map.get(&scrap.self_key()).len();
+        let links_count = scrap.links().len();
+        let summary = Summary::from_md_text(scrap.md_text(), SUMMARY_MAX_CHARS)
+            .map(|s| s.as_str().to_string());
         let html_file_name = format!("{}.html", ScrapFileStem::from(scrap.self_key().clone()));
         SerializeIndexScrap {
             ctx: scrap.ctx().as_ref().map(|c| c.to_string()),
@@ -32,8 +42,10 @@ impl SerializeIndexScrap {
             html_file_name,
             html_text: content.to_string(),
             thumbnail: scrap.thumbnail(),
+            summary,
             commited_ts,
             backlinks_count,
+            links_count,
         }
     }
 }

--- a/src/usecase/build/model.rs
+++ b/src/usecase/build/model.rs
@@ -7,3 +7,4 @@ pub mod list_view_configs;
 pub mod paging;
 pub mod scrap_detail;
 pub mod sort;
+pub mod summary;

--- a/src/usecase/build/model/summary.rs
+++ b/src/usecase/build/model/summary.rs
@@ -1,0 +1,318 @@
+/// One-line summary shown for a scrap on index and tag pages.
+///
+/// A leading heading is the term's expanded name (`ADR` → `Architectural
+/// Decision Records`) and indexes better than any excerpt. Without one, tag
+/// lines are skipped so the summary starts at prose instead of at
+/// `#[[Documentation]] #[[Software Design]]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Summary(String);
+
+impl Summary {
+    pub fn from_md_text(md_text: &str, max_chars: usize) -> Option<Summary> {
+        let mut lines = md_text.lines().map(str::trim);
+
+        let first = lines.find(|l| !l.is_empty())?;
+        let text = match heading_text(first) {
+            Some(expanded) => clean(expanded),
+            None => first_paragraph(std::iter::once(first).chain(lines)),
+        };
+
+        let text = truncate(&text, max_chars);
+        if text.is_empty() {
+            None
+        } else {
+            Some(Summary(text))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Markdown paragraphs are often hard-wrapped, so a summary taken from one
+/// line alone stops mid-sentence. Lines are joined until the paragraph ends.
+fn first_paragraph<'a>(lines: impl Iterator<Item = &'a str>) -> String {
+    let mut para = String::new();
+    let mut in_fence = false;
+
+    for line in lines {
+        if line.starts_with("```") || line.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        let ends_paragraph = line.is_empty() || is_block_break(line) || is_meta_line(line);
+        let cleaned = if ends_paragraph {
+            String::new()
+        } else {
+            clean(strip_prose_marker(line))
+        };
+
+        if cleaned.is_empty() {
+            if para.is_empty() {
+                continue;
+            }
+            break;
+        }
+
+        if needs_space(&para, &cleaned) {
+            para.push(' ');
+        }
+        para.push_str(&cleaned);
+    }
+
+    para
+}
+
+/// A space belongs between wrapped ASCII words but not between wrapped
+/// Japanese, where the line break carries no space of its own.
+fn needs_space(para: &str, next: &str) -> bool {
+    match (para.chars().last(), next.chars().next()) {
+        (Some(prev), Some(first)) => prev.is_ascii() && first.is_ascii(),
+        _ => false,
+    }
+}
+
+/// A line of nothing but tags or embeds is metadata, not prose. Tags inside a
+/// sentence stay, so `#[[tag]] marks a tag.` keeps its subject.
+fn is_meta_line(line: &str) -> bool {
+    let mut rest = line.to_string();
+    for prefix in ['#', '!'] {
+        rest = drop_prefixed_links(&rest, prefix);
+    }
+    rest.trim().is_empty()
+}
+
+fn drop_prefixed_links(line: &str, prefix: char) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == prefix && chars.get(i + 1..i + 3) == Some(&['[', '[']) {
+            if let Some(end) = find_close(&chars, i + 3) {
+                i = end + 2;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+fn is_block_break(line: &str) -> bool {
+    heading_text(line).is_some()
+        || (line.len() >= 3 && line.chars().all(|c| c == '-' || c == '*' || c == '_'))
+}
+
+/// `## Foo` → `Foo`. `#[[Tag]]` is not a heading: a heading needs whitespace
+/// after the hashes, which is what separates the two syntaxes.
+fn heading_text(line: &str) -> Option<&str> {
+    let rest = line.trim_start_matches('#');
+    let level = line.len() - rest.len();
+    if (1..=6).contains(&level) && rest.starts_with(char::is_whitespace) {
+        let text = rest.trim();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    } else {
+        None
+    }
+}
+
+/// Drop list bullets and quote markers so a body that opens with a list still
+/// summarises as prose.
+fn strip_prose_marker(line: &str) -> &str {
+    let line = line.trim_start_matches(['>', ' ']);
+    for marker in ["- ", "* ", "+ "] {
+        if let Some(rest) = line.strip_prefix(marker) {
+            return rest.trim_start();
+        }
+    }
+    line
+}
+
+/// Inline code fences and bold markers are noise in a one-line gloss. Single
+/// `*` and `_` are left alone so identifiers like `stale_by_git` survive.
+fn clean(line: &str) -> String {
+    let bare = line.replace("**", "").replace("__", "").replace('`', "");
+    strip_wiki_syntax(&bare)
+}
+
+/// Renders wiki syntax as the text a reader sees: `[[a|b]]` → `b`, `[[a]]` →
+/// `a`, `#[[a]]` → `#a`, `![[a]]` → `a`. Any of them can be a sentence's
+/// subject, so none is dropped; whole lines of them are skipped upstream.
+fn strip_wiki_syntax(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        let marker = if chars.get(i + 1..i + 3) == Some(&['[', '[']) {
+            match chars[i] {
+                '#' => Some('#'),
+                '!' => Some('!'),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        let opens = marker.is_some() || chars.get(i..i + 2) == Some(&['[', '[']);
+
+        if !opens {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        let start = if marker.is_some() { i + 3 } else { i + 2 };
+        match find_close(&chars, start) {
+            Some(end) => {
+                let inner: String = chars[start..end].iter().collect();
+                if marker == Some('#') {
+                    out.push('#');
+                    out.push_str(inner.trim());
+                } else {
+                    out.push_str(inner.rsplit('|').next().unwrap_or(&inner).trim());
+                }
+                i = end + 2;
+            }
+            None => {
+                out.push(chars[i]);
+                i += 1;
+            }
+        }
+    }
+
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn find_close(chars: &[char], from: usize) -> Option<usize> {
+    (from..chars.len().saturating_sub(1)).find(|&i| chars[i] == ']' && chars[i + 1] == ']')
+}
+
+/// Counts characters rather than bytes so Japanese summaries are not cut
+/// mid-codepoint.
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max_chars).collect();
+    format!("{}…", head.trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    // A leading heading is the expanded name, and wins over the prose below it.
+    #[case(
+        "## Architectural Decision Records\n\n#[[Documentation]]\n\nアーキテクチャに関する意思決定を記録する文書",
+        "Architectural Decision Records"
+    )]
+    #[case(
+        "## Large Language Model Wiki\n\n#[[LLM]] #[[Documentation]]\n\n[[Andrej Karpathy]]が提唱したパターン",
+        "Large Language Model Wiki"
+    )]
+    // Without a heading the tag line is skipped, and links render as their text.
+    #[case(
+        "#[[Documentation]]\n\n[[Write the Docs]]コミュニティが提唱するアプローチ",
+        "Write the Docsコミュニティが提唱するアプローチ"
+    )]
+    #[case(
+        "#[[Documentation]] #[[Software Design]]\n\n[[ドメイン駆動設計|DDD]]において共有する言語",
+        "DDDにおいて共有する言語"
+    )]
+    // Bodies that open straight into prose are unchanged.
+    #[case(
+        "個人やチームの認知容量に対する負荷のこと",
+        "個人やチームの認知容量に対する負荷のこと"
+    )]
+    // Bullets and embeds do not leak into the summary.
+    #[case("- [[Git]]を使用したバージョン管理", "Gitを使用したバージョン管理")]
+    #[case("![[architecture]]\n\n実際の本文", "実際の本文")]
+    #[case(
+        "![[Page#Heading]] embeds a single section from another scrap.",
+        "Page#Heading embeds a single section from another scrap."
+    )]
+    fn it_summarizes(#[case] md: &str, #[case] expected: &str) {
+        let summary = Summary::from_md_text(md, 120).unwrap();
+        assert_eq!(summary.as_str(), expected);
+    }
+
+    #[test]
+    fn it_returns_none_when_there_is_no_prose() {
+        assert_eq!(Summary::from_md_text("", 120), None);
+        assert_eq!(
+            Summary::from_md_text("#[[OnlyTag]]\n\n![[embed]]", 120),
+            None
+        );
+    }
+
+    #[test]
+    fn it_truncates_on_character_boundaries() {
+        let summary = Summary::from_md_text("あいうえおかきくけこ", 5).unwrap();
+        assert_eq!(summary.as_str(), "あいうえお…");
+    }
+
+    #[test]
+    fn it_joins_a_hard_wrapped_paragraph() {
+        let md = "#[[Notation/Wiki-link]]\n\nWiki-link notation gives Markdown a typed surface: each `[[…]]` is a typed\nreference that the compiler can resolve, lint, and emit.\n\n## [[Normal Link|Normal link]]";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(
+            summary.as_str(),
+            "Wiki-link notation gives Markdown a typed surface: each … is a typed reference that the compiler can resolve, lint, and emit."
+        );
+    }
+
+    #[test]
+    fn it_joins_wrapped_japanese_without_inserting_spaces() {
+        let md = "ドメインエキスパートと開発者が\n共有する言語のこと";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(
+            summary.as_str(),
+            "ドメインエキスパートと開発者が共有する言語のこと"
+        );
+    }
+
+    #[test]
+    fn it_stops_at_the_end_of_the_first_paragraph() {
+        let md = "最初の段落。\n\n二つ目の段落は含めない。";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(summary.as_str(), "最初の段落。");
+    }
+
+    #[test]
+    fn it_skips_a_leading_code_fence() {
+        let md = "```mermaid\ngraph LR\n  Source --> IR\n```\n\nビルドの流れ";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(summary.as_str(), "ビルドの流れ");
+    }
+
+    // A tag inside a sentence is often its subject, so it renders rather than
+    // being dropped; only a line made of nothing but tags is skipped.
+    #[test]
+    fn it_renders_an_inline_tag_as_text() {
+        let md = "`#[[tag]]` marks a tag. Tags and scraps live in separate namespaces.";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(
+            summary.as_str(),
+            "#tag marks a tag. Tags and scraps live in separate namespaces."
+        );
+    }
+
+    #[test]
+    fn it_skips_a_line_of_only_tags_and_embeds() {
+        let md = "#[[Documentation]] #[[Software Design]]\n![[diagram]]\n\n本文はここから";
+        let summary = Summary::from_md_text(md, 200).unwrap();
+        assert_eq!(summary.as_str(), "本文はここから");
+    }
+}

--- a/tokens/check-contrast.py
+++ b/tokens/check-contrast.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Gate every semantic colour role against its surface at WCAG AA.
+
+Deliberately dependency-free: this runs in CI without adding Node to the
+core loop, unlike the CSS generation step.
+"""
+import json
+import pathlib
+import re
+import sys
+
+HERE = pathlib.Path(__file__).parent
+TEXT_ROLES = ("text", "text-muted", "accent")
+AA_BODY = 4.5
+
+
+def load():
+    prim = json.loads((HERE / "primitive.tokens.json").read_text())
+    sem = json.loads((HERE / "semantic.tokens.json").read_text())
+    flat = {}
+
+    def walk(node, prefix=""):
+        for key, val in node.items():
+            if key.startswith("$") or not isinstance(val, dict):
+                continue
+            if "$value" in val:
+                flat[prefix + key] = val["$value"]
+            else:
+                walk(val, prefix + key + ".")
+
+    walk(prim)
+    return flat, sem
+
+
+def resolve(value, flat):
+    ref = re.findall(r"\{([^}]+)\}", value)
+    return flat[ref[0]] if ref else value
+
+
+def luminance(hex_color):
+    raw = hex_color.lstrip("#")
+    channels = [int(raw[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+    channels = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels]
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+
+
+def contrast(a, b):
+    la, lb = luminance(a), luminance(b)
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+
+
+def main():
+    flat, sem = load()
+    roles = sem["color"]
+    failures = []
+    for mode in ("light", "dark"):
+        surface = resolve(roles["surface"][mode]["$value"], flat)
+        for name in TEXT_ROLES:
+            value = resolve(roles[name][mode]["$value"], flat)
+            ratio = contrast(value, surface)
+            status = "ok" if ratio >= AA_BODY else "FAIL"
+            print(f"{status:4s} {mode:5s} {name:12s} {value} on {surface}  {ratio:5.2f}:1")
+            if ratio < AA_BODY:
+                failures.append(f"{mode}/{name} {ratio:.2f}:1 < {AA_BODY}")
+    if failures:
+        print("\n" + "\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,0 +1,2478 @@
+{
+  "name": "scraps-tokens",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scraps-tokens",
+      "devDependencies": {
+        "style-dictionary": "^4.4.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/deepmerge": {
+      "version": "4.3.2",
+      "resolved": "https://npm.flatt.tech/@bundled-es-modules/deepmerge/-/deepmerge-4.3.2.tgz",
+      "integrity": "sha512-q8doe7ndrY2IolUOFIn0A0++JBX38pMhN7kFhTF4cnjIcILf6X6H2yWczInyv8ZFdR0lrE8088X8XS5efxXz8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob": {
+      "version": "10.4.2",
+      "resolved": "https://npm.flatt.tech/@bundled-es-modules/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "glob": "^10.4.2",
+        "patch-package": "^8.0.0",
+        "path": "^0.12.7",
+        "stream": "^0.0.3",
+        "string_decoder": "^1.3.0",
+        "url": "^0.11.3"
+      }
+    },
+    "node_modules/@bundled-es-modules/memfs": {
+      "version": "4.17.0",
+      "resolved": "https://npm.flatt.tech/@bundled-es-modules/memfs/-/memfs-4.17.0.tgz",
+      "integrity": "sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "assert": "^2.1.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "memfs": "^4.17.0",
+        "path": "^0.12.7",
+        "stream": "^0.0.3",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://npm.flatt.tech/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "glob-to-regex.js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.21.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://npm.flatt.tech/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://npm.flatt.tech/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.61",
+      "resolved": "https://npm.flatt.tech/@zip.js/zip.js/-/zip.js-2.8.61.tgz",
+      "integrity": "sha512-F9RnQJXgvCSdAJfMtSrH5Uh/LcLg8fZlg5ARC4u5N4w9v/DG27cN3C/ngUrY1JdJGX2LRv5DDViXeZJgbcppWA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://npm.flatt.tech/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://npm.flatt.tech/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://npm.flatt.tech/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://npm.flatt.tech/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://npm.flatt.tech/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://npm.flatt.tech/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://npm.flatt.tech/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://npm.flatt.tech/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://npm.flatt.tech/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://npm.flatt.tech/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://npm.flatt.tech/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://npm.flatt.tech/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://npm.flatt.tech/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://npm.flatt.tech/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://npm.flatt.tech/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://npm.flatt.tech/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://npm.flatt.tech/component-emitter/-/component-emitter-2.0.0.tgz",
+      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://npm.flatt.tech/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://npm.flatt.tech/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://npm.flatt.tech/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://npm.flatt.tech/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://npm.flatt.tech/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://npm.flatt.tech/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://npm.flatt.tech/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://npm.flatt.tech/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://npm.flatt.tech/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://npm.flatt.tech/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://npm.flatt.tech/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://npm.flatt.tech/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://npm.flatt.tech/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://npm.flatt.tech/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://npm.flatt.tech/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://npm.flatt.tech/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://npm.flatt.tech/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://npm.flatt.tech/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://npm.flatt.tech/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://npm.flatt.tech/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://npm.flatt.tech/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://npm.flatt.tech/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://npm.flatt.tech/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://npm.flatt.tech/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://npm.flatt.tech/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://npm.flatt.tech/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://npm.flatt.tech/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://npm.flatt.tech/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://npm.flatt.tech/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://npm.flatt.tech/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://npm.flatt.tech/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://npm.flatt.tech/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://npm.flatt.tech/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://npm.flatt.tech/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://npm.flatt.tech/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://npm.flatt.tech/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://npm.flatt.tech/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://npm.flatt.tech/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://npm.flatt.tech/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://npm.flatt.tech/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://npm.flatt.tech/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://npm.flatt.tech/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://npm.flatt.tech/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://npm.flatt.tech/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://npm.flatt.tech/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://npm.flatt.tech/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "4.68.1",
+      "resolved": "https://npm.flatt.tech/memfs/-/memfs-4.68.1.tgz",
+      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://npm.flatt.tech/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://npm.flatt.tech/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://npm.flatt.tech/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://npm.flatt.tech/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://npm.flatt.tech/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://npm.flatt.tech/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://npm.flatt.tech/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://npm.flatt.tech/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://npm.flatt.tech/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://npm.flatt.tech/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://npm.flatt.tech/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://npm.flatt.tech/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://npm.flatt.tech/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://npm.flatt.tech/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://npm.flatt.tech/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-unified": {
+      "version": "0.2.0",
+      "resolved": "https://npm.flatt.tech/path-unified/-/path-unified-0.2.0.tgz",
+      "integrity": "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://npm.flatt.tech/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://npm.flatt.tech/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://npm.flatt.tech/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://npm.flatt.tech/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://npm.flatt.tech/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://npm.flatt.tech/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://npm.flatt.tech/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://npm.flatt.tech/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://npm.flatt.tech/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://npm.flatt.tech/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://npm.flatt.tech/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://npm.flatt.tech/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://npm.flatt.tech/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://npm.flatt.tech/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://npm.flatt.tech/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://npm.flatt.tech/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://npm.flatt.tech/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stream": {
+      "version": "0.0.3",
+      "resolved": "https://npm.flatt.tech/stream/-/stream-0.0.3.tgz",
+      "integrity": "sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^2.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://npm.flatt.tech/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://npm.flatt.tech/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://npm.flatt.tech/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://npm.flatt.tech/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://npm.flatt.tech/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://npm.flatt.tech/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://npm.flatt.tech/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://npm.flatt.tech/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://npm.flatt.tech/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/style-dictionary": {
+      "version": "4.4.0",
+      "resolved": "https://npm.flatt.tech/style-dictionary/-/style-dictionary-4.4.0.tgz",
+      "integrity": "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.1",
+        "@bundled-es-modules/glob": "^10.4.2",
+        "@bundled-es-modules/memfs": "^4.9.4",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "patch-package": "^8.0.0",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://npm.flatt.tech/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thingies": {
+      "version": "2.6.1",
+      "resolved": "https://npm.flatt.tech/thingies/-/thingies-2.6.1.tgz",
+      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://npm.flatt.tech/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://npm.flatt.tech/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://npm.flatt.tech/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.1.0",
+      "resolved": "https://npm.flatt.tech/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://npm.flatt.tech/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://npm.flatt.tech/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://npm.flatt.tech/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://npm.flatt.tech/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://npm.flatt.tech/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://npm.flatt.tech/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://npm.flatt.tech/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://npm.flatt.tech/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://npm.flatt.tech/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://npm.flatt.tech/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://npm.flatt.tech/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://npm.flatt.tech/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://npm.flatt.tech/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://npm.flatt.tech/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "scraps-tokens",
+  "private": true,
+  "type": "module",
+  "description": "Generates the site's CSS custom properties from the DTCG token files.",
+  "scripts": {
+    "build": "style-dictionary build --config style-dictionary.config.mjs"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.4.0"
+  }
+}

--- a/tokens/primitive.tokens.json
+++ b/tokens/primitive.tokens.json
@@ -1,0 +1,36 @@
+{
+  "$description": "Palette primitives. The only place raw hex appears — swap this file to change the palette without touching the semantic layer.",
+  "color": {
+    "$type": "color",
+    "nord": {
+      "$description": "Nord by Sven Greb / Arctic Ice Studio (MIT) — https://www.nordtheme.com/",
+      "0":  { "$value": "#2e3440" },
+      "1":  { "$value": "#3b4252" },
+      "2":  { "$value": "#434c5e" },
+      "3":  { "$value": "#4c566a" },
+      "4":  { "$value": "#d8dee9" },
+      "5":  { "$value": "#e5e9f0" },
+      "6":  { "$value": "#eceff4" },
+      "7":  { "$value": "#8fbcbb" },
+      "8":  { "$value": "#88c0d0" },
+      "9":  { "$value": "#81a1c1" },
+      "10": { "$value": "#5e81ac" },
+      "11": { "$value": "#bf616a" },
+      "12": { "$value": "#d08770" },
+      "13": { "$value": "#ebcb8b" },
+      "14": { "$value": "#a3be8c" },
+      "15": { "$value": "#b48ead" }
+    },
+    "ext": {
+      "$description": "Outside the Nord ramp. Added only where no Nord colour meets WCAG AA against a Nord surface.",
+      "frost-deep": {
+        "$value": "#47698f",
+        "$description": "Darkened nord10 for accents on light surfaces. 4.94:1 on nord6; nord10 reaches 3.50:1 and nord8 only 1.74:1."
+      },
+      "slate-mid": {
+        "$value": "#5d6a80",
+        "$description": "Muted text on light surfaces. 4.75:1 on nord6, sitting below text (nord3, 6.40:1) so the hierarchy still reads."
+      }
+    }
+  }
+}

--- a/tokens/semantic.tokens.json
+++ b/tokens/semantic.tokens.json
@@ -1,0 +1,218 @@
+{
+  "color": {
+    "surface": {
+      "$description": "Page ground.",
+      "light": {
+        "$value": "{color.nord.6}"
+      },
+      "dark": {
+        "$value": "{color.nord.0}"
+      }
+    },
+    "surface-raised": {
+      "$description": "Separated from the ground without elevation: code blocks, inputs. No shadow — compiler output does not float.",
+      "light": {
+        "$value": "#ffffff"
+      },
+      "dark": {
+        "$value": "{color.nord.1}"
+      }
+    },
+    "text": {
+      "$description": "Body. 6.40:1 on light, 10.85:1 on dark.",
+      "light": {
+        "$value": "{color.nord.3}"
+      },
+      "dark": {
+        "$value": "{color.nord.6}"
+      }
+    },
+    "text-muted": {
+      "$description": "Metadata: namespace, counts, timestamps. 4.75:1 on light, 4.64:1 on dark — AA, unlike the 3.10:1 it replaces.",
+      "light": {
+        "$value": "{color.ext.slate-mid}"
+      },
+      "dark": {
+        "$value": "{color.nord.9}"
+      }
+    },
+    "rule": {
+      "$description": "Hairlines. Carries the separation that shadows used to. Has a dark value, which the horizontal-rule colour it replaces did not.",
+      "light": {
+        "$value": "{color.nord.4}"
+      },
+      "dark": {
+        "$value": "{color.nord.2}"
+      }
+    },
+    "accent": {
+      "$description": "Links, including wiki-links and tags. 4.94:1 on light, 6.24:1 on dark — replaces nord8's 1.74:1 on light.",
+      "light": {
+        "$value": "{color.ext.frost-deep}"
+      },
+      "dark": {
+        "$value": "{color.nord.8}"
+      }
+    },
+    "$description": "Semantic layer. Components reference only these; never a primitive directly. Each colour role carries a light and a dark value, emitted as CSS light-dark()."
+  },
+  "font": {
+    "family": {
+      "$type": "fontFamily",
+      "sans": {
+        "$value": [
+          "Rubik",
+          "Noto Sans JP",
+          "sans-serif"
+        ]
+      },
+      "mono": {
+        "$value": [
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Consolas",
+          "monospace"
+        ],
+        "$description": "New. Typed primitives — [[reference]], #[[tag]], ctx_path — are syntax, and the product's whole claim is that they are typed. Typography should say so."
+      }
+    },
+    "weight": {
+      "$type": "fontWeight",
+      "regular": {
+        "$value": 400
+      },
+      "medium": {
+        "$value": 500
+      },
+      "bold": {
+        "$value": 700
+      }
+    },
+    "size": {
+      "$type": "dimension",
+      "xs": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        }
+      },
+      "sm": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        }
+      },
+      "base": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        }
+      },
+      "lg": {
+        "$value": {
+          "value": 20,
+          "unit": "px"
+        }
+      },
+      "xl": {
+        "$value": {
+          "value": 26,
+          "unit": "px"
+        }
+      },
+      "2xl": {
+        "$value": {
+          "value": 34,
+          "unit": "px"
+        }
+      }
+    },
+    "line-height": {
+      "$type": "number",
+      "tight": {
+        "$value": 1.25
+      },
+      "body": {
+        "$value": 1.7
+      }
+    }
+  },
+  "space": {
+    "$type": "dimension",
+    "$description": "4px base. Replaces the ad-hoc 32px used almost everywhere today.",
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      }
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      }
+    },
+    "5": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "6": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      }
+    },
+    "7": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      }
+    }
+  },
+  "radius": {
+    "$type": "dimension",
+    "$description": "Reduced from 2/4/8 to 2/4. Nothing in a compiler's output is pillowy.",
+    "none": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      }
+    },
+    "sm": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      }
+    }
+  },
+  "border": {
+    "$type": "dimension",
+    "hairline": {
+      "$value": {
+        "value": 1,
+        "unit": "px"
+      }
+    }
+  }
+}

--- a/tokens/style-dictionary.config.mjs
+++ b/tokens/style-dictionary.config.mjs
@@ -1,0 +1,104 @@
+import StyleDictionary from 'style-dictionary';
+
+const OUT = '../src/usecase/build/css/builtins/_tokens.css';
+
+/// Semantic colours pair a light and a dark value under one role. CSS
+/// light-dark() keeps that in a single stylesheet, which is why the built-in
+/// css/variables format cannot be used here.
+const MODES = ['light', 'dark'];
+
+function cssName(path) {
+  const [head, ...rest] = path;
+  if (head === 'color' && rest[0] === 'nord') return `--nord${rest[1]}`;
+  if (head === 'color' && rest[0] === 'ext') return `--ext-${rest.slice(1).join('-')}`;
+  if (head === 'color') return `--color-${rest.filter((p) => !MODES.includes(p)).join('-')}`;
+  return `--${path.join('-')}`;
+}
+
+/// Generic families must stay unquoted to keep their keyword meaning;
+/// everything else is a family name and is quoted.
+const GENERIC_FAMILIES = new Set([
+  'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui',
+  'ui-serif', 'ui-sans-serif', 'ui-monospace', 'ui-rounded', 'math', 'emoji',
+]);
+
+function groupOf(path, name) {
+  if (name.startsWith('--nord') || name.startsWith('--ext-')) return 'primitive';
+  if (path[0] === 'color') return 'color';
+  return path.slice(0, -1).join('-');
+}
+
+function literal(token) {
+  const raw = token.original?.$value ?? token.$value;
+  if (typeof raw === 'string' && raw.startsWith('{')) {
+    return `var(${cssName(raw.slice(1, -1).split('.'))})`;
+  }
+  const value = token.$value;
+  if (Array.isArray(value)) {
+    return value.map((f) => (GENERIC_FAMILIES.has(f) ? f : `"${f}"`)).join(', ');
+  }
+  if (value && typeof value === 'object' && 'unit' in value) {
+    return `${value.value}${value.unit}`;
+  }
+  return String(value);
+}
+
+function walk(node, path, out) {
+  for (const [key, child] of Object.entries(node)) {
+    if (key.startsWith('$') || typeof child !== 'object') continue;
+    if ('$value' in child) out.push([[...path, key], child]);
+    else walk(child, [...path, key], out);
+  }
+}
+
+StyleDictionary.registerFormat({
+  name: 'scraps/css-custom-properties',
+  format: ({ dictionary }) => {
+    const flat = [];
+    walk(dictionary.tokens, [], flat);
+
+    const lines = [
+      '    /* Generated from tokens/*.tokens.json — do not edit. `mise run tokens:build` */',
+      '',
+    ];
+    const emitted = new Set();
+    let group = null;
+
+    for (const [path, token] of flat) {
+      const name = cssName(path);
+      if (emitted.has(name)) continue;
+
+      const nextGroup = groupOf(path, name);
+      if (group !== null && nextGroup !== group) lines.push('');
+      group = nextGroup;
+
+      const mode = path[path.length - 1];
+      if (MODES.includes(mode)) {
+        const pair = MODES.map((m) => {
+          const sibling = flat.find(
+            ([p]) => cssName(p) === name && p[p.length - 1] === m,
+          );
+          return literal(sibling[1]);
+        });
+        lines.push(`    ${name}: light-dark(${pair.join(', ')});`);
+      } else {
+        lines.push(`    ${name}: ${literal(token)};`);
+      }
+      emitted.add(name);
+    }
+
+    return lines.join('\n') + '\n';
+  },
+});
+
+export default {
+  source: ['*.tokens.json'],
+  platforms: {
+    css: {
+      // The format computes its own names; this only keeps Style Dictionary's
+      // internal names unique so genuine collisions still get reported.
+      transforms: ['name/kebab'],
+      files: [{ destination: OUT, format: 'scraps/css-custom-properties' }],
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Replaces the built-in theme's card layout with a token-driven design system.

The index presented every scrap as a drop-shadowed card whose body was the first N characters of the rendered HTML. That leaked tag notation and context breadcrumbs into the excerpt (`#Content Internal links like wiki Specifying the name of…`), fit five entries on a screen, and said nothing about a scrap's position in the link graph.

**Design tokens.** Colours, type, spacing, radii and border widths move into DTCG token files under `tokens/`, generated into `src/usecase/build/css/builtins/_tokens.css` by Style Dictionary v4 and pulled into `main.css` through a Tera `{% include %}`. `tokens/primitive.tokens.json` is the only file containing raw hex, so a palette change is a one-file swap.

**Index rows.** `macros.html` gains a `scrap_rows` component: the namespace sits beside the title where it disambiguates (`Pod` vs `Pod Kubernetes`), and each row carries the scrap's outbound and inbound link counts. `scrap_links` stays as the compact list used by scrap and tag pages. Roughly ten entries now fit where five did, each carrying more information. Both counts were already reaching the template, so no new query work was needed.

**Summaries.** `Summary::from_md_text` derives the gloss from the markdown rather than the rendered HTML. A leading heading is a term's expanded name (`ADR` → `Architectural Decision Records`) and wins outright; otherwise tag-only lines, code fences and block breaks are skipped and the first paragraph is joined across hard wraps, without inserting spaces into wrapped Japanese. Tags and embeds inside a sentence render as text rather than being dropped, since they are often the subject.

**Accessibility.** The light accent was `nord8` on `nord6` at **1.74:1** and muted text at **3.10:1**, both well under WCAG AA. They are now 4.94:1 and 4.75:1, using one darkened Nord-adjacent value each. `tokens/check-contrast.py` gates every colour role against its surface and needs no Node.

Drop shadows are gone (separation comes from rules), typed primitives are set in a monospace face, and the emoji pseudo-element icons (🏷 🔍 ⬅ ➡) are replaced by typography.

## Related Issues

<!-- none -->

## Docs deployment

The Pages workflow installed the released `boykush/scraps` action and ran that binary against `docs/`, and triggered on `docs/**` only. That meant this PR's redesign would not have appeared on the docs site until a release cut a new binary, and a source-only change would not have redeployed at all.

The build now sets up rust through mise and runs `mise run docs:build`, which compiles the binary from the checkout and uses it; `src/**`, `modules/**`, `Cargo.{toml,lock}` and `.mise-tasks/docs/**` join the trigger paths. `docs:build` and `docs:serve` share that binary so local preview matches what deploys.

**Known gap, left for a separate change:** the e2e suite still runs against the released binary. Playwright's `webServer` spawns `scraps serve` from PATH, which mise pins to `v1.1.0`, so the suite does not currently exercise template or CSS changes in a PR. Same defect, and arguably more serious there.

Also noticed but not touched: the deploy checkout uses `fetch-depth: 0` "For scraps git committed date", but the build never passes `--git`, so the full history fetch is currently doing nothing.

## Logo and social preview

The old mark — an illustrated card stack ringed with document icons and a network graph — came from the v0 framing of scraps as a notes-shaped SSG, and was busy enough to dissolve at favicon size.

It is replaced by `[[ ]]` with a node between the brackets: wiki-link notation is the one piece of syntax only this product owns, and the enclosed node reads as the typed reference that notation denotes. The colours are the site's own semantic roles in their dark-theme values (plate = `surface`, brackets = `text`, node = `accent`), so the icon is the theme in miniature and follows any palette change made in `tokens/`.

`assets/logo.svg` is the source; `assets/render.mjs` (`mise run assets:build`) regenerates the PNGs from it, borrowing the e2e suite's Playwright rather than adding a second headless browser. Re-running reproduces both files byte for byte. Verified at the sizes that ship — the mark still reads as `[[·]]` at 16px, which its predecessor did not.

The `_opacity` twins are written identically: a plated mark carries its own background, so the distinction they encoded no longer exists. Collapsing them to one file each would be a reasonable follow-up, but it would break the README and docs references and is left out here.

## Additional Notes

- `mise.toml` gains `node = "24.19.0"` for the token build, matching what `boykush/livt` already does. Node is only needed to regenerate `_tokens.css`; the shipped binary is unchanged and the contrast gate is dependency-free.
- New tasks: `mise run tokens:build` and `mise run tokens:check` (freshness + AA). **`tokens:check` is not wired into CI or the hk pre-commit hook yet** — the existing workflow is Rust-only and I did not want to guess at how a Node job should be added.
- The three selectors the Playwright suite depends on (`.readme-block`, `#search-input`, `#search-results`) are preserved. The `<span class="icon" />` before the search input was removed: being self-closing it never closed, so anything styled on it swallowed the input.
- Verified with 240 unit tests, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and by building `docs/` and reviewing it in both light and dark. The freshness and contrast gates were each confirmed to fail when deliberately broken.
- Follow-up: `SerializeLinkScrap::html_text` renders every linked scrap's markdown on every page and now has no consumer. Removing it should help the 4-second CI performance budget.
- The branch name refers to the icon/thumbnail work that started this session; that work is still open and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

