### PR TITLE
perf(build): drop dead html_text left over from the token-based UI

### DIFF
--- a/src/usecase/build/html/scrap_render.rs
+++ b/src/usecase/build/html/scrap_render.rs
@@ -45,10 +45,7 @@ impl ScrapRender {
         context.insert("scrap", &ScrapDetailTera::from(scrap_detail.clone()));
 
         let linked_scraps = backlinks_map.get(&scrap.self_key());
-        context.insert(
-            "linked_scraps",
-            &LinkScrapsTera::new(&linked_scraps, base_url),
-        );
+        context.insert("linked_scraps", &LinkScrapsTera::new(&linked_scraps));
 
         // The stem may contain `/`-separated context directories, which
         // `render_to_file` creates on the way.

--- a/src/usecase/build/html/serde/index_scraps.rs
+++ b/src/usecase/build/html/serde/index_scraps.rs
@@ -18,7 +18,6 @@ struct SerializeIndexScrap {
     ctx: Option<String>,
     title: String,
     html_file_name: String,
-    html_text: String,
     thumbnail: Option<Url>,
     summary: Option<String>,
     pub commited_ts: Option<i64>,
@@ -29,7 +28,6 @@ struct SerializeIndexScrap {
 impl SerializeIndexScrap {
     pub fn new(scrap_detail: &ScrapDetail, backlinks_map: &BacklinksMap) -> SerializeIndexScrap {
         let scrap = scrap_detail.scrap();
-        let content = scrap_detail.content();
         let commited_ts = scrap_detail.commited_ts();
         let backlinks_count = backlinks_map.get(&scrap.self_key()).len();
         let links_count = scrap.links().len();
@@ -40,7 +38,6 @@ impl SerializeIndexScrap {
             ctx: scrap.ctx().as_ref().map(|c| c.to_string()),
             title: scrap.title().to_string(),
             html_file_name,
-            html_text: content.to_string(),
             thumbnail: scrap.thumbnail(),
             summary,
             commited_ts,

--- a/src/usecase/build/html/serde/link_scraps.rs
+++ b/src/usecase/build/html/serde/link_scraps.rs
@@ -1,30 +1,21 @@
 use itertools::Itertools;
-use url::Url;
 
-use scraps_libs::{
-    html::{self, EmbedMode},
-    model::{base_url::BaseUrl, file::ScrapFileStem, scrap::Scrap},
-};
+use scraps_libs::model::{file::ScrapFileStem, scrap::Scrap};
 
 #[derive(serde::Serialize, Clone, PartialEq, Debug)]
 struct SerializeLinkScrap {
     ctx: Option<String>,
     title: String,
     html_file_name: String,
-    html_text: String,
-    thumbnail: Option<Url>,
 }
 
 impl SerializeLinkScrap {
-    fn new(scrap: &Scrap, base_url: &BaseUrl) -> SerializeLinkScrap {
-        let content = html::to_content(scrap.md_text(), base_url, EmbedMode::Preserve);
+    fn new(scrap: &Scrap) -> SerializeLinkScrap {
         let html_file_name = format!("{}.html", ScrapFileStem::from(scrap.self_key().clone()));
         SerializeLinkScrap {
             ctx: scrap.ctx().as_ref().map(|c| c.to_string()),
             title: scrap.title().to_string(),
             html_file_name,
-            html_text: content.to_string(),
-            thumbnail: scrap.thumbnail(),
         }
     }
 }
@@ -33,11 +24,8 @@ impl SerializeLinkScrap {
 pub struct LinkScrapsTera(Vec<SerializeLinkScrap>);
 
 impl LinkScrapsTera {
-    pub fn new(scraps: &[Scrap], base_url: &BaseUrl) -> LinkScrapsTera {
-        let serialize_scraps = scraps
-            .iter()
-            .map(|s| SerializeLinkScrap::new(s, base_url))
-            .collect_vec();
+    pub fn new(scraps: &[Scrap]) -> LinkScrapsTera {
+        let serialize_scraps = scraps.iter().map(SerializeLinkScrap::new).collect_vec();
 
         LinkScrapsTera(serialize_scraps)
     }

--- a/src/usecase/build/html/tag_render.rs
+++ b/src/usecase/build/html/tag_render.rs
@@ -44,10 +44,7 @@ impl TagRender {
         context.insert("tag", &TagTera::new(tag, backlinks_map));
 
         let linked_scraps = backlinks_map.get_tag(tag);
-        context.insert(
-            "linked_scraps",
-            &LinkScrapsTera::new(&linked_scraps, base_url),
-        );
+        context.insert("linked_scraps", &LinkScrapsTera::new(&linked_scraps));
 
         // Build the slug-based path: `tags/<slug-segment>/<...>.html`. Each
         // segment of a hierarchical tag becomes a directory.


### PR DESCRIPTION
## Summary

The design-token rebuild in #663 replaced the drop-shadowed excerpt cards with dense rows and a plain link list. `scrap_rows` now glosses each entry with `Summary::from_md_text`, and `scrap_links` renders title and ctx alone. The `html_text` field both components used to read stayed behind on the two serializers, unread by any template.

The waste was not evenly distributed:

- **`SerializeLinkScrap`** ran `html::to_content(...)` — a full markdown-to-HTML render — for every linked scrap, on every scrap page and every tag page. Nothing consumed the result. Its `thumbnail` went unread the same way once `scrap_links` stopped rendering images, and with both fields gone `base_url` has no remaining use, so it drops from the constructor and both call sites.
- **`SerializeIndexScrap`** only cloned an already-built content string (the render itself is shared since 2f86dc9), but `IndexScrapsTera::chunks` clones the whole vec per chunk, so paginated builds paid for it repeatedly.

## Performance

Measured against the CI gate's own corpus, [boykush/wiki](https://github.com/boykush/wiki) at 1029 scraps, `scraps build -C <wiki>` in release mode. 25 interleaved before/after runs on the same machine:

| | min | p50 | mean | p90 |
|---|---|---|---|---|
| before | 0.253s | 0.278s | 0.280s | 0.299s |
| after | 0.172s | 0.191s | 0.200s | 0.246s |
| **delta** | **-0.081s (-31.9%)** | **-0.087s (-31.2%)** | **-0.080s (-28.6%)** | |

Roughly a 31% cut against the 4-second performance gate.

## Correctness

All **1072 generated files are byte-for-byte identical** before and after (`diff -r` over the full `_site` output). This is the load-bearing check: if any removed field still reached a template, the output would differ.

Also verified on this branch:

- `cargo test` — 240 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

No test needed updating; the existing tests compare whole structs rather than naming the removed fields.

## Note for review

Removing `thumbnail` from `SerializeLinkScrap` goes one step beyond the dead-render cleanup — it is dead only because the new `scrap_links` is a plain title/ctx link list. If backlink thumbnails are meant to return, say so and I will restore that field alone; the `html_text` removal stands either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)