### PR TITLE
ci(tokens): gate design tokens in CI and on commit

### DIFF
--- a/.github/workflows/tokens-check.yml
+++ b/.github/workflows/tokens-check.yml
@@ -1,0 +1,47 @@
+name: Design tokens
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'tokens/**'
+      - 'src/usecase/build/css/builtins/_tokens.css'
+      - '.mise-tasks/tokens/**'
+      - '.github/workflows/tokens-check.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'tokens/**'
+      - 'src/usecase/build/css/builtins/_tokens.css'
+      - '.mise-tasks/tokens/**'
+      - '.github/workflows/tokens-check.yml'
+
+env:
+  # Only node is installed below; keep the task from pulling the rest of the
+  # toolchain (rust, pkl, hk) that mise.toml declares.
+  MISE_AUTO_INSTALL: "false"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        cache: false
+        install_args: "node"
+    - name: Check design tokens
+      run: mise run tokens:check
+      # Runs tokens:check-contrast (python3, preinstalled) and
+      # tokens:check-generated (Style Dictionary, needs node)

--- a/.mise-tasks/tokens/check
+++ b/.mise-tasks/tokens/check
@@ -1,22 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Fail if the generated token CSS is stale, or a colour role misses WCAG AA"
-#MISE dir="tokens"
-set -euo pipefail
-
-python3 check-contrast.py
-
-generated="../src/usecase/build/css/builtins/_tokens.css"
-before="$(mktemp)"
-trap 'rm -f "$before"' EXIT
-cp "$generated" "$before"
-
-npm install --no-fund --no-audit
-npm run build
-
-# Compared against the file itself rather than against git, so the check also
-# holds before the generated CSS is first committed.
-if ! diff -q "$before" "$generated" >/dev/null; then
-  echo "error: $generated is out of date. Run 'mise run tokens:build' and commit the result." >&2
-  diff "$before" "$generated" >&2
-  exit 1
-fi
+#MISE depends=["tokens:check-contrast", "tokens:check-generated"]
+echo '✅ All token checks passed!'

--- a/.mise-tasks/tokens/check-contrast
+++ b/.mise-tasks/tokens/check-contrast
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Fail if a semantic colour role misses WCAG AA against its surface"
+#MISE dir="tokens"
+set -euo pipefail
+
+# Split out of tokens:check so the commit hook can gate accessibility without
+# paying for a Node install. Dependency-free and read-only, unlike the
+# generated-CSS half.
+python3 check-contrast.py

--- a/.mise-tasks/tokens/check-generated
+++ b/.mise-tasks/tokens/check-generated
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Fail if the generated token CSS is stale against the token files"
+#MISE dir="tokens"
+set -euo pipefail
+
+generated="../src/usecase/build/css/builtins/_tokens.css"
+before="$(mktemp)"
+trap 'rm -f "$before"' EXIT
+cp "$generated" "$before"
+
+npm install --no-fund --no-audit
+npm run build
+
+# Compared against the file itself rather than against git, so the check also
+# holds before the generated CSS is first committed.
+if ! diff -q "$before" "$generated" >/dev/null; then
+  echo "error: $generated is out of date. Run 'mise run tokens:build' and commit the result." >&2
+  diff "$before" "$generated" >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ The pre-commit hook runs quality checks on staged files:
   - Linter checks (clippy)
 - **PKL files (*.pkl)**: Validates configuration syntax
 - **Plugin sources (`plugins/**`)**: Runs `mise run plugins:check-version`, which blocks the commit when a plugin's content (skills, agents, etc.) changes without also updating its `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` (i.e. bumping the `version`).
+- **Design tokens (`tokens/**`)**: Runs `mise run tokens:check-contrast`, which blocks the commit when a semantic colour role falls below WCAG AA against its surface. Only this half of `tokens:check` runs on commit — it needs nothing but `python3`. The other half, which regenerates `src/usecase/build/css/builtins/_tokens.css` and fails if the committed file is stale, needs Node and runs in CI (`.github/workflows/tokens-check.yml`). Run `mise run tokens:check` locally to get both.
 
 If any check fails, the commit will be blocked. Fix the issues and try again.
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -22,6 +22,15 @@ local linters = new Mapping<String, Step> {
         glob = "plugins/**/*"
         check = "mise run plugins:check-version"
     }
+
+    // Design token accessibility gate. Only the contrast half of tokens:check
+    // runs here: it is dependency-free and read-only, while the freshness half
+    // needs a Node install and rewrites the generated CSS in place, which a
+    // fix = false hook must not do. CI runs both.
+    ["tokens_contrast"] = new Step {
+        glob = "tokens/**"
+        check = "mise run tokens:check-contrast"
+    }
 }
 
 hooks {


### PR DESCRIPTION
<!-- 🙏 Thanks for your contribution! -->

## Summary

[#663](https://github.com/boykush/scraps/pull/663) added the design tokens and a `mise run tokens:check` task, but nothing invoked it. The generated CSS could go stale and a colour role could drop below WCAG AA with nothing to catch either. This wires the task into CI and the pre-commit hook.

The task is split in two:

| Task | What it gates | Needs | Cost |
| --- | --- | --- | --- |
| `tokens:check-contrast` | Every semantic colour role clears WCAG AA against its surface | `python3` only | 51ms |
| `tokens:check-generated` | `_tokens.css` matches the token files | Node + Style Dictionary | 3.6s cold, 0.9s warm |
| `tokens:check` | Aggregate of both, via `#MISE depends` | | |

`mise run tokens:check` behaves exactly as before, so nothing downstream of it changes.

- **CI** — `.github/workflows/tokens-check.yml` runs the aggregate, scoped to `tokens/**`, `src/usecase/build/css/builtins/_tokens.css`, `.mise-tasks/tokens/**` and the workflow itself.
- **Pre-commit** — `hk.pkl` gates `tokens/**` with `tokens:check-contrast` only.

## Related Issues

Follows up [#663](https://github.com/boykush/scraps/pull/663).

## Additional Notes

**Why the hook only runs the contrast half.** Speed was not the deciding factor — 0.9s warm would have been tolerable. `tokens:check-generated` regenerates `_tokens.css` *in place* and only then diffs it, so on a stale file it silently rewrites the working tree before failing. The pre-commit hook is `fix = false` with `stash = "git"`; a step that mutates tracked files underneath a stash/restore cycle is a hazard, independent of its runtime. The contrast half is read-only and needs no Node, so it is the half that belongs on the commit path.

**The resulting gap, by design.** Committing a token edit without regenerating the CSS passes the hook and fails in CI. CI is the backstop for staleness; the hook is the fast gate for accessibility. `CONTRIBUTING.md` states this, and points at `mise run tokens:check` for both locally.

**Why a dedicated workflow instead of a job in `cargo-test-and-lint.yml`.** Path filters in GitHub Actions apply per workflow, not per job, so a job added there would inherit that workflow's `paths-ignore` and run on nearly every push — the opposite of the intended scoping. The new workflow follows the existing setup convention: `actions/checkout` and `jdx/mise-action` pinned by SHA, `persist-credentials: false`, `cache: false`, `install_args: "node"`, and `MISE_AUTO_INSTALL: "false"` so the task does not pull in rust/pkl/hk.

## Verification

Each half was broken deliberately and confirmed caught:

| Break | Result |
| --- | --- |
| `text-muted` light → `nord4` (1.17:1) | Hook failed with `light/text-muted 1.17:1 < 4.5`; `git commit` exited 1, HEAD unchanged |
| ↳ same break via CI path | `mise run tokens:check` exited 1 |
| Hand-edited `_tokens.css` | `tokens:check-generated` exited 1, printing the offending diff line |
| ↳ same break via CI path | `mise run tokens:check` exited 1 |
| Valid tokens staged | Hook fired (`1 file – tokens/**`) and passed — no false positive |

Also verified: `pkl eval hk.pkl` valid, `actionlint` clean, `zizmor --persona regular` reports no findings on the new workflow, and the happy path (`mise run tokens:check`) exits 0 after rebasing onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
