### PR TITLE
ci(e2e): run the Playwright suite against the binary from this checkout

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,11 +23,18 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - name: Setup mise (install scraps)
+    - name: Setup mise (install rust)
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         cache: false
-        install_args: "github:boykush/scraps"
+        install_args: "rust"
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+    # Built from this checkout, so the suite renders the PR's templates and CSS
+    # instead of a released binary's. Ahead of the browser install so a compile
+    # error fails fast, and outside Playwright's webServer command, whose 30s
+    # timeout a cold release build would exceed.
+    - name: Build scraps
+      run: cargo build --release
     - name: Setup Node.js
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
@@ -41,10 +48,10 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       working-directory: ./tests/e2e
-      env:
-        # Skip auto-install of dev-only tools (rust, cargo-deny, llvm-cov, hk,
-        # pkl, markdownlint-cli2) when the webServer subprocess invokes
-        # `mise run docs:serve`. Only scraps is required and is installed
-        # explicitly by the mise-action step above.
-        MISE_AUTO_INSTALL: "false"
       run: npx playwright test
+
+env:
+  # rust and node are installed explicitly by the mise-action steps above; stop
+  # the shims from also pulling in the rest of mise.toml (hk, pkl,
+  # markdownlint-cli2, cargo-llvm-cov, cargo-deny), which this job never runs.
+  MISE_AUTO_INSTALL: "false"

--- a/.mise-tasks/e2e/test
+++ b/.mise-tasks/e2e/test
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
-#MISE description="Run E2E tests with Playwright"
+#MISE description="Run E2E tests with Playwright against the scraps binary from this checkout"
 #MISE dir="tests/e2e"
-npm install && npx playwright test
+set -euo pipefail
+
+# Built here rather than from playwright.config.ts's webServer command, whose
+# 30s timeout a cold release build would exceed.
+(cd ../.. && cargo build --release)
+
+npm install
+npx playwright test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,9 @@ mise run e2e:test
 
 E2E tests are configured to:
 - Use three browsers: Chromium, Firefox, and WebKit
-- Automatically start `cargo run serve` on `http://127.0.0.1:1112`
+- Build `scraps` from this checkout and serve `docs/` with it on
+  `http://127.0.0.1:1112`, so template and CSS changes are what the suite
+  renders
 - Generate HTML reports for test results
 
 #### Writing E2E Tests

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,6 @@ experimental = true
 "node" = "24.19.0"
 "hk" = "latest"
 "pkl" = "latest"
-"github:boykush/scraps" = "v1.1.0"
 "npm:markdownlint-cli2" = "latest"
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-deny" = "latest"

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -66,18 +66,15 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests.
-   *
-   * Invoke the `scraps` binary directly rather than going through
-   * `mise run docs:serve`. The mise wrapper (mise -> bash task -> shim
-   * resolution -> scraps) was unreliable on CI runners: shim resolution can
-   * stall on the network at startup, and on teardown the multi-process tree
-   * was left orphaned so Playwright's webServer shutdown hung until the job
-   * timeout. `scraps` is on PATH in both the mise dev shell and CI, so a single
-   * directly-spawned process is what Playwright starts and cleanly kills. */
+  /* The binary from this checkout, not PATH `scraps` — that resolves to a
+   * pinned release, so template and CSS changes never reached the suite.
+   * Building it is the caller's job (`mise run e2e:test`, or the workflow's
+   * build step): a cold `cargo build --release` would blow the timeout below.
+   * Spawned directly, not via a mise task, which orphaned its process tree on
+   * CI teardown and could stall on shim resolution at startup. */
   webServer: {
     cwd: '../..',
-    command: 'scraps serve --directory docs',
+    command: './target/release/scraps serve --directory docs',
     url: 'http://127.0.0.1:1112',
     reuseExistingServer: !process.env.CI,
     /* `scraps serve` builds + binds in well under a second locally; default


### PR DESCRIPTION
<!-- 🙏 Thanks for your contribution! -->

## Summary

The e2e suite tested a released binary rather than the code under review.

`tests/e2e/playwright.config.ts` declared `webServer: { cwd: '../..', command: 'scraps serve --directory docs' }`, resolving `scraps` from PATH. In CI, `playwright.yml` supplied that PATH entry with `jdx/mise-action` and `install_args: "github:boykush/scraps"`, which `mise.toml` pinned to `v1.1.0`; locally it resolved to the same pinned release. So a PR changing `src/usecase/build/html/builtins/*.html` or `src/usecase/build/css/builtins/*.css` passed e2e without those changes ever being rendered — the suite asserted against HTML produced by v1.1.0.

Same fix as the docs deploy in #663: build from the checkout and run that binary.

- **`tests/e2e/playwright.config.ts`** — `webServer.command` is now `./target/release/scraps serve --directory docs` (`cwd: '../..'` unchanged, so it resolves at the repo root). The comment keeps the existing rationale for spawning directly rather than through a mise task (orphaned process tree on CI teardown, shim resolution stalling at startup).
- **`.mise-tasks/e2e/test`** — `(cd ../.. && cargo build --release)` before `npm install && npx playwright test`, under `set -euo pipefail`.
- **`.github/workflows/playwright.yml`** — mise installs `rust` instead of `github:boykush/scraps`, plus `Swatinem/rust-cache`, and a `Build scraps` step running `cargo build --release`.

Both build sites are outside the webServer command. A cold `cargo build --release` there would blow the 30s `webServer.timeout`, which is sized for serve binding in well under a second; the incremental rebuild inside `mise run e2e:test` measures ~1.4s, so that timeout is unchanged. In CI the build sits ahead of `npx playwright install --with-deps` so a compile error fails before the slow browser install.

`MISE_AUTO_INSTALL: "false"` moves from the test step to workflow level (matching `performance.yml`) since the build step needs it too. Its comment was stale twice over: it described a `mise run docs:serve` invocation the config had already stopped making, and it listed rust among the tools to skip.

**`mise.toml`: the `"github:boykush/scraps"` pin is dropped.** Nothing resolves `scraps` from PATH any more — the docs tasks use `./target/release/scraps` after #663, `test-action.yml` exercises the repo's own `action.yml` with an explicit version, and the migration plugin's docs use `mise exec "github:boykush/scraps@<ref>"` with their own refs. Beyond being unused, leaving it is the footgun that caused this bug: a bare `scraps` in a task or a contributor's shell silently means v1.1.0, not the working tree.

`CONTRIBUTING.md`'s e2e description said the suite starts `cargo run serve`, which was never true; it now describes what actually happens.

## Related Issues

Follows up the known gap called out in #663.

## Additional Notes

**Verification** — `mise run e2e:test` locally, four runs:

1. Baseline: 6 passed.
2. Renamed `class="readme-block"` → `readme-block-DELIBERATELY-RENAMED` in `src/usecase/build/html/builtins/index.html`: `get home` **failed in all three browsers** on `locator('[class="readme-block"]')`. The template change is visible to the suite.
3. Counter-proof, same broken template: started `mise exec github:boykush/scraps@v1.1.0 -- scraps serve --directory docs` on 1112 and let `reuseExistingServer` pick it up — **6 passed**. That is the old behavior exactly, and the bug this PR fixes.
4. Template reverted: 6 passed. `actionlint` passes on the workflow.

**Two things noticed but not changed:**

- `playwright.yml` triggers on `push: branches: [main]` only — there is no `pull_request` trigger, so a PR touching these templates doesn't pass e2e, it never runs e2e. This fix therefore bites on the post-merge run. Adding `pull_request` would make it actually gate PRs, but that's a separate call about CI cost and required checks.
- `reuseExistingServer: !process.env.CI` means that locally, a stale `scraps serve` already listening on 1112 silently wins over the freshly built binary (that's how the counter-proof above was run). Worth knowing when a local run disagrees with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
