### PR TITLE
ci(docs): stop the Pages deploy installing tools it never runs

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -15,6 +15,12 @@ on:
       - '.github/workflows/deploy-scraps-github-pages.yml'
   workflow_dispatch:
 
+env:
+  # Only rust is installed below; keep the build from pulling the rest of
+  # mise.toml (node, hk, pkl, markdownlint-cli2, cargo-llvm-cov, cargo-deny),
+  # which this job never runs.
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Problem

The Pages deploy has failed on **every push** since `fab0869` switched it from the released `boykush/scraps` action to building from this checkout — [33240357295](https://github.com/boykush/scraps/actions/runs/33240357295) and [33241518185](https://github.com/boykush/scraps/actions/runs/33241518185), same cause both times.

`mise run docs:build` auto-installs every tool in `mise.toml`, and `npm:markdownlint-cli2@latest` now fails a supply-chain trust check on a transitive dependency:

```
mise ERROR Failed to install npm:markdownlint-cli2@latest: aube install failed: failed to resolve dependencies
  caused by: trust downgrade for fastq@1.20.2 (trustPolicy=no-downgrade):
  earlier published version 1.20.0 had trusted publisher but this version has no trust evidence
```

The install aborts, `mise run` exits 1, and the deploy never reaches Configure Pages.

## Fix

Every other mise workflow in this repo already sets `MISE_AUTO_INSTALL: "false"` — `cargo-test-and-lint.yml`, `playwright.yml`, `performance.yml`, `tokens-check.yml`. `fab0869` introduced the first `mise run` in this workflow without that guard. This adds it, matching `tokens-check.yml`'s placement and comment style.

`docs:build` needs `cargo` alone, which the `install_args: "rust"` step already provides. Side benefit: the job stops spending ~3 minutes compiling `cargo-llvm-cov` and `cargo-deny`, which it never runs.

## Why not bypass the trust policy

Adding `trust_policy_excludes` would be a supply-chain decision needing a look at the actual `fastq@1.20.2` release. Not installing a tool this job never uses is the narrower fix and leaves that judgment untouched.

## Known gap

`markdownlint-cli2` is a local-only tool (`mise run docs:lint` / `docs:lint-fix`); no CI workflow invokes it. It remains unresolvable on a clean `mise install`, which is the setup step CONTRIBUTING.md gives new contributors. Existing checkouts have it cached and won't notice. Left for a separate change.

## Verification

CI on this PR does not exercise the deploy — it only runs on pushes to `main`. The green signal is the Pages run on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)