### PR TITLE
feat(build): emit a full scrap index at scraps/index.html

### DIFF
--- a/docs/Reference/Static Site/Output Structure.md
+++ b/docs/Reference/Static Site/Output Structure.md
@@ -8,12 +8,17 @@ Build output is written to the directory configured by `output_dir`
 _site
 ├── index.html              # README.md or scrap index
 ├── scraps/
+│   ├── index.html          # every scrap, in title order
 │   ├── getting-started.html
 │   └── guide/
 │       └── links.html
 ├── main.css
 └── search_index.json       # when build_search_index = true
 ```
+
+`scraps/index.html` lists every scrap in title order on a single page, with
+no pagination, so a wiki can be browsed whole however large it grows. The
+root index stays paginated and sorted by `sort_key`.
 
 Each Markdown file is converted to a slugified HTML file under `scraps/`.
 Folders become path segments — the same folders that form

--- a/src/output/build_renderer.rs
+++ b/src/output/build_renderer.rs
@@ -8,7 +8,8 @@ use crate::service::search::render::SearchIndexRender;
 use crate::usecase::build::{
     css::render::CSSRender,
     html::{
-        index_render::IndexRender, scrap_render::ScrapRender, tag_render::TagRender,
+        index_render::IndexRender, scrap_render::ScrapRender,
+        scraps_index_render::ScrapsIndexRender, tag_render::TagRender,
         tags_index_render::TagsIndexRender,
     },
     model::{
@@ -19,8 +20,8 @@ use crate::usecase::build::{
         scrap_detail::{ScrapDetail, ScrapDetails},
     },
     renderer::{
-        CssRenderer, HtmlIndexRenderer, HtmlScrapRenderer, HtmlTagRenderer, HtmlTagsIndexRenderer,
-        SearchIndexJsonRenderer,
+        CssRenderer, HtmlIndexRenderer, HtmlScrapRenderer, HtmlScrapsIndexRenderer,
+        HtmlTagRenderer, HtmlTagsIndexRenderer, SearchIndexJsonRenderer,
     },
 };
 
@@ -30,6 +31,7 @@ use crate::usecase::build::{
 pub struct BuildRendererImpl {
     index_render: IndexRender,
     scrap_render: ScrapRender,
+    scraps_index_render: ScrapsIndexRender,
     tags_index_render: TagsIndexRender,
     tag_render: TagRender,
     css_render: CSSRender,
@@ -41,6 +43,7 @@ impl BuildRendererImpl {
         Ok(BuildRendererImpl {
             index_render: IndexRender::new(static_dir_path, output_dir_path)?,
             scrap_render: ScrapRender::new(static_dir_path, output_dir_path)?,
+            scraps_index_render: ScrapsIndexRender::new(static_dir_path, output_dir_path)?,
             tags_index_render: TagsIndexRender::new(static_dir_path, output_dir_path)?,
             tag_render: TagRender::new(static_dir_path, output_dir_path)?,
             css_render: CSSRender::new(static_dir_path, output_dir_path)?,
@@ -86,6 +89,19 @@ impl HtmlScrapRenderer for BuildRendererImpl {
             scrap_detail,
             backlinks_map,
         )
+    }
+}
+
+impl HtmlScrapsIndexRenderer for BuildRendererImpl {
+    fn render_scraps_index(
+        &self,
+        base_url: &BaseUrl,
+        html_metadata: &HtmlMetadata,
+        scrap_details: &ScrapDetails,
+        backlinks_map: &BacklinksMap,
+    ) -> ScrapsResult<()> {
+        self.scraps_index_render
+            .run(base_url, html_metadata, scrap_details, backlinks_map)
     }
 }
 

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -286,6 +286,9 @@ div.index {
             justify-content: space-between;
             gap: var(--space-4);
             margin: 0 0 var(--space-2);
+            a.all-link {
+                color: var(--color-accent);
+            }
             padding-bottom: var(--space-2);
             border-bottom: var(--border-hairline) solid var(--color-rule);
             font-family: var(--font-family-mono);
@@ -430,6 +433,72 @@ ul.scrap-links {
         flex-shrink: 0;
         font-family: var(--font-family-mono);
         font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+    }
+}
+
+/* scraps index — the full listing, multi-column so it stays scannable */
+div.scraps-index {
+    p.list-head {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-4);
+        margin: 0 0 var(--space-3);
+        padding-bottom: var(--space-2);
+        border-bottom: var(--border-hairline) solid var(--color-rule);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+    }
+}
+
+ul.scrap-index {
+    columns: 260px 4;
+    column-gap: var(--space-6);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li.item {
+        break-inside: avoid;
+        border-bottom: var(--border-hairline) solid var(--color-rule);
+    }
+
+    a.entry {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        padding: var(--space-1) 0;
+
+        &:hover {
+            text-decoration: none;
+
+            .title {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    span.title {
+        font-size: var(--font-size-sm);
+        color: var(--color-accent);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    span.ctx {
+        flex-shrink: 0;
+        font-family: var(--font-family-mono);
+        font-size: 10px;
+        color: var(--color-text-muted);
+    }
+
+    span.count {
+        margin-left: auto;
+        flex-shrink: 0;
+        font-family: var(--font-family-mono);
+        font-size: 10px;
         color: var(--color-text-muted);
     }
 }

--- a/src/usecase/build/html.rs
+++ b/src/usecase/build/html.rs
@@ -2,6 +2,7 @@ mod cdn_versions;
 pub mod index_render;
 mod page_pointer;
 pub mod scrap_render;
+pub mod scraps_index_render;
 mod serde;
 pub mod tag_render;
 pub mod tags_index_render;

--- a/src/usecase/build/html/builtins/index.html
+++ b/src/usecase/build/html/builtins/index.html
@@ -25,7 +25,7 @@
         <div class="links-block">
             <p class="list-head">
                 <span class="sort-key">sorted by {{ sort_key }}</span>
-                <span class="legend">namespace &#183; graph</span>
+                <a class="all-link" href="{{ base_url }}scraps/">all scraps &#8250;</a>
             </p>
             {{ <scrap_rows scraps={scraps} base_url={base_url} /> }}
         </div>

--- a/src/usecase/build/html/builtins/macros.html
+++ b/src/usecase/build/html/builtins/macros.html
@@ -23,6 +23,20 @@
     </ul>
 {% endcomponent scrap_rows %}
 
+{% component scrap_index(scraps, base_url) %}
+    <ul class="scrap-index">
+        {% for scrap in scraps %}
+            <li class="item">
+                <a class="entry" href="{{ base_url }}scraps/{{ scrap.html_file_name }}">
+                    <span class="title">{{ scrap.title }}</span>
+                    {% if scrap.ctx %}<span class="ctx">{{ scrap.ctx }}</span>{% endif %}
+                    <span class="count">{{ scrap.backlinks_count }}</span>
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endcomponent scrap_index %}
+
 {% component scrap_links(scraps, base_url) %}
     <ul class="scrap-links">
         {% for scrap in scraps %}

--- a/src/usecase/build/html/builtins/scraps_index.html
+++ b/src/usecase/build/html/builtins/scraps_index.html
@@ -1,0 +1,11 @@
+{% extends "__builtins/base.html" %}
+
+{% block main %}
+    <div class="scraps-index">
+        <p class="list-head">
+            <span class="count">{{ scraps | length }} scraps</span>
+            <span class="legend">title order &#183; backlinks</span>
+        </p>
+        {{ <scrap_index scraps={scraps} base_url={base_url} /> }}
+    </div>
+{% endblock %}

--- a/src/usecase/build/html/scraps_index_render.rs
+++ b/src/usecase/build/html/scraps_index_render.rs
@@ -1,0 +1,99 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::ScrapsResult;
+use crate::service::tera_render::{render_to_file, resolve_template, user_template_glob};
+use crate::usecase::build::html::templates;
+use crate::usecase::build::model::backlinks_map::BacklinksMap;
+use crate::usecase::build::model::html::HtmlMetadata;
+use crate::usecase::build::model::scrap_detail::ScrapDetails;
+use scraps_libs::model::base_url::BaseUrl;
+use tera::Tera;
+
+use super::serde::index_scraps::IndexScrapsTera;
+
+/// The paginated index answers "what changed lately"; this one answers "what
+/// is in here", which pagination actively gets in the way of once a wiki runs
+/// to hundreds of scraps.
+pub struct ScrapsIndexRender {
+    tera: Tera,
+    output_scraps_dir_path: PathBuf,
+}
+
+impl ScrapsIndexRender {
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<ScrapsIndexRender> {
+        let tera = templates::scraps_index(&user_template_glob(static_dir_path, "*.html"))?;
+
+        Ok(ScrapsIndexRender {
+            tera,
+            output_scraps_dir_path: output_dir_path.join("scraps"),
+        })
+    }
+
+    pub fn run(
+        &self,
+        base_url: &BaseUrl,
+        metadata: &HtmlMetadata,
+        scrap_details: &ScrapDetails,
+        backlinks_map: &BacklinksMap,
+    ) -> ScrapsResult<()> {
+        let mut context = templates::context(base_url, metadata);
+        context.insert(
+            "scraps",
+            &IndexScrapsTera::new_sorted_by_title(scrap_details, backlinks_map),
+        );
+
+        let template_name = resolve_template(
+            &self.tera,
+            "scraps_index.html",
+            "__builtins/scraps_index.html",
+        );
+        let file_path = self.output_scraps_dir_path.join("index.html");
+        render_to_file(&self.tera, template_name, &context, &file_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use crate::usecase::build::model::scrap_detail::ScrapDetail;
+    use rstest::rstest;
+    use scraps_libs::{lang::LangCode, model::base_url::BaseUrl, model::scrap::Scrap};
+    use std::fs;
+    use url::Url;
+
+    use super::*;
+
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_static_file(
+            "scraps_index.html",
+            b"{% for scrap in scraps %}<a>{{ scrap.title }}:{{ scrap.backlinks_count }}</a>{% endfor %}",
+        );
+
+        let base_url = BaseUrl::new(Url::parse("http://localhost:1112/").unwrap()).unwrap();
+        let metadata = HtmlMetadata::new(&LangCode::default(), "Scrap", &None, &None);
+
+        // Deliberately out of title order, and mixed case, to pin the sort.
+        let scrap1 = Scrap::new("beta", &None, "[[Alpha]]");
+        let scrap2 = Scrap::new("Alpha", &None, "");
+        let scraps = [scrap1.clone(), scrap2.clone()];
+        let scrap_texts = scraps
+            .iter()
+            .map(|s| (s.self_key(), s.md_text().to_string()))
+            .collect();
+
+        let details = ScrapDetails::new(&vec![
+            ScrapDetail::new(&scrap1, &None, &base_url, &scrap_texts),
+            ScrapDetail::new(&scrap2, &None, &base_url, &scrap_texts),
+        ]);
+        let backlinks_map = BacklinksMap::new(&scraps);
+
+        let render = ScrapsIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
+        render
+            .run(&base_url, &metadata, &details, &backlinks_map)
+            .unwrap();
+
+        let result = fs::read_to_string(project.output_path("scraps/index.html")).unwrap();
+        assert_eq!(result, "<a>Alpha:1</a><a>beta:0</a>");
+    }
+}

--- a/src/usecase/build/html/serde/index_scraps.rs
+++ b/src/usecase/build/html/serde/index_scraps.rs
@@ -69,6 +69,22 @@ impl IndexScrapsTera {
         IndexScrapsTera(sorted)
     }
 
+    /// Title order rather than a `SortKey`: the full index is a reference
+    /// listing, and neither recency nor link count is what a reader scans by.
+    pub fn new_sorted_by_title(
+        scrap_details: &ScrapDetails,
+        backlinks_map: &BacklinksMap,
+    ) -> IndexScrapsTera {
+        let sorted = scrap_details
+            .to_vec()
+            .into_iter()
+            .map(|s| SerializeIndexScrap::new(&s, backlinks_map))
+            .sorted_by_key(|s| s.title.to_lowercase())
+            .collect_vec();
+
+        IndexScrapsTera(sorted)
+    }
+
     pub fn chunks(&self, chunk_size: usize) -> Vec<IndexScrapsTera> {
         self.0
             .chunks(chunk_size)

--- a/src/usecase/build/html/templates.rs
+++ b/src/usecase/build/html/templates.rs
@@ -18,6 +18,12 @@ static SCRAP: Lazy<Tera> =
     Lazy::new(|| builtins(("__builtins/scrap.html", include_str!("builtins/scrap.html"))));
 static TAG: Lazy<Tera> =
     Lazy::new(|| builtins(("__builtins/tag.html", include_str!("builtins/tag.html"))));
+static SCRAPS_INDEX: Lazy<Tera> = Lazy::new(|| {
+    builtins((
+        "__builtins/scraps_index.html",
+        include_str!("builtins/scraps_index.html"),
+    ))
+});
 static TAGS_INDEX: Lazy<Tera> = Lazy::new(|| {
     builtins((
         "__builtins/tags_index.html",
@@ -54,6 +60,10 @@ pub fn scrap(template_dir: &str) -> ScrapsResult<Tera> {
 
 pub fn tag(template_dir: &str) -> ScrapsResult<Tera> {
     with_user_templates(&TAG, template_dir)
+}
+
+pub fn scraps_index(template_dir: &str) -> ScrapsResult<Tera> {
+    with_user_templates(&SCRAPS_INDEX, template_dir)
 }
 
 pub fn tags_index(template_dir: &str) -> ScrapsResult<Tera> {

--- a/src/usecase/build/renderer.rs
+++ b/src/usecase/build/renderer.rs
@@ -33,6 +33,16 @@ pub trait HtmlScrapRenderer {
     ) -> ScrapsResult<()>;
 }
 
+pub trait HtmlScrapsIndexRenderer {
+    fn render_scraps_index(
+        &self,
+        base_url: &BaseUrl,
+        html_metadata: &HtmlMetadata,
+        scrap_details: &ScrapDetails,
+        backlinks_map: &BacklinksMap,
+    ) -> ScrapsResult<()>;
+}
+
 pub trait HtmlTagsIndexRenderer {
     fn render_tags_index(
         &self,
@@ -64,6 +74,7 @@ pub trait SearchIndexJsonRenderer {
 pub trait BuildRenderer:
     HtmlIndexRenderer
     + HtmlScrapRenderer
+    + HtmlScrapsIndexRenderer
     + HtmlTagsIndexRenderer
     + HtmlTagRenderer
     + CssRenderer
@@ -75,6 +86,7 @@ pub trait BuildRenderer:
 impl<T> BuildRenderer for T where
     T: HtmlIndexRenderer
         + HtmlScrapRenderer
+        + HtmlScrapsIndexRenderer
         + HtmlTagsIndexRenderer
         + HtmlTagRenderer
         + CssRenderer
@@ -116,6 +128,18 @@ pub mod tests {
             _timezone: Tz,
             _html_metadata: &HtmlMetadata,
             _scrap_detail: &ScrapDetail,
+            _backlinks_map: &BacklinksMap,
+        ) -> ScrapsResult<()> {
+            Ok(())
+        }
+    }
+
+    impl HtmlScrapsIndexRenderer for BuildRendererTest {
+        fn render_scraps_index(
+            &self,
+            _base_url: &BaseUrl,
+            _html_metadata: &HtmlMetadata,
+            _scrap_details: &ScrapDetails,
             _backlinks_map: &BacklinksMap,
         ) -> ScrapsResult<()> {
             Ok(())

--- a/src/usecase/build/usecase.rs
+++ b/src/usecase/build/usecase.rs
@@ -99,6 +99,12 @@ impl BuildUsecase {
             })?;
         span_generate_html_scraps.exit();
 
+        // generate html scraps index
+        let span_generate_html_scraps_index =
+            span!(Level::INFO, "generate_html_scraps_index").entered();
+        renderer.render_scraps_index(base_url, html_metadata, &scrap_details, &backlinks_map)?;
+        span_generate_html_scraps_index.exit();
+
         // generate html tags index
         let span_generate_html_tags_index =
             span!(Level::INFO, "generate_html_tags_index").entered();


### PR DESCRIPTION
## Summary

Adds a second index page listing every scrap on one page, in title order, with no pagination.

The root index is paginated and sorted by `sort_key`, which answers "what changed lately". It has no answer for "what is in here" — on a wiki of several hundred scraps that question turns into dozens of pages of next-next-next. `boykush/wiki` is past 700 scraps, so at ten per page the existing index is roughly seventy pages deep.

Entries are dense and multi-column (`columns: 260px 4`, so the column count follows the viewport). Each carries the ctx beside the title, where it is the thing that disambiguates — `Pod` and `Pod Kubernetes` both exist in `boykush/wiki` and cannot be told apart otherwise — plus the backlink count, which is the one piece of graph weight that still reads at that density.

The root index links to it, and it sits at `scraps/index.html` alongside the existing `tags/index.html`.

## Related Issues

Follows the design system in #663; this is the index page that design proposed but that was never built.

## Additional Notes

- Sorted by title rather than by a `SortKey`. Recency and link count are not what a reader scans a reference listing by, so this is a dedicated constructor rather than a new configurable sort — no new config surface.
- Wired as `HtmlScrapsIndexRenderer`, following the same shape as the existing `HtmlTagsIndexRenderer`: a builtin template overridable by a user `scraps_index.html`, a `scrap_index` component in `macros.html`, and a renderer built once in `BuildRendererImpl`.
- Verified in light and dark against the `docs/` wiki, with entry links resolving to real files.
- **Known collision, matching one that already exists:** a scrap titled exactly `index` at the wiki root would render to `scraps/index.html` and collide with this page. `tags/index.html` has had the same latent collision with a tag named `index` since it was introduced. Worth solving once for both rather than special-casing here.
- `scraps lint` reports two warnings on `docs/`, both pre-existing — confirmed by running it with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)