### PR TITLE
feat(tokens): publish a design token page at /design-tokens/

### DIFF
--- a/.github/workflows/deploy-scraps-github-pages.yml
+++ b/.github/workflows/deploy-scraps-github-pages.yml
@@ -11,6 +11,7 @@ on:
       - 'modules/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'tokens/**'
       - '.mise-tasks/docs/**'
       - '.github/workflows/deploy-scraps-github-pages.yml'
   workflow_dispatch:
@@ -42,7 +43,7 @@ jobs:
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
-          install_args: "rust"
+          install_args: "rust node"
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -52,13 +53,25 @@ jobs:
       - name: Build docs
         run: mise run docs:build
 
+      # The design token page is generated from tokens/, not authored as a
+      # scrap, so it is built separately and mounted beside the wiki rather
+      # than appearing in its index, search and lint.
+      - name: Build design token page
+        run: mise run tokens:build
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site/design-tokens
+          cp -r docs/_site/. _site/
+          cp tokens/dist/index.html _site/design-tokens/
+
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: docs/_site
+          path: _site
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _site
 
 # Design tokens
 /tokens/node_modules
+/tokens/dist
 
 # Playwright
 /tests/e2e/node_modules

--- a/tokens/style-dictionary.config.mjs
+++ b/tokens/style-dictionary.config.mjs
@@ -1,6 +1,7 @@
 import StyleDictionary from 'style-dictionary';
 
 const OUT = '../src/usecase/build/css/builtins/_tokens.css';
+const DOC = 'dist/index.html';
 
 /// Semantic colours pair a light and a dark value under one role. CSS
 /// light-dark() keeps that in a single stylesheet, which is why the built-in
@@ -91,6 +92,141 @@ StyleDictionary.registerFormat({
   },
 });
 
+/// WCAG relative luminance, so the generated page can state the contrast a
+/// role actually achieves rather than asserting it passes.
+function luminance(hex) {
+  const raw = hex.replace('#', '');
+  const channels = [0, 2, 4]
+    .map((i) => parseInt(raw.slice(i, i + 2), 16) / 255)
+    .map((c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a, b) {
+  const [la, lb] = [luminance(a), luminance(b)];
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+function swatch(name) {
+  return `  <div style="border: var(--border-hairline) solid var(--color-rule); border-radius: var(--radius-md); overflow: hidden;">
+    <div style="height: 48px; background: var(${name});"></div>
+    <div style="padding: var(--space-2) var(--space-3); border-top: var(--border-hairline) solid var(--color-rule); font-family: var(--font-family-mono); font-size: var(--font-size-xs); color: var(--color-text-muted);">${name}</div>
+  </div>`;
+}
+
+function grid(inner, min = 190) {
+  return `<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(${min}px, 1fr)); gap: var(--space-3);">
+${inner}
+</div>`;
+}
+
+StyleDictionary.registerFormat({
+  name: 'scraps/tokens-doc',
+  format: ({ dictionary }) => {
+    const flat = [];
+    walk(dictionary.tokens, [], flat);
+
+    const byName = new Map();
+    for (const [path, token] of flat) {
+      const name = cssName(path);
+      const mode = path[path.length - 1];
+      if (!byName.has(name)) byName.set(name, { path, modes: {}, token });
+      if (MODES.includes(mode)) byName.get(name).modes[mode] = token.$value;
+    }
+
+    const semantic = [...byName.entries()].filter(([n, e]) => n.startsWith('--color-') && Object.keys(e.modes).length);
+    const primitives = [...byName.keys()].filter((n) => n.startsWith('--nord') || n.startsWith('--ext-'));
+    const scale = (prefix) => [...byName.entries()].filter(([n]) => n.startsWith(prefix));
+
+    const surface = byName.get('--color-surface').modes;
+    const rows = semantic.map(([name, entry]) => {
+      const ratio = (mode) => {
+        if (name === '--color-surface') return '&#8212;';
+        return `${contrast(entry.modes[mode], surface[mode]).toFixed(2)}:1`;
+      };
+      return `<tr><td><code>${name}</code></td><td><code>${entry.modes.light}</code></td><td><code>${entry.modes.dark}</code></td><td>${ratio('light')}</td><td>${ratio('dark')}</td></tr>`;
+    });
+
+    const typeRows = scale('--font-size-').map(([name, e]) =>
+      `  <div style="display: flex; align-items: baseline; gap: var(--space-4);"><span style="width: 140px; flex-shrink: 0; font-family: var(--font-family-mono); font-size: var(--font-size-xs); color: var(--color-text-muted);">${name}</span><span style="font-size: var(${name}); line-height: var(--font-line-height-tight);">Typed source</span></div>`);
+
+    const spaceBars = scale('--space-').map(([name]) =>
+      `  <div style="width: var(${name}); height: 30px; background: var(--color-accent); border-radius: var(--radius-sm);" title="${name}"></div>`);
+
+    const radiusBoxes = scale('--radius-').map(([name]) =>
+      `  <div style="width: 62px; height: 44px; background: var(--color-surface-raised); border: var(--border-hairline) solid var(--color-rule); border-radius: var(${name});" title="${name}"></div>`);
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex">
+<title>Design Tokens — Scraps</title>
+<!-- The theme's own stylesheet, one level up on the deployed site, so this
+     page shows what the tokens actually produce rather than a copy of it. -->
+<link rel="stylesheet" href="../main.css">
+<link href="https://fonts.cdnfonts.com/css/rubik" rel="stylesheet">
+</head>
+<body>
+<header><h1>Design Tokens</h1></header>
+<main>
+<div class="scrap">
+<div class="content">
+
+<p>The design tokens Scraps compiles its theme from. Generated from
+<code>tokens/*.tokens.json</code> by <code>mise run tokens:build</code>; edit the
+token files, not this page.</p>
+
+<p>Swatches reference the live CSS custom properties, so they follow whichever
+colour scheme you are reading in. The table states resolved values and the
+contrast each role reaches against its surface, which
+<code>tokens/check-contrast.py</code> gates at WCAG AA.</p>
+
+<h2>Semantic colours</h2>
+
+${grid(semantic.map(([n]) => swatch(n)).join('\n'))}
+
+<table>
+<thead><tr><th>Role</th><th>Light</th><th>Dark</th><th>Contrast light</th><th>Contrast dark</th></tr></thead>
+<tbody>
+${rows.join('\n')}
+</tbody>
+</table>
+
+<h2>Primitives</h2>
+
+<p>Raw palette values. Nothing outside the semantic layer should reference these.</p>
+
+${grid(primitives.map(swatch).join('\n'), 150)}
+
+<h2>Type scale</h2>
+
+<div style="display: flex; flex-direction: column; gap: var(--space-2);">
+${typeRows.join('\n')}
+</div>
+
+<h2>Space</h2>
+
+<div style="display: flex; align-items: flex-end; gap: var(--space-3);">
+${spaceBars.join('\n')}
+</div>
+
+<h2>Radius</h2>
+
+<div style="display: flex; gap: var(--space-3);">
+${radiusBoxes.join('\n')}
+</div>
+
+</div>
+</div>
+</main>
+</body>
+</html>
+`;
+  },
+});
+
 export default {
   source: ['*.tokens.json'],
   platforms: {
@@ -98,7 +234,10 @@ export default {
       // The format computes its own names; this only keeps Style Dictionary's
       // internal names unique so genuine collisions still get reported.
       transforms: ['name/kebab'],
-      files: [{ destination: OUT, format: 'scraps/css-custom-properties' }],
+      files: [
+        { destination: OUT, format: 'scraps/css-custom-properties' },
+        { destination: DOC, format: 'scraps/tokens-doc' },
+      ],
     },
   },
 };


### PR DESCRIPTION
## Summary

Publishes a design token page on the Pages site at `/design-tokens/`, generated from the DTCG token files.

The token files describe the theme and `tokens/check-contrast.py` gates accessibility in CI, but neither is visible anywhere. Judging a palette change meant reading JSON and computing contrast ratios by hand.

Style Dictionary now emits a standalone page alongside `_tokens.css`, listing every semantic role and primitive with live swatches, the resolved light and dark values, the contrast each role reaches against its surface, and the type, space and radius scales.

## Related Issues

Builds on the token pipeline from #663 and the gates from #667.

## Additional Notes

**Built on its own route, not authored as a scrap.** The first version of this was a Markdown page under `docs/Reference/Static Site/`, which put a project check surface into the wiki's index, search and lint, and made it subject to `dead_end` / `lonely` / `overlinking`. It is now built separately and mounted beside the wiki, following the pattern `boykush/livt` already uses in its own deploy — mdBook to the site root, `go run . build` output to `/demo/`. Here that is:

```
mkdir -p _site/design-tokens
cp -r docs/_site/. _site/
cp tokens/dist/index.html _site/design-tokens/
```

so the deploy uploads an assembled `_site` rather than `docs/_site` directly.

- The page links the deployed site's own `../main.css`, so it shows what the tokens actually produce rather than a copy of it. Swatches reference the CSS custom properties, so the page follows the reader's colour scheme instead of claiming one; the table carries the resolved hex for both.
- `tokens/dist/` is generated output and gitignored — nothing new is committed. The deploy runs `mise run tokens:build` (mise now installs `node` alongside `rust` there), and `tokens/**` joins the trigger paths so a token change redeploys.
- Contrast figures are computed in the generator, independently of `check-contrast.py`; the two agree to the digit, which cross-checks both.
- Verified by reproducing the assembly locally and loading `/design-tokens/` against a built `docs/` site.

**Found while building this, not fixed here:** the syntax highlighting theme 404s. `base.html` loads `https://unpkg.com/nord-highlightjs@0.2.0/dist/nord.css`, which the package's own `main` field points at but which is absent from the published tarball — every path under that package returns 404, so code blocks on the docs site have had no theme. `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.12.0/styles/base16/nord.min.css` serves the same Nord theme from the CDN and version `base.html` already uses for highlight.js itself, and would drop the `nord_highlightjs` dependency entirely. Left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)