### PR TITLE
feat(mcp): carry the next step inside every tool response

### DIFF
--- a/livt/discoveries/example-mappings/follow-response-hints.yaml
+++ b/livt/discoveries/example-mappings/follow-response-hints.yaml
@@ -1,0 +1,29 @@
+story: follow-response-hints
+
+rules:
+  - id: R-01
+    name: すべてのツール応答がトップレベルの next で次の一手を示す
+    examples:
+      - id: EX-01
+        name: 6ツールすべての応答に next が1つ付く
+      - id: EX-02
+        name: list_tags は素の配列をやめ、results / count / next の封筒に揃える
+    automated: true
+  - id: R-02
+    name: 結果が空の応答は、別の辿り方を教える
+    examples:
+      - id: EX-01
+        name: search_scraps の0件応答は list_tags からの入り直しを勧める
+      - id: EX-02
+        name: lookup_scrap_links の0件応答は lookup_scrap_backlinks を勧める
+    automated: true
+  - id: R-03
+    name: next は応答に1つだけ置き、results の各要素を太らせない
+    examples:
+      - id: EX-01
+        name: search のヒット要素に next キーは付かない
+    automated: true
+
+questions:
+  - id: Q-01
+    text: CLI の --json 応答にも next を映すか

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -273,6 +273,133 @@ mod tests {
         );
     }
 
+    async fn call_tool_json(
+        project: &TempScrapProject,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> serde_json::Value {
+        let server = ScrapsServer::new(
+            project.scraps_dir.clone(),
+            vec![project.static_dir.clone(), project.output_dir.clone()],
+        );
+
+        let (client_stream, server_stream) = tokio::io::duplex(4096);
+
+        let server_handle = tokio::spawn(async move { server.serve(server_stream).await });
+
+        let client = ().serve(client_stream).await.unwrap();
+
+        let mut params = CallToolRequestParams::new(name.to_string());
+        if let Some(args) = arguments.as_object() {
+            if !args.is_empty() {
+                params = params.with_arguments(args.clone());
+            }
+        }
+        let result = client.call_tool(params).await.unwrap();
+
+        client.cancel().await.unwrap();
+        server_handle.abort();
+
+        serde_json::from_str(&result.content[0].as_text().unwrap().text).unwrap()
+    }
+
+    // Automates livt://mapping/follow-response-hints/rule/R-01
+    #[rstest]
+    #[tokio::test]
+    async fn test_every_response_carries_a_next_hint(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("source.md", b"# Source\n\n[[target]] #[[rust]]");
+        project.add_scrap("target.md", b"# Target\n\nContent");
+
+        let calls = vec![
+            ("search_scraps", serde_json::json!({"query": "target"})),
+            ("get_scrap", serde_json::json!({"title": "target"})),
+            ("lookup_scrap_links", serde_json::json!({"title": "source"})),
+            (
+                "lookup_scrap_backlinks",
+                serde_json::json!({"title": "target"}),
+            ),
+            ("list_tags", serde_json::json!({})),
+            ("lookup_tag_backlinks", serde_json::json!({"tag": "rust"})),
+        ];
+
+        for (name, args) in calls {
+            let response = call_tool_json(&project, name, args).await;
+            let next = response["next"].as_str().unwrap_or_default();
+            assert!(
+                !next.is_empty(),
+                "{name} response should carry a next hint: {response}"
+            );
+        }
+
+        let tags = call_tool_json(&project, "list_tags", serde_json::json!({})).await;
+        assert!(
+            tags["results"].is_array() && tags["count"].is_u64(),
+            "list_tags should use the results/count envelope: {tags}"
+        );
+    }
+
+    // Automates livt://mapping/follow-response-hints/rule/R-02
+    #[rstest]
+    #[tokio::test]
+    async fn test_empty_responses_teach_another_way_in(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("target.md", b"# Target\n\nContent");
+
+        let search = call_tool_json(
+            &project,
+            "search_scraps",
+            serde_json::json!({"query": "zzzqqqxxx"}),
+        )
+        .await;
+        assert_eq!(search["count"], 0);
+        assert!(
+            search["next"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("list_tags"),
+            "empty search should point at the topic map: {search}"
+        );
+
+        let links = call_tool_json(
+            &project,
+            "lookup_scrap_links",
+            serde_json::json!({"title": "target"}),
+        )
+        .await;
+        assert_eq!(links["count"], 0);
+        assert!(
+            links["next"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("lookup_scrap_backlinks"),
+            "empty links should point at the inbound direction: {links}"
+        );
+    }
+
+    // Automates livt://mapping/follow-response-hints/rule/R-03
+    #[rstest]
+    #[tokio::test]
+    async fn test_next_stays_top_level_only(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_scrap("target.md", b"# Target\n\nContent");
+
+        let search = call_tool_json(
+            &project,
+            "search_scraps",
+            serde_json::json!({"query": "target"}),
+        )
+        .await;
+        assert!(search["count"].as_u64().unwrap() > 0);
+
+        let first = search["results"][0].as_object().unwrap();
+        assert!(
+            !first.contains_key("next"),
+            "result elements should stay lean: {search}"
+        );
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_call_search_scraps(#[from(temp_scrap_project)] project: TempScrapProject) {

--- a/src/mcp/tools/get_scrap.rs
+++ b/src/mcp/tools/get_scrap.rs
@@ -159,6 +159,13 @@ pub async fn get_scrap(
             _ => unreachable!("validated by resolve_fields"),
         }
     }
+    out.insert(
+        "next".to_string(),
+        Value::String(
+            "Traverse onward with lookup_scrap_links or lookup_scrap_backlinks {title, ctx}."
+                .to_string(),
+        ),
+    );
 
     Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string(&Value::Object(out)).map_err(|e| {

--- a/src/mcp/tools/list_tags.rs
+++ b/src/mcp/tools/list_tags.rs
@@ -48,7 +48,19 @@ pub async fn list_tags(
         count_b.cmp(&count_a)
     });
 
+    let count = tags_with_backlinks.len();
+    let next = if count == 0 {
+        "No tags yet. Search content directly with search_scraps."
+    } else {
+        "Expand a tag into its scraps with lookup_tag_backlinks {tag}."
+    };
+    let response = json!({
+        "results": tags_with_backlinks,
+        "count": count,
+        "next": next,
+    });
+
     Ok(CallToolResult::success(vec![ContentBlock::text(
-        serde_json::to_string(&tags_with_backlinks).unwrap(),
+        serde_json::to_string(&response).unwrap(),
     )]))
 }

--- a/src/mcp/tools/lookup_scrap_backlinks.rs
+++ b/src/mcp/tools/lookup_scrap_backlinks.rs
@@ -23,6 +23,7 @@ pub struct LookupScrapBacklinksRequest {
 pub struct LookupScrapBacklinksResponse {
     pub results: Vec<ScrapKeyJson>,
     pub count: usize,
+    pub next: String,
 }
 
 pub async fn lookup_scrap_backlinks(
@@ -70,9 +71,15 @@ pub async fn lookup_scrap_backlinks(
         .collect();
 
     let count = scrap_jsons.len();
+    let next = if count == 0 {
+        "No backlinks. Try lookup_scrap_links {title, ctx} for outbound references."
+    } else {
+        "Read a linking scrap with get_scrap {title, ctx}."
+    };
     let response = LookupScrapBacklinksResponse {
         results: scrap_jsons,
         count,
+        next: next.to_string(),
     };
 
     Ok(CallToolResult::success(vec![ContentBlock::text(

--- a/src/mcp/tools/lookup_scrap_links.rs
+++ b/src/mcp/tools/lookup_scrap_links.rs
@@ -46,6 +46,7 @@ pub struct LinkRefJson {
 pub struct LookupScrapLinksResponse {
     pub results: Vec<LinkRefJson>,
     pub count: usize,
+    pub next: String,
 }
 
 pub async fn lookup_scrap_links(
@@ -95,9 +96,15 @@ pub async fn lookup_scrap_links(
         .collect();
 
     let count = refs.len();
+    let next = if count == 0 {
+        "No outbound links. Try lookup_scrap_backlinks {title, ctx} for inbound references."
+    } else {
+        "Read a linked scrap with get_scrap {title, ctx} — add heading to jump to the referenced section."
+    };
     let response = LookupScrapLinksResponse {
         results: refs,
         count,
+        next: next.to_string(),
     };
 
     Ok(CallToolResult::success(vec![ContentBlock::text(

--- a/src/mcp/tools/lookup_tag_backlinks.rs
+++ b/src/mcp/tools/lookup_tag_backlinks.rs
@@ -21,6 +21,7 @@ pub struct LookupTagBacklinksRequest {
 pub struct LookupTagBacklinksResponse {
     pub results: Vec<ScrapKeyJson>,
     pub count: usize,
+    pub next: String,
 }
 
 pub async fn lookup_tag_backlinks(
@@ -62,9 +63,15 @@ pub async fn lookup_tag_backlinks(
         .collect();
 
     let count = scrap_jsons.len();
+    let next = if count == 0 {
+        "No scraps under this tag. List available tags with list_tags."
+    } else {
+        "Read a result with get_scrap {title, ctx}."
+    };
     let response = LookupTagBacklinksResponse {
         results: scrap_jsons,
         count,
+        next: next.to_string(),
     };
 
     Ok(CallToolResult::success(vec![ContentBlock::text(

--- a/src/mcp/tools/search_scraps.rs
+++ b/src/mcp/tools/search_scraps.rs
@@ -45,6 +45,7 @@ pub struct SearchRequest {
 pub struct SearchResponse {
     pub results: Vec<ScrapKeyJson>,
     pub count: usize,
+    pub next: String,
 }
 
 pub async fn search_scraps(
@@ -82,9 +83,15 @@ pub async fn search_scraps(
         .collect();
 
     let count = scrap_jsons.len();
+    let next = if count == 0 {
+        "No hits. Vary the keywords (default OR logic matches any), or start from the topic map with list_tags."
+    } else {
+        "Read a hit with get_scrap {title, ctx}; then traverse it with lookup_scrap_links."
+    };
     let response = SearchResponse {
         results: scrap_jsons,
         count,
+        next: next.to_string(),
     };
 
     Ok(CallToolResult::success(vec![ContentBlock::text(


### PR DESCRIPTION
## Why

Second story of the `recallable-memory` slice **引き出し方を教える** (after #669). Tool definitions now teach usage statically, but the hop an agent takes after each response was still improvised. This PR puts the best-practice next step inside the response itself — the agent-facing analogue of HATEOAS — implementing [応答の次の一手で深掘る](livt/stories/follow-response-hints.md).

## Rules (from the example mapping)

| Rule | Automated by |
|---|---|
| R-01 every response carries one top-level `next` hint | `test_every_response_carries_a_next_hint` |
| R-02 empty responses teach another way in (empty search → list_tags, empty links → backlinks) | `test_empty_responses_teach_another_way_in` |
| R-03 `next` stays top-level; result elements stay lean | `test_next_stays_top_level_only` |

Tests cite their rules by livt URI. R-01/R-02 were written red-first; R-03 already held and lands as a regression guard.

## What changed

- All 6 tool responses gain a state-aware top-level `next` string (`src/mcp/tools/*.rs`)
- **Shape change (the one to review):** `list_tags` moves from a bare JSON array to the `{results, count, next}` envelope its sibling tools already use — a bare array has nowhere to put the hint
- `livt/discoveries/example-mappings/follow-response-hints.yaml` — the spec; open question Q-01 (mirror `next` into CLI `--json`) lands on the livt Tasks page

Constraint held: no AI inside the CLI/MCP process — hints are deterministic strings chosen by response state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)