### PR TITLE
feat(mcp): orient a session with one argument-less call

### DIFF
--- a/livt/discoveries/example-mappings/orient-at-session-start.yaml
+++ b/livt/discoveries/example-mappings/orient-at-session-start.yaml
@@ -1,0 +1,31 @@
+story: orient-at-session-start
+
+rules:
+  - id: R-01
+    name: orient は引数なしの1応答で、規模・文脈・主要タグを揃えて返す
+    examples:
+      - id: EX-01
+        name: scrap_count / tag_count / contexts / top_tags が1回の呼び出しで揃う
+      - id: EX-02
+        name: contexts は名前順で安定している
+    automated: true
+  - id: R-02
+    name: 主要タグは被リンク数の降順で上位10件に絞る（全量は list_tags の仕事）
+    examples:
+      - id: EX-01
+        name: top_tags の先頭は最も被リンクの多いタグ
+      - id: EX-02
+        name: タグが10件を超えても top_tags は10件で止まり、tag_count は全量を示す
+    automated: true
+  - id: R-03
+    name: orient も既存ルールの下に入る — 定義は「いつ使うか」で始まり、応答は次の一手を運ぶ
+    examples:
+      - id: EX-01
+        name: 応答の next が search_scraps と lookup_tag_backlinks を名指す
+      - id: EX-02
+        name: learn-usage-from-tool-defs と follow-response-hints の既存テストが orient にもそのまま効く
+    automated: true
+
+questions:
+  - id: Q-01
+    text: git 由来の最近更新を orient に足すか（依存なしの決定論 core 方針との兼ね合い）

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let response: serde_json::Value = serde_json::from_str(&body).unwrap();
         let tools = response["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
 
         server_handle.abort();
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,6 +5,7 @@ use super::tools::list_tags::list_tags;
 use super::tools::lookup_scrap_backlinks::{lookup_scrap_backlinks, LookupScrapBacklinksRequest};
 use super::tools::lookup_scrap_links::{lookup_scrap_links, LookupScrapLinksRequest};
 use super::tools::lookup_tag_backlinks::{lookup_tag_backlinks, LookupTagBacklinksRequest};
+use super::tools::orient::orient;
 use super::tools::search_scraps::{search_scraps, SearchRequest};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -40,6 +41,16 @@ impl ScrapsServer {
         parameters: Parameters<GetScrapRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         get_scrap(&self.scraps_dir, &self.exclude_dirs, context, parameters).await
+    }
+
+    #[tool(
+        description = "Use when you start a session on an unfamiliar wiki: returns its scale (scrap and tag counts), folder contexts, and top tags in one response, with no arguments. Continue with search_scraps for content, or expand a topic with lookup_tag_backlinks; the full tag list is list_tags."
+    )]
+    async fn orient(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        orient(&self.scraps_dir, &self.exclude_dirs, context).await
     }
 
     #[tool(
@@ -149,9 +160,10 @@ mod tests {
 
         let tools = client.list_tools(Default::default()).await.unwrap();
 
-        assert_eq!(tools.tools.len(), 6);
+        assert_eq!(tools.tools.len(), 7);
 
         let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(tool_names.contains(&"orient"));
         assert!(tool_names.contains(&"get_scrap"));
         assert!(tool_names.contains(&"search_scraps"));
         assert!(tool_names.contains(&"lookup_scrap_links"));
@@ -322,6 +334,7 @@ mod tests {
             ),
             ("list_tags", serde_json::json!({})),
             ("lookup_tag_backlinks", serde_json::json!({"tag": "rust"})),
+            ("orient", serde_json::json!({})),
         ];
 
         for (name, args) in calls {
@@ -337,6 +350,61 @@ mod tests {
         assert!(
             tags["results"].is_array() && tags["count"].is_u64(),
             "list_tags should use the results/count envelope: {tags}"
+        );
+    }
+
+    // Automates livt://mapping/orient-at-session-start/rule/R-01
+    #[rstest]
+    #[tokio::test]
+    async fn test_orient_gathers_scale_contexts_and_top_tags(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("a.md", b"# A\n\n#[[rust]] #[[go]]");
+        project.add_scrap("Kubernetes/b.md", b"# B\n\n#[[rust]]");
+        project.add_scrap("Book/c.md", b"# C\n\nplain");
+
+        let orient = call_tool_json(&project, "orient", serde_json::json!({})).await;
+
+        assert_eq!(orient["scrap_count"], 3);
+        assert_eq!(orient["tag_count"], 2);
+        assert_eq!(
+            orient["contexts"],
+            serde_json::json!(["Book", "Kubernetes"])
+        );
+        assert_eq!(orient["top_tags"][0]["title"], "rust");
+    }
+
+    // Automates livt://mapping/orient-at-session-start/rule/R-02
+    #[rstest]
+    #[tokio::test]
+    async fn test_orient_ranks_and_caps_top_tags(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        let all_tags: String = (1..=12).map(|i| format!("#[[t{i:02}]] ")).collect();
+        project.add_scrap("a.md", format!("# A\n\n{all_tags}").as_bytes());
+        project.add_scrap("b.md", b"# B\n\n#[[t12]]");
+
+        let orient = call_tool_json(&project, "orient", serde_json::json!({})).await;
+
+        assert_eq!(orient["tag_count"], 12);
+        assert_eq!(orient["top_tags"].as_array().unwrap().len(), 10);
+        assert_eq!(orient["top_tags"][0]["title"], "t12");
+    }
+
+    // Automates livt://mapping/orient-at-session-start/rule/R-03
+    #[rstest]
+    #[tokio::test]
+    async fn test_orient_names_entry_tools_in_next(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("a.md", b"# A\n\nContent");
+
+        let orient = call_tool_json(&project, "orient", serde_json::json!({})).await;
+
+        let next = orient["next"].as_str().unwrap_or_default();
+        assert!(
+            next.contains("search_scraps") && next.contains("lookup_tag_backlinks"),
+            "orient next should name the entry tools: {orient}"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,4 +3,5 @@ pub mod list_tags;
 pub mod lookup_scrap_backlinks;
 pub mod lookup_scrap_links;
 pub mod lookup_tag_backlinks;
+pub mod orient;
 pub mod search_scraps;

--- a/src/mcp/tools/orient.rs
+++ b/src/mcp/tools/orient.rs
@@ -1,0 +1,80 @@
+use crate::input::file::read_scraps;
+use crate::usecase::tag::list::usecase::ListTagUsecase;
+use rmcp::model::ErrorCode;
+use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer};
+use serde_json::json;
+use std::path::Path;
+
+// Head of the topic map only; the full list stays list_tags' job.
+const TOP_TAGS_LIMIT: usize = 10;
+
+pub async fn orient(
+    scraps_dir: &Path,
+    exclude_dirs: &[std::path::PathBuf],
+    _context: RequestContext<RoleServer>,
+) -> Result<CallToolResult, ErrorData> {
+    // Load scraps from directory
+    let scraps = read_scraps::to_all_scraps(scraps_dir, exclude_dirs).map_err(|e| {
+        ErrorData::new(
+            ErrorCode(-32003),
+            format!("Failed to load scraps: {e}"),
+            None,
+        )
+    })?;
+
+    let mut contexts: Vec<String> = scraps
+        .iter()
+        .filter_map(|s| s.ctx().as_ref().map(|c| c.to_string()))
+        .collect();
+    contexts.sort();
+    contexts.dedup();
+
+    // Create tag usecase
+    let tag_usecase = ListTagUsecase::new();
+
+    let (tags, backlinks_map) = tag_usecase
+        .execute(&scraps)
+        .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("List tags failed: {e}"), None))?;
+
+    let tag_count = tags.len();
+    let mut ranked: Vec<(String, usize)> = tags
+        .into_iter()
+        .map(|tag| {
+            let backlinks_count = backlinks_map.get_tag(&tag).len();
+            (tag.to_string(), backlinks_count)
+        })
+        .collect();
+    // Tie-break by name so the head of the topic map is stable.
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let top_tags: Vec<_> = ranked
+        .into_iter()
+        .take(TOP_TAGS_LIMIT)
+        .map(|(title, backlinks_count)| {
+            json!({
+                "title": title,
+                "backlinks_count": backlinks_count
+            })
+        })
+        .collect();
+
+    let scrap_count = scraps.len();
+    let next = if scrap_count == 0 {
+        "The wiki has no scraps yet."
+    } else {
+        "Search content with search_scraps, or expand a top tag with lookup_tag_backlinks {tag}; the full tag list is list_tags."
+    };
+
+    let response = json!({
+        "scrap_count": scrap_count,
+        "tag_count": tag_count,
+        "contexts": contexts,
+        "top_tags": top_tags,
+        "next": next,
+    });
+
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string(&response).unwrap(),
+    )]))
+}


### PR DESCRIPTION
## Why

Third and last story of the `recallable-memory` slice **引き出し方を教える** (after #669, #678). An agent starting on an unfamiliar wiki opened with guesswork — probing searches, a bare list_tags. [一枚のオリエンテーションで起点を掴む](livt/stories/orient-at-session-start.md): one argument-less call returns the lay of the wiki.

## Rules (from the example mapping)

| Rule | Automated by |
|---|---|
| R-01 one response gathers scale, contexts (stably sorted), top tags | `test_orient_gathers_scale_contexts_and_top_tags` |
| R-02 top tags ranked by inbound references, capped at 10 (full list stays `list_tags`) | `test_orient_ranks_and_caps_top_tags` |
| R-03 orient falls under the existing interface rules | `test_orient_names_entry_tools_in_next` + the two earlier mappings' suites, which iterate every tool and so cover orient automatically |

Written red-first: the new tests plus the tool-count and every-response suites all failed before the implementation landed.

## What changed

- `src/mcp/tools/orient.rs` — new tool: `{scrap_count, tag_count, contexts, top_tags, next}`
- `src/mcp/server.rs` — registration with a definition that opens with when-to-use and names the follow-up tools
- `src/mcp/http.rs` — tool count 6 → 7
- `livt/discoveries/example-mappings/orient-at-session-start.yaml` — the spec; open question Q-01 (git-based recent changes in orient vs. the no-dependency deterministic core) lands on the livt Tasks page

Constraint held: no AI inside the CLI/MCP process; everything here is a deterministic aggregation over the parsed wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)