### PR TITLE
feat(build): render the README at its own /about/ page

### DIFF
--- a/design/storybook/stories/Sidebar.stories.js
+++ b/design/storybook/stories/Sidebar.stories.js
@@ -15,10 +15,13 @@ const tagItem = ({ title, count }) => `
 
 const sidebar = ({ activeView, results = [] }) => `
   <aside class="sidebar" style="height: 640px; position: static;">
-    <a class="brand" href="#">
-      <span class="mark">[[&nbsp;]]</span>
-      <span class="name">Scraps Doc</span>
-    </a>
+    <div class="brand-block">
+      <a class="brand" href="#">
+        <span class="mark">[[&nbsp;]]</span>
+        <span class="name">Scraps Doc</span>
+      </a>
+      ${activeView === 'about' ? '<span class="about active">about</span>' : '<a class="about" href="#">about</a>'}
+    </div>
     <div class="search">
       <input type="search" id="search-input" placeholder="Search by title..." autocomplete="off" />
       ${

--- a/design/v2/mockups/home.html
+++ b/design/v2/mockups/home.html
@@ -15,9 +15,12 @@
 <div style="width: 1440px; height: 1000px; box-sizing: border-box; background-color: #2e3440; color: #eceff4; font-family: 'Rubik', 'Noto Sans JP', sans-serif; display: flex; overflow: hidden;">
 
   <div style="width: 264px; flex-shrink: 0; box-sizing: border-box; background-color: #3b4252; border-right: 1px solid #434c5e; display: flex; flex-direction: column; padding: 20px 16px;">
-    <div style="display: flex; align-items: center; gap: 10px; padding: 0 4px;">
-      <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
-      <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+    <div style="display: flex; flex-direction: column; gap: 4px; padding: 0 4px;">
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
+        <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+      </div>
+      <a href="#" style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 12px; color: #81a1c1;">about</a>
     </div>
 
     <div style="margin-top: 18px; display: flex; align-items: center; gap: 8px; background-color: #2e3440; border: 1px solid #434c5e; border-radius: 4px; padding: 8px 10px;">

--- a/design/v2/mockups/scrap.html
+++ b/design/v2/mockups/scrap.html
@@ -15,9 +15,12 @@
 <div style="width: 1440px; height: 1000px; box-sizing: border-box; background-color: #2e3440; color: #eceff4; font-family: 'Rubik', 'Noto Sans JP', sans-serif; display: flex; overflow: hidden;">
 
   <div style="width: 264px; flex-shrink: 0; box-sizing: border-box; background-color: #3b4252; border-right: 1px solid #434c5e; display: flex; flex-direction: column; padding: 20px 16px;">
-    <div style="display: flex; align-items: center; gap: 10px; padding: 0 4px;">
-      <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
-      <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+    <div style="display: flex; flex-direction: column; gap: 4px; padding: 0 4px;">
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
+        <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+      </div>
+      <a href="#" style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 12px; color: #81a1c1;">about</a>
     </div>
 
     <div style="margin-top: 18px; display: flex; align-items: center; gap: 8px; background-color: #2e3440; border: 1px solid #434c5e; border-radius: 4px; padding: 8px 10px;">

--- a/design/v2/mockups/title-index.html
+++ b/design/v2/mockups/title-index.html
@@ -15,9 +15,12 @@
 <div style="width: 1440px; height: 1000px; box-sizing: border-box; background-color: #2e3440; color: #eceff4; font-family: 'Rubik', 'Noto Sans JP', sans-serif; display: flex; overflow: hidden;">
 
   <div style="width: 264px; flex-shrink: 0; box-sizing: border-box; background-color: #3b4252; border-right: 1px solid #434c5e; display: flex; flex-direction: column; padding: 20px 16px;">
-    <div style="display: flex; align-items: center; gap: 10px; padding: 0 4px;">
-      <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
-      <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+    <div style="display: flex; flex-direction: column; gap: 4px; padding: 0 4px;">
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <span style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 16px; font-weight: 500; color: #88c0d0;">[[&nbsp;]]</span>
+        <span style="font-size: 15px; font-weight: 700;">Kush's Wiki</span>
+      </div>
+      <a href="#" style="font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace; font-size: 12px; color: #81a1c1;">about</a>
     </div>
 
     <div style="margin-top: 18px; display: flex; align-items: center; gap: 8px; background-color: #2e3440; border: 1px solid #434c5e; border-radius: 4px; padding: 8px 10px;">

--- a/design/v2/ui-spec.md
+++ b/design/v2/ui-spec.md
@@ -32,13 +32,12 @@
 
 ## 2. Functional changes (v2, breaking)
 
-1. **README stays on the home — the shell absorbs it.** v1's problem was that
-   the home's entire structure depended on README content. v2 fixes the
-   structure instead of dropping the feature: the sidebar (nav / search /
-   tags) and the view header + stats line are always present, and an optional
-   README block renders in the content column above the scrap list. No
-   config — the presence of README.md is the switch. The docs site's own home
-   relies on this. `mockups/home.html` shows the README-absent case.
+1. **README gets its own page.** v1 injected README.md into the home, so the
+   home's height and rhythm depended on prose. v2 keeps the home fully
+   designed (view header, stats, list) and renders README.md at `/about/`
+   instead, linked from the sidebar brand block. No config — the presence of
+   README.md is the switch. Autolinks on the about page render as cards like
+   any scrap, retiring v1's plain-link fallback on the index.
 2. **`sort_key` config is removed.** Every sort view is always generated:
 
    | View | Route | Order | Pagination |

--- a/docs/Reference/Markdown/Autolink.md
+++ b/docs/Reference/Markdown/Autolink.md
@@ -16,5 +16,5 @@ Reach for `<…>` when the link is a "you should look at this" pointer
 (canonical source, prior art, recipe target). Use `[text](url)` for inline
 references that the reader skims past.
 
-The wiki root `README.md` falls back to plain links — see
-[[Reference/Static Site/README and Index]] for the limitation.
+The wiki root `README.md` renders at its own about page, cards included —
+see [[Reference/Static Site/README and About]].

--- a/docs/Reference/Static Site.md
+++ b/docs/Reference/Static Site.md
@@ -14,9 +14,9 @@ fully supported.
 
 ![[Reference/Static Site/Output Structure]]
 
-## [[Reference/Static Site/README and Index|README and the index page]]
+## [[Reference/Static Site/README and About|README and the about page]]
 
-![[Reference/Static Site/README and Index]]
+![[Reference/Static Site/README and About]]
 
 ## [[Reference/Static Site/Search Index|Search index]]
 

--- a/docs/Reference/Static Site/Output Structure.md
+++ b/docs/Reference/Static Site/Output Structure.md
@@ -6,7 +6,9 @@ Build output is written to the directory configured by `output_dir`
 ```bash
 ❯ tree _site
 _site
-├── index.html              # home: the updated view (plus README.md, when present)
+├── index.html              # home: the updated view
+├── about/
+│   └── index.html          # README.md, when present
 ├── backlinks/
 │   └── index.html          # most linked first
 ├── scraps/

--- a/docs/Reference/Static Site/README and About.md
+++ b/docs/Reference/Static Site/README and About.md
@@ -1,0 +1,9 @@
+#[[Emit/Static Site]]
+
+`README.md` at the wiki root is special-cased: it is not a scrap, and it
+renders at its own `about/index.html` page, linked from the sidebar next to
+the site title. This keeps the home a designed listing whatever the README
+grows into, while the file still renders directly on GitHub.
+
+No configuration — the presence of `README.md` is the switch. Without one,
+the sidebar shows no about link.

--- a/docs/Reference/Static Site/README and Index.md
+++ b/docs/Reference/Static Site/README and Index.md
@@ -1,9 +1,0 @@
-#[[Emit/Static Site]]
-
-`README.md` at the wiki root is special-cased: it becomes `index.html`
-instead of `scraps/readme.html`. This lets the wiki render correctly both
-on the static site and directly on GitHub.
-
-One limitation: [[Reference/Markdown/Autolink|autolinks]] inside the wiki
-root `README.md` fall back to plain links — the OGP card is suppressed on
-the index page.

--- a/src/output/build_renderer.rs
+++ b/src/output/build_renderer.rs
@@ -10,7 +10,7 @@ use crate::service::search::render::SearchIndexRender;
 use crate::usecase::build::{
     css::render::CSSRender,
     html::{
-        index_render::IndexRender, scrap_render::ScrapRender,
+        about_render::AboutRender, index_render::IndexRender, scrap_render::ScrapRender,
         scraps_index_render::ScrapsIndexRender, tag_render::TagRender,
         tags_index_render::TagsIndexRender,
     },
@@ -23,8 +23,8 @@ use crate::usecase::build::{
         site_nav::SiteNav,
     },
     renderer::{
-        CssRenderer, HtmlIndexRenderer, HtmlScrapRenderer, HtmlScrapsIndexRenderer,
-        HtmlTagRenderer, HtmlTagsIndexRenderer, SearchIndexJsonRenderer,
+        CssRenderer, HtmlAboutRenderer, HtmlIndexRenderer, HtmlScrapRenderer,
+        HtmlScrapsIndexRenderer, HtmlTagRenderer, HtmlTagsIndexRenderer, SearchIndexJsonRenderer,
     },
 };
 
@@ -33,6 +33,7 @@ use crate::usecase::build::{
 /// than per rendered page.
 pub struct BuildRendererImpl {
     index_render: IndexRender,
+    about_render: AboutRender,
     scrap_render: ScrapRender,
     scraps_index_render: ScrapsIndexRender,
     tags_index_render: TagsIndexRender,
@@ -45,6 +46,7 @@ impl BuildRendererImpl {
     pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<BuildRendererImpl> {
         Ok(BuildRendererImpl {
             index_render: IndexRender::new(static_dir_path, output_dir_path)?,
+            about_render: AboutRender::new(static_dir_path, output_dir_path)?,
             scrap_render: ScrapRender::new(static_dir_path, output_dir_path)?,
             scraps_index_render: ScrapsIndexRender::new(static_dir_path, output_dir_path)?,
             tags_index_render: TagsIndexRender::new(static_dir_path, output_dir_path)?,
@@ -64,7 +66,6 @@ impl HtmlIndexRenderer for BuildRendererImpl {
         scrap_details: &ScrapDetails,
         backlinks_map: &BacklinksMap,
         site_nav: &SiteNav,
-        readme_content: &Option<Content>,
     ) -> ScrapsResult<usize> {
         self.index_render.run(
             base_url,
@@ -73,7 +74,25 @@ impl HtmlIndexRenderer for BuildRendererImpl {
             scrap_details,
             backlinks_map,
             site_nav,
+        )
+    }
+}
+
+impl HtmlAboutRenderer for BuildRendererImpl {
+    fn render_about(
+        &self,
+        base_url: &BaseUrl,
+        html_metadata: &HtmlMetadata,
+        readme_content: &Content,
+        backlinks_map: &BacklinksMap,
+        site_nav: &SiteNav,
+    ) -> ScrapsResult<()> {
+        self.about_render.run(
+            base_url,
+            html_metadata,
             readme_content,
+            backlinks_map,
+            site_nav,
         )
     }
 }

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -35,7 +35,7 @@ a {
    the accent and the body colour sit at 1.29:1, well under the 3:1 that would
    make the hue difference dispensable. Underline them. */
 div.scrap .content a,
-div.index div.readme-block a {
+div.about .content a {
     text-decoration: underline;
     text-underline-offset: 2px;
 }
@@ -101,27 +101,44 @@ aside.sidebar {
     background-color: var(--color-surface-raised);
     border-right: var(--border-hairline) solid var(--color-rule);
 
-    a.brand {
+    div.brand-block {
         display: flex;
-        align-items: center;
-        gap: var(--space-2);
+        flex-direction: column;
+        gap: var(--space-1);
         padding: 0 var(--space-2);
-        color: var(--color-text);
 
-        &:hover {
-            text-decoration: none;
+        a.brand {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            color: var(--color-text);
+
+            &:hover {
+                text-decoration: none;
+            }
+
+            span.mark {
+                font-family: var(--font-family-mono);
+                font-weight: var(--font-weight-medium);
+                color: var(--color-accent);
+            }
+
+            span.name {
+                font-size: var(--font-size-sm);
+                font-weight: var(--font-weight-bold);
+                line-height: var(--font-line-height-tight);
+            }
         }
 
-        span.mark {
+        .about {
+            align-self: flex-start;
             font-family: var(--font-family-mono);
-            font-weight: var(--font-weight-medium);
-            color: var(--color-accent);
+            font-size: var(--font-size-xs);
+            color: var(--color-text-muted);
         }
 
-        span.name {
-            font-size: var(--font-size-sm);
-            font-weight: var(--font-weight-bold);
-            line-height: var(--font-line-height-tight);
+        span.about.active {
+            color: var(--color-text);
         }
     }
 
@@ -340,54 +357,67 @@ div.scrap {
         border-top: var(--border-hairline) solid var(--color-rule);
         word-break: break-word;
 
-        .link-card {
-            display: flex;
-            align-items: center;
-            gap: var(--space-3);
-            background-color: var(--color-surface-raised);
-            border: var(--border-hairline) solid var(--color-rule);
-            border-radius: var(--radius-md);
-            margin: var(--space-4) 0;
-            padding: var(--space-3) var(--space-4);
-
-            &:hover {
-                text-decoration: none;
-
-                .host {
-                    text-decoration: underline;
-                }
-            }
-
-            svg.icon {
-                flex-shrink: 0;
-                color: var(--color-text-muted);
-            }
-
-            .body {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-                min-width: 0;
-            }
-
-            .host {
-                font-weight: var(--font-weight-medium);
-                color: var(--color-text);
-            }
-
-            .url {
-                font-family: var(--font-family-mono);
-                font-size: var(--font-size-xs);
-                color: var(--color-text-muted);
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-        }
     }
 
     img {
         max-width: 100%;
+    }
+}
+
+/* Autolink card, shared by scrap content and the about page. Underlines from
+   the prose-link rule stay off it: the card is its own affordance. */
+.content a.link-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    background-color: var(--color-surface-raised);
+    border: var(--border-hairline) solid var(--color-rule);
+    border-radius: var(--radius-md);
+    margin: var(--space-4) 0;
+    padding: var(--space-3) var(--space-4);
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: none;
+
+        .host {
+            text-decoration: underline;
+        }
+    }
+
+    svg.icon {
+        flex-shrink: 0;
+        color: var(--color-text-muted);
+    }
+
+    .body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+    }
+
+    .host {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-text);
+    }
+
+    .url {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+/* about — the README's own page */
+div.about {
+    max-width: 760px;
+
+    .content {
+        word-break: break-word;
     }
 }
 
@@ -409,13 +439,6 @@ div.tag {
 
 /* index */
 div.index {
-    /* readme block */
-    div.readme-block {
-        hr {
-            margin: var(--space-7) 0;
-        }
-    }
-
     /* links block */
     div.links-block {
         p.list-head {

--- a/src/usecase/build/html.rs
+++ b/src/usecase/build/html.rs
@@ -1,3 +1,4 @@
+pub mod about_render;
 mod cdn_versions;
 pub mod index_render;
 mod page_pointer;

--- a/src/usecase/build/html/about_render.rs
+++ b/src/usecase/build/html/about_render.rs
@@ -1,0 +1,100 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::ScrapsResult;
+use crate::service::tera_render::{render_to_file, resolve_template, user_template_glob};
+use crate::usecase::build::html::templates;
+use crate::usecase::build::model::backlinks_map::BacklinksMap;
+use crate::usecase::build::model::html::HtmlMetadata;
+use crate::usecase::build::model::site_nav::SiteNav;
+use scraps_libs::model::{base_url::BaseUrl, content::Content};
+use tera::Tera;
+
+use super::serde::content::ContentTera;
+
+/// A root README.md is the wiki's front matter, not its front page: it
+/// renders at /about/ so the home stays a designed listing whatever the
+/// README grows into.
+pub struct AboutRender {
+    tera: Tera,
+    output_about_dir_path: PathBuf,
+}
+
+impl AboutRender {
+    pub fn new(static_dir_path: &Path, output_dir_path: &Path) -> ScrapsResult<AboutRender> {
+        let tera = templates::about(&user_template_glob(static_dir_path, "*.html"))?;
+
+        Ok(AboutRender {
+            tera,
+            output_about_dir_path: output_dir_path.join("about"),
+        })
+    }
+
+    pub fn run(
+        &self,
+        base_url: &BaseUrl,
+        metadata: &HtmlMetadata,
+        readme_content: &Content,
+        backlinks_map: &BacklinksMap,
+        site_nav: &SiteNav,
+    ) -> ScrapsResult<()> {
+        let mut context = templates::context(base_url, metadata);
+        templates::insert_site_nav(&mut context, "about", site_nav, backlinks_map);
+        context.insert("readme_content", &ContentTera::from(readme_content.clone()));
+
+        let template_name = resolve_template(&self.tera, "about.html", "__builtins/about.html");
+        let file_path = self.output_about_dir_path.join("index.html");
+        render_to_file(&self.tera, template_name, &context, &file_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
+    use scraps_libs::html::{self, EmbedMode};
+    use scraps_libs::{
+        lang::LangCode, model::base_url::BaseUrl, model::scrap::Scrap, model::tags::Tags,
+    };
+    use std::collections::HashMap;
+    use std::fs;
+    use url::Url;
+
+    use super::*;
+
+    #[rstest]
+    fn it_run(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let base_url = BaseUrl::new(Url::parse("http://localhost:1112/").unwrap()).unwrap();
+        let metadata = HtmlMetadata::new(&LangCode::default(), "Scrap", &None, &None);
+
+        let scrap1 = Scrap::new("intro", &None, "# Intro");
+        let scraps = [scrap1.clone()];
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC, true);
+
+        let scrap_texts: HashMap<_, _> = scraps
+            .iter()
+            .map(|s| (s.self_key(), s.md_text().to_string()))
+            .collect();
+        let readme_content = html::to_content(
+            "# About this wiki\n\nhttps://example.com/\n",
+            &base_url,
+            EmbedMode::Expand(&scrap_texts),
+        );
+
+        let render = AboutRender::new(&project.static_dir, &project.output_dir).unwrap();
+        render
+            .run(
+                &base_url,
+                &metadata,
+                &readme_content,
+                &backlinks_map,
+                &site_nav,
+            )
+            .unwrap();
+
+        let result = fs::read_to_string(project.output_path("about/index.html")).unwrap();
+        assert!(result.contains("About this wiki"));
+        assert!(result.contains("link-card"));
+        assert!(result.contains(">about<"));
+    }
+}

--- a/src/usecase/build/html/builtins/about.html
+++ b/src/usecase/build/html/builtins/about.html
@@ -1,0 +1,11 @@
+{% extends "__builtins/base.html" %}
+
+{% block status_left %}about{% endblock status_left %}
+
+{% block main %}
+    <div class="about">
+        <div class="content">
+            {% for element in readme_content.elements %}{% if element.raw %}{{ element.raw | safe }}{% elif element.autolink %}{{ <link_card autolink={element.autolink} /> }}{% endif %}{% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/usecase/build/html/builtins/base.html
+++ b/src/usecase/build/html/builtins/base.html
@@ -40,10 +40,15 @@
     <body>
         <div class="shell">
         <aside class="sidebar">
-            <a class="brand" href="{{ base_url }}">
-                <span class="mark">[[&nbsp;]]</span>
-                <span class="name">{{ title }}</span>
-            </a>
+            <div class="brand-block">
+                <a class="brand" href="{{ base_url }}">
+                    <span class="mark">[[&nbsp;]]</span>
+                    <span class="name">{{ title }}</span>
+                </a>
+                {% if has_readme %}
+                    {% if view == "about" %}<span class="about active">about</span>{% else %}<a class="about" href="{{ base_url }}about/">about</a>{% endif %}
+                {% endif %}
+            </div>
             {% if build_search_index == true %}
                 <div class="search">
                     <input

--- a/src/usecase/build/html/builtins/index.html
+++ b/src/usecase/build/html/builtins/index.html
@@ -2,12 +2,6 @@
 
 {% block main %}
     <div class="index">
-        {% if readme_content %}
-          <div class="readme-block">
-            {% for element in readme_content.elements %}{% if element.raw %}{{ element.raw | safe }}{% elif element.autolink %}<a href="{{ element.autolink.url }}">{{ element.autolink.url }}</a>{% endif %}{% endfor %}
-            <hr>
-          </div>
-        {% endif %}
         <div class="links-block">
             <p class="list-head">
                 <span class="view-name">{% if view == "backlinks" %}most backlinked{% else %}recently updated{% endif %}</span>

--- a/src/usecase/build/html/index_render.rs
+++ b/src/usecase/build/html/index_render.rs
@@ -10,14 +10,13 @@ use crate::usecase::build::model::list_view_configs::ListViewConfigs;
 use crate::usecase::build::model::scrap_detail::ScrapDetails;
 use crate::usecase::build::model::site_nav::SiteNav;
 use crate::usecase::build::model::sort::SortKey;
-use scraps_libs::model::{base_url::BaseUrl, content::Content};
+use scraps_libs::model::base_url::BaseUrl;
 use tera::Tera;
 use tracing::{span, Level};
 
 use crate::usecase::build::html::templates;
 
 use super::page_pointer::PagePointer;
-use super::serde::content::ContentTera;
 use super::serde::index_scraps::IndexScrapsTera;
 
 pub struct IndexRender {
@@ -36,7 +35,6 @@ impl IndexRender {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn run(
         &self,
         base_url: &BaseUrl,
@@ -45,14 +43,13 @@ impl IndexRender {
         scrap_details: &ScrapDetails,
         backlinks_map: &BacklinksMap,
         site_nav: &SiteNav,
-        readme_content: &Option<Content>,
     ) -> ScrapsResult<usize> {
         let scraps = &scrap_details.to_scraps();
         let paging_size = list_view_configs.paging.size_with(scraps);
         let shared_context = templates::context(base_url, metadata);
 
         // Every sort view is always generated; a sort key is a URL, not a
-        // config. The home is the updated view, README included.
+        // config. The home is the updated view.
         let updated_pages = {
             let _span = span!(Level::INFO, "generate_updated_view").entered();
             let sorted = IndexScrapsTera::new_with_sort(
@@ -64,7 +61,6 @@ impl IndexRender {
                 &Self::view_context(&shared_context, "updated", site_nav, backlinks_map),
                 &sorted,
                 paging_size,
-                readme_content,
                 &self.output_dir_path,
             )?
         };
@@ -77,7 +73,6 @@ impl IndexRender {
                 &Self::view_context(&shared_context, "backlinks", site_nav, backlinks_map),
                 &sorted,
                 paging_size,
-                &None,
                 &self.output_dir_path.join("backlinks"),
             )?
         };
@@ -101,19 +96,14 @@ impl IndexRender {
         view_context: &tera::Context,
         sorted_scraps: &IndexScrapsTera,
         paging_size: usize,
-        readme_content: &Option<Content>,
         output_dir: &Path,
     ) -> ScrapsResult<usize> {
         let chunks = sorted_scraps.chunks(paging_size);
         let total_pages = chunks.len();
 
         if let Some(first_scraps) = chunks.first() {
-            let (context, page_pointer) = Self::prepare_index_context(
-                view_context,
-                first_scraps,
-                total_pages,
-                readme_content,
-            );
+            let (context, page_pointer) =
+                Self::prepare_index_context(view_context, first_scraps, total_pages);
             self.render_html(&context, &page_pointer, output_dir)?;
         }
 
@@ -140,15 +130,11 @@ impl IndexRender {
         base_context: &tera::Context,
         scraps: &IndexScrapsTera,
         total_pages: usize,
-        readme_content: &Option<Content>,
     ) -> (tera::Context, PagePointer) {
         let pointer = PagePointer::new_index(total_pages);
         let mut context = base_context.clone();
         context.insert("scraps", &scraps);
         context.insert("next", &pointer.next);
-        if let Some(readme) = readme_content {
-            context.insert("readme_content", &ContentTera::from(readme.clone()));
-        }
         (context, pointer)
     }
 
@@ -224,7 +210,13 @@ mod tests {
 
         let scraps = scrap_details.to_scraps();
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render
@@ -235,7 +227,6 @@ mod tests {
                 &scrap_details,
                 &backlinks_map,
                 &site_nav,
-                &None,
             )
             .unwrap();
 
@@ -301,10 +292,15 @@ mod tests {
 
         let scraps = scrap_details.to_scraps();
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
-        let readme_content: Option<Content> = None;
         render
             .run(
                 base_url,
@@ -313,7 +309,6 @@ mod tests {
                 &scrap_details,
                 &backlinks_map,
                 &site_nav,
-                &readme_content,
             )
             .unwrap();
 
@@ -363,7 +358,13 @@ mod tests {
         let scrap_details = ScrapDetails::new(&vec![sc1]);
         let scraps = scrap_details.to_scraps();
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = IndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render
@@ -374,7 +375,6 @@ mod tests {
                 &scrap_details,
                 &backlinks_map,
                 &site_nav,
-                &None,
             )
             .unwrap();
 

--- a/src/usecase/build/html/scrap_render.rs
+++ b/src/usecase/build/html/scrap_render.rs
@@ -124,7 +124,13 @@ mod tests {
             .map(|scrap| (scrap.self_key(), scrap.md_text().to_string()))
             .collect();
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
         let scraps_by_key: HashMap<_, _> = scraps
             .iter()
             .map(|scrap| (scrap.self_key(), scrap.clone()))

--- a/src/usecase/build/html/scraps_index_render.rs
+++ b/src/usecase/build/html/scraps_index_render.rs
@@ -91,7 +91,13 @@ mod tests {
             ScrapDetail::new(&scrap3, &None, &base_url, &scrap_texts),
         ]);
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = ScrapsIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render
@@ -121,7 +127,13 @@ mod tests {
             &scrap_texts,
         )]);
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = ScrapsIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render

--- a/src/usecase/build/html/tag_render.rs
+++ b/src/usecase/build/html/tag_render.rs
@@ -99,7 +99,13 @@ mod tests {
         let scrap2 = &Scrap::new("scrap2", &None, "#[[tag 1]] #[[tag2]]");
         let scraps = vec![scrap1.to_owned(), scrap2.to_owned()];
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
         // tag
         let tag1: Tag = "tag 1".into();
 
@@ -135,7 +141,13 @@ mod tests {
         let scrap = Scrap::new("paper", &None, "#[[ai/ml]]");
         let scraps = vec![scrap];
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let tag: Tag = "ai/ml".into();
         // Expected path: public/tags/ai/ml.html

--- a/src/usecase/build/html/tags_index_render.rs
+++ b/src/usecase/build/html/tags_index_render.rs
@@ -82,7 +82,13 @@ mod tests {
         let scraps = vec![scrap1.to_owned(), scrap2.to_owned()];
 
         let backlinks_map = BacklinksMap::new(&scraps);
-        let site_nav = SiteNav::new(scraps.len(), Tags::new(&scraps), true, chrono_tz::UTC);
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            true,
+            chrono_tz::UTC,
+            false,
+        );
 
         let render = TagsIndexRender::new(&project.static_dir, &project.output_dir).unwrap();
         render

--- a/src/usecase/build/html/templates.rs
+++ b/src/usecase/build/html/templates.rs
@@ -16,6 +16,8 @@ const MACROS: (&str, &str) = (
 
 static INDEX: Lazy<Tera> =
     Lazy::new(|| builtins(("__builtins/index.html", include_str!("builtins/index.html"))));
+static ABOUT: Lazy<Tera> =
+    Lazy::new(|| builtins(("__builtins/about.html", include_str!("builtins/about.html"))));
 static SCRAP: Lazy<Tera> =
     Lazy::new(|| builtins(("__builtins/scrap.html", include_str!("builtins/scrap.html"))));
 static TAG: Lazy<Tera> =
@@ -54,6 +56,10 @@ fn with_user_templates(builtin: &Tera, template_dir: &str) -> ScrapsResult<Tera>
 
 pub fn index(template_dir: &str) -> ScrapsResult<Tera> {
     with_user_templates(&INDEX, template_dir)
+}
+
+pub fn about(template_dir: &str) -> ScrapsResult<Tera> {
+    with_user_templates(&ABOUT, template_dir)
 }
 
 pub fn scrap(template_dir: &str) -> ScrapsResult<Tera> {
@@ -99,4 +105,5 @@ pub fn insert_site_nav(
     context.insert("nav_tags", &TagsTera::new(&site_nav.tags, backlinks_map));
     context.insert("build_search_index", &site_nav.build_search_index);
     context.insert("timezone", &site_nav.timezone);
+    context.insert("has_readme", &site_nav.has_readme);
 }

--- a/src/usecase/build/model/site_nav.rs
+++ b/src/usecase/build/model/site_nav.rs
@@ -9,15 +9,25 @@ pub struct SiteNav {
     pub tags: Tags,
     pub build_search_index: bool,
     pub timezone: Tz,
+    /// A root README.md renders at its own /about/ page; the sidebar links
+    /// it only when the file exists.
+    pub has_readme: bool,
 }
 
 impl SiteNav {
-    pub fn new(scrap_count: usize, tags: Tags, build_search_index: bool, timezone: Tz) -> SiteNav {
+    pub fn new(
+        scrap_count: usize,
+        tags: Tags,
+        build_search_index: bool,
+        timezone: Tz,
+        has_readme: bool,
+    ) -> SiteNav {
         SiteNav {
             scrap_count,
             tags,
             build_search_index,
             timezone,
+            has_readme,
         }
     }
 }

--- a/src/usecase/build/renderer.rs
+++ b/src/usecase/build/renderer.rs
@@ -15,7 +15,6 @@ use crate::usecase::build::model::{
 };
 
 pub trait HtmlIndexRenderer {
-    #[allow(clippy::too_many_arguments)]
     fn render_index(
         &self,
         base_url: &BaseUrl,
@@ -24,8 +23,18 @@ pub trait HtmlIndexRenderer {
         scrap_details: &ScrapDetails,
         backlinks_map: &BacklinksMap,
         site_nav: &SiteNav,
-        readme_content: &Option<Content>,
     ) -> ScrapsResult<usize>;
+}
+
+pub trait HtmlAboutRenderer {
+    fn render_about(
+        &self,
+        base_url: &BaseUrl,
+        html_metadata: &HtmlMetadata,
+        readme_content: &Content,
+        backlinks_map: &BacklinksMap,
+        site_nav: &SiteNav,
+    ) -> ScrapsResult<()>;
 }
 
 pub trait HtmlScrapRenderer {
@@ -83,6 +92,7 @@ pub trait SearchIndexJsonRenderer {
 
 pub trait BuildRenderer:
     HtmlIndexRenderer
+    + HtmlAboutRenderer
     + HtmlScrapRenderer
     + HtmlScrapsIndexRenderer
     + HtmlTagsIndexRenderer
@@ -95,6 +105,7 @@ pub trait BuildRenderer:
 
 impl<T> BuildRenderer for T where
     T: HtmlIndexRenderer
+        + HtmlAboutRenderer
         + HtmlScrapRenderer
         + HtmlScrapsIndexRenderer
         + HtmlTagsIndexRenderer
@@ -126,9 +137,21 @@ pub mod tests {
             _scrap_details: &ScrapDetails,
             _backlinks_map: &BacklinksMap,
             _site_nav: &SiteNav,
-            _readme_content: &Option<Content>,
         ) -> ScrapsResult<usize> {
             Ok(1)
+        }
+    }
+
+    impl HtmlAboutRenderer for BuildRendererTest {
+        fn render_about(
+            &self,
+            _base_url: &BaseUrl,
+            _html_metadata: &HtmlMetadata,
+            _readme_content: &Content,
+            _backlinks_map: &BacklinksMap,
+            _site_nav: &SiteNav,
+        ) -> ScrapsResult<()> {
+            Ok(())
         }
     }
 

--- a/src/usecase/build/usecase.rs
+++ b/src/usecase/build/usecase.rs
@@ -74,6 +74,7 @@ impl BuildUsecase {
             Tags::new(&scraps),
             list_view_configs.build_search_index,
             timezone,
+            readme_content.is_some(),
         );
         span_read_scraps.exit();
         progress.complete_stage(&Stage::ReadScraps, &scrap_details.len());
@@ -90,9 +91,15 @@ impl BuildUsecase {
             &scrap_details,
             &backlinks_map,
             &site_nav,
-            &readme_content,
         )?;
         span_generate_html_indexes.exit();
+
+        // generate html about page from README, when present
+        if let Some(readme) = &readme_content {
+            let span_generate_html_about = span!(Level::INFO, "generate_html_about").entered();
+            renderer.render_about(base_url, html_metadata, readme, &backlinks_map, &site_nav)?;
+            span_generate_html_about.exit();
+        }
 
         // generate html scraps
         let span_generate_html_scraps = span!(Level::INFO, "generate_html_scraps").entered();

--- a/tests/e2e/scraps-doc.spec.ts
+++ b/tests/e2e/scraps-doc.spec.ts
@@ -71,8 +71,18 @@ test('get home', async ({ page }) => {
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Scraps Doc/);
 
-  const readme_content = await page.locator('[class="readme-block"]').textContent();
-  expect(readme_content).toContain('What is Scraps?');
+  // The home is a designed listing — the README renders at /about/ instead.
+  await expect(page.locator('div.index .links-block')).toBeVisible();
+  await expect(page.locator('.readme-block')).toHaveCount(0);
+});
+
+test('readme renders at its own about page', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.locator('.sidebar .brand-block a.about').click();
+
+  await expect(page).toHaveURL(/\/about\/$/);
+  const about_content = await page.locator('div.about .content').textContent();
+  expect(about_content).toContain('What is Scraps?');
 });
 
 test('sort views are always generated', async ({ page }) => {


### PR DESCRIPTION
## Summary

A v2 correction caught before the release: the home still rendered README.md inline, so its layout depended on README content — the original v1 complaint. The intended design was a dedicated page.

- **Home**: pure designed listing (view head, stats, rows). The readme block is gone.
- **`/about/`**: a root `README.md` renders here — 760px measure, autolinks as cards (retiring the v1 plain-link fallback on the index). Contextual status bar shows `about`.
- **Sidebar**: an `about` link sits under the brand, only when README.md exists (`SiteNav.has_readme`); active state on the page itself.
- `render_index` sheds its `readme_content` argument (and the last `too_many_arguments` allow with it); a new `AboutRender`/`HtmlAboutRenderer` renders the page only when a README exists.
- Docs updated: `README and Index` → `README and About` (rewritten), Output Structure tree, Autolink limitation note removed; spec §2.1 rewritten; mockups + Storybook sidebar stories carry the about link.

**Verified**: 572 unit/medium tests green; docs build 0.23s; in-browser check of the clean home and `/about/` (light server). Local e2e is currently blocked by another session's `scraps serve` holding port 1112 (`reuseExistingServer` would test a stale site) — needs a run once that server stops.

Follows the merged v2 stack (#682–#686); this should land before v2.0.0 is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)