### PR TITLE
docs: retune the README heading for its own page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-**The Wiki-link doc compiler for the LLM era.**
+# The Wiki-link doc compiler for the LLM era
 
 Scraps treats documentation like a programming language. Wiki-linked
 markdown becomes a typed source, compiling into a static site for readers


### PR DESCRIPTION
## Summary

Tiny follow-up to #687 (the commit just missed the merge): the README's bold-paragraph tagline was sized to sit under the old site header on the injected home. As a standalone `/about/` page it left the page titleless — the tagline is the h1 now, which also reads better on GitHub.

Verified in-browser: `/about/` opens with a proper page title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)