### PR TITLE
fix(design): code blocks, syntax palette and mermaid follow the theme

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,6 +2,12 @@
   "version": "0.0.1",
   "configurations": [
     {
+      "name": "docs",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "mise exec -- mise run docs:serve"],
+      "port": 1112
+    },
+    {
       "name": "livt",
       "runtimeExecutable": "sh",
       "runtimeArgs": ["-c", "cd livt && mise exec -- livt serve"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,7 +43,6 @@
       "matchPackageNames": [
         "highlight.js",
         "mermaid",
-        "nord-highlightjs",
         "fuse.js"
       ]
     }

--- a/design/storybook/stories/Scrap.stories.js
+++ b/design/storybook/stories/Scrap.stories.js
@@ -71,6 +71,22 @@ export const Code = {
 }</code></pre>`),
 };
 
+export const Diff = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'A fenced diff. Added and removed lines carry their own roles so the pairing survives on both grounds.',
+      },
+    },
+  },
+  render: () =>
+    wrap(`<pre><code class="hljs language-diff"><span class="hljs-meta">--- a/tokens/semantic.tokens.json</span>
+<span class="hljs-meta">+++ b/tokens/semantic.tokens.json</span>
+<span class="hljs-deletion">-      "$value": "{color.nord.8}"</span>
+<span class="hljs-addition">+      "$value": "{color.ext.frost-deep}"</span>
+</code></pre>`),
+};
+
 export const Table = {
   render: () =>
     wrap(`<table>

--- a/design/storybook/stories/Scrap.stories.js
+++ b/design/storybook/stories/Scrap.stories.js
@@ -51,12 +51,23 @@ export const Quote = {
     ),
 };
 
+// Storybook renders against main.css alone, so the hljs-* spans are written by
+// hand here to stand in for what highlight.js emits at runtime.
 export const Code = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Code blocks wear surface-raised with a hairline, so the block keeps an edge on the dark ground where the page is nord0. The five syntax roles are gated against that ground, not the page.',
+      },
+    },
+  },
   render: () =>
-    wrap(`<pre><code>pub fn from_md_text(md_text: &amp;str, max_chars: usize) -&gt; Option&lt;Summary&gt; {
-    let mut lines = md_text.lines().map(str::trim);
-    let first = lines.find(|l| !l.is_empty())?;
-    Some(Summary(truncate(first, max_chars)))
+    wrap(`<pre><code class="hljs language-rust"><span class="hljs-comment">// The summary is a scrap's first non-empty line, truncated.</span>
+<span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title function_">from_md_text</span>(md_text: &amp;<span class="hljs-type">str</span>, max_chars: <span class="hljs-type">usize</span>) -&gt; <span class="hljs-type">Option</span>&lt;<span class="hljs-title class_">Summary</span>&gt; {
+    <span class="hljs-keyword">let</span> <span class="hljs-keyword">mut</span> lines = md_text.<span class="hljs-title function_ invoke__">lines</span>().<span class="hljs-title function_ invoke__">map</span>(str::trim);
+    <span class="hljs-keyword">let</span> first = lines.<span class="hljs-title function_ invoke__">find</span>(|l| !l.<span class="hljs-title function_ invoke__">starts_with</span>(<span class="hljs-string">"#"</span>))?;
+    <span class="hljs-title function_ invoke__">Some</span>(<span class="hljs-title class_">Summary</span>(<span class="hljs-title function_ invoke__">truncate</span>(first, max_chars.<span class="hljs-title function_ invoke__">min</span>(<span class="hljs-number">120</span>))))
 }</code></pre>`),
 };
 

--- a/design/v2/ui-spec.md
+++ b/design/v2/ui-spec.md
@@ -101,14 +101,17 @@
   (rule or a nord step) — do not invent a new role unless contrast gates force
   it.
 - **Syntax highlighting is a token concern, not a CDN one.** Code blocks wear
-  `color.surface-raised`, and five roles — `color.syntax-comment` / `-keyword`
-  / `-entity` / `-string` / `-number` — carry the highlight.js palette from
-  `main.css`. Nord's own hljs theme painted the block nord0, the dark page
+  `color.surface-raised`, and seven roles — `color.syntax-comment` / `-keyword`
+  / `-entity` / `-string` / `-number` / `-added` / `-deleted` — carry the
+  highlight.js palette from `main.css`. Nord's own hljs theme painted the block nord0, the dark page
   ground itself, so the block had no edge; npm no longer ships that stylesheet
   at all. These roles are gated against `surface-raised`, not `surface`, since
   that is the ground code is read on. Nord's frost/aurora steps clear AA on the
   dark ground but not on the light one, so light mode uses darkened `ext.*`
   derivations, the same move `ext.frost-deep` already makes for accent.
+- Mermaid is themed from the page, not left on its default: the module reads
+  the resolved `color-scheme` and re-runs on a `prefers-color-scheme` change,
+  because a diagram left alone draws dark strokes onto the dark ground.
 - Typography and spacing scales unchanged (Rubik + Noto Sans JP, mono for
   metadata/syntax, 4px scale, radius 2/4).
 

--- a/design/v2/ui-spec.md
+++ b/design/v2/ui-spec.md
@@ -100,6 +100,15 @@
 - Bracket dimming for `[[ ]]` / `#[[ ]]` uses an existing low-emphasis color
   (rule or a nord step) — do not invent a new role unless contrast gates force
   it.
+- **Syntax highlighting is a token concern, not a CDN one.** Code blocks wear
+  `color.surface-raised`, and five roles — `color.syntax-comment` / `-keyword`
+  / `-entity` / `-string` / `-number` — carry the highlight.js palette from
+  `main.css`. Nord's own hljs theme painted the block nord0, the dark page
+  ground itself, so the block had no edge; npm no longer ships that stylesheet
+  at all. These roles are gated against `surface-raised`, not `surface`, since
+  that is the ground code is read on. Nord's frost/aurora steps clear AA on the
+  dark ground but not on the light one, so light mode uses darkened `ext.*`
+  derivations, the same move `ext.frost-deep` already makes for accent.
 - Typography and spacing scales unchanged (Rubik + Noto Sans JP, mono for
   metadata/syntax, 4px scale, radius 2/4).
 

--- a/src/usecase/build/css/builtins/_tokens.css
+++ b/src/usecase/build/css/builtins/_tokens.css
@@ -24,6 +24,8 @@
     --ext-aurora-green-deep: #577140;
     --ext-aurora-purple-deep: #895b80;
     --ext-aurora-purple-soft: #c6a9c0;
+    --ext-aurora-red-deep: #b04752;
+    --ext-aurora-red-soft: #daa4a9;
 
     --color-surface: light-dark(var(--nord6), var(--nord0));
     --color-surface-raised: light-dark(#ffffff, var(--nord1));
@@ -37,6 +39,8 @@
     --color-syntax-entity: light-dark(var(--ext-frost-teal-deep), var(--nord7));
     --color-syntax-string: light-dark(var(--ext-aurora-green-deep), var(--nord14));
     --color-syntax-number: light-dark(var(--ext-aurora-purple-deep), var(--ext-aurora-purple-soft));
+    --color-syntax-added: light-dark(var(--ext-aurora-green-deep), var(--nord14));
+    --color-syntax-deleted: light-dark(var(--ext-aurora-red-deep), var(--ext-aurora-red-soft));
 
     --font-family-sans: "Rubik", "Noto Sans JP", sans-serif;
     --font-family-mono: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace;

--- a/src/usecase/build/css/builtins/_tokens.css
+++ b/src/usecase/build/css/builtins/_tokens.css
@@ -18,6 +18,12 @@
     --nord15: #b48ead;
     --ext-frost-deep: #47698f;
     --ext-slate-mid: #5d6a80;
+    --ext-slate-soft: #a9b2c2;
+    --ext-frost-teal-deep: #447170;
+    --ext-frost-blue-soft: #9bb4ce;
+    --ext-aurora-green-deep: #577140;
+    --ext-aurora-purple-deep: #895b80;
+    --ext-aurora-purple-soft: #c6a9c0;
 
     --color-surface: light-dark(var(--nord6), var(--nord0));
     --color-surface-raised: light-dark(#ffffff, var(--nord1));
@@ -26,6 +32,11 @@
     --color-rule: light-dark(var(--nord4), var(--nord2));
     --color-accent: light-dark(var(--ext-frost-deep), var(--nord8));
     --color-accent-wash: light-dark(#dfe4ec, #3b4854);
+    --color-syntax-comment: light-dark(var(--ext-slate-mid), var(--ext-slate-soft));
+    --color-syntax-keyword: light-dark(var(--ext-frost-deep), var(--ext-frost-blue-soft));
+    --color-syntax-entity: light-dark(var(--ext-frost-teal-deep), var(--nord7));
+    --color-syntax-string: light-dark(var(--ext-aurora-green-deep), var(--nord14));
+    --color-syntax-number: light-dark(var(--ext-aurora-purple-deep), var(--ext-aurora-purple-soft));
 
     --font-family-sans: "Rubik", "Noto Sans JP", sans-serif;
     --font-family-mono: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace;

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -109,13 +109,20 @@ p code {
 
 .hljs-string,
 .hljs-meta-string,
-.hljs-regexp,
-.hljs-addition {
+.hljs-regexp {
     color: var(--color-syntax-string);
 }
 
 .hljs-number {
     color: var(--color-syntax-number);
+}
+
+.hljs-addition {
+    color: var(--color-syntax-added);
+}
+
+.hljs-deletion {
+    color: var(--color-syntax-deleted);
 }
 
 .hljs-emphasis {

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -51,8 +51,17 @@ code {
     font-size: 0.92em;
 }
 
-pre code {
+/* Code blocks take the raised surface, like every other panel. Nord's
+   highlight.js theme painted them nord0 — the dark page ground itself — so the
+   block had no edge at all; npm no longer ships that stylesheet either, which
+   is why the token classes below live here now. */
+pre:not(:has(code.mermaid)) {
+    margin: var(--space-4) 0;
+    padding: var(--space-3) var(--space-4);
+    background-color: var(--color-surface-raised);
+    border: var(--border-hairline) solid var(--color-rule);
     border-radius: var(--radius-md);
+    overflow-x: auto;
 }
 
 p code {
@@ -60,6 +69,61 @@ p code {
     border: var(--border-hairline) solid var(--color-rule);
     border-radius: var(--radius-sm);
     padding: 1px 4px;
+}
+
+.hljs-comment,
+.hljs-quote {
+    color: var(--color-syntax-comment);
+}
+
+.hljs-keyword,
+.hljs-literal,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-tag,
+.hljs-name,
+.hljs-builtin-name,
+.hljs-selector-tag,
+.hljs-meta,
+.hljs-meta-keyword,
+.hljs-template-tag {
+    color: var(--color-syntax-keyword);
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-built_in,
+.hljs-type,
+.hljs-class,
+.hljs-function,
+.hljs-attr,
+.hljs-doctag,
+.hljs-formula,
+.hljs-code,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+    color: var(--color-syntax-entity);
+}
+
+.hljs-string,
+.hljs-meta-string,
+.hljs-regexp,
+.hljs-addition {
+    color: var(--color-syntax-string);
+}
+
+.hljs-number {
+    color: var(--color-syntax-number);
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}
+
+.hljs-strong {
+    font-weight: var(--font-weight-bold);
 }
 
 blockquote {

--- a/src/usecase/build/html/builtins/base.html
+++ b/src/usecase/build/html/builtins/base.html
@@ -87,8 +87,6 @@
         <!-- Code syntax highlight -->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ cdn.highlightjs }}/highlight.min.js"></script>
         <script>hljs.highlightAll();</script>
-        <!-- Code syntax highlight theme -->
-        <link href="https://unpkg.com/nord-highlightjs@{{ cdn.nord_highlightjs }}/dist/nord.css" rel="stylesheet" type="text/css" />
         <!-- Mermaid -->
         <script type="module">
             import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{{ cdn.mermaid }}/+esm'

--- a/src/usecase/build/html/builtins/base.html
+++ b/src/usecase/build/html/builtins/base.html
@@ -89,7 +89,25 @@
         <script>hljs.highlightAll();</script>
         <!-- Mermaid -->
         <script type="module">
-            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{{ cdn.mermaid }}/+esm'
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{{ cdn.mermaid }}/+esm';
+            // A diagram carries its own colours, so it has to be told which
+            // scheme the page resolved to; left on the default it draws dark
+            // strokes onto the dark ground and the edges disappear.
+            const prefersDark = matchMedia('(prefers-color-scheme: dark)');
+            const isDark = () => {
+                const declared = getComputedStyle(document.documentElement).colorScheme;
+                return declared === 'dark' || (declared !== 'light' && prefersDark.matches);
+            };
+            const draw = () => {
+                mermaid.initialize({ startOnLoad: false, theme: isDark() ? 'dark' : 'default' });
+                document.querySelectorAll('code.mermaid').forEach((node) => {
+                    node.textContent = node.dataset.source ??= node.textContent;
+                    node.removeAttribute('data-processed');
+                });
+                mermaid.run({ querySelector: 'code.mermaid' });
+            };
+            draw();
+            prefersDark.addEventListener('change', draw);
         </script>
         {% if build_search_index == true %}
         <!-- For search scraps -->

--- a/src/usecase/build/html/cdn_versions.rs
+++ b/src/usecase/build/html/cdn_versions.rs
@@ -6,13 +6,11 @@ use serde::Serialize;
 pub struct CdnVersions {
     pub highlightjs: &'static str,
     pub mermaid: &'static str,
-    pub nord_highlightjs: &'static str,
     pub fusejs: &'static str,
 }
 
 pub const CDN_VERSIONS: CdnVersions = CdnVersions {
-    highlightjs: "11.12.0",    // renovate: datasource=npm depName=highlight.js
-    mermaid: "11.17.2",        // renovate: datasource=npm depName=mermaid
-    nord_highlightjs: "0.2.0", // renovate: datasource=npm depName=nord-highlightjs
-    fusejs: "7.5.0",           // renovate: datasource=npm depName=fuse.js
+    highlightjs: "11.12.0", // renovate: datasource=npm depName=highlight.js
+    mermaid: "11.17.2",     // renovate: datasource=npm depName=mermaid
+    fusejs: "7.5.0",        // renovate: datasource=npm depName=fuse.js
 };

--- a/tests/e2e/scraps-doc.spec.ts
+++ b/tests/e2e/scraps-doc.spec.ts
@@ -51,12 +51,15 @@ async function mockExternalRequests(page: Page) {
       return route.fulfill({ contentType: 'text/javascript', body: FUSE_STUB });
     }
     if (url.includes('cdn.jsdelivr.net/npm/mermaid')) {
-      return route.fulfill({ contentType: 'text/javascript', body: 'export default {};' });
+      return route.fulfill({
+        contentType: 'text/javascript',
+        body: 'export default { initialize() {}, run() {} };',
+      });
     }
     if (url.includes('cdnjs.cloudflare.com') && url.includes('highlight')) {
       return route.fulfill({ contentType: 'text/javascript', body: 'window.hljs = { highlightAll() {} };' });
     }
-    // Fonts, theme CSS, anything else external: empty 200 so nothing blocks.
+    // Fonts and anything else external: empty 200 so nothing blocks.
     return route.fulfill({ status: 200, contentType: 'text/css', body: '' });
   });
 }

--- a/tokens/check-contrast.py
+++ b/tokens/check-contrast.py
@@ -11,6 +11,9 @@ import sys
 
 HERE = pathlib.Path(__file__).parent
 TEXT_ROLES = ("text", "text-muted", "accent")
+# Syntax roles never sit on the page ground — code blocks wear surface-raised —
+# so they are gated against that instead.
+SYNTAX_ROLES = ("syntax-comment", "syntax-keyword", "syntax-entity", "syntax-string", "syntax-number")
 AA_BODY = 4.5
 
 
@@ -70,6 +73,14 @@ def main():
         print(f"{status:4s} {mode:5s} {'text/wash':12s} {text_on_wash} on {wash}  {ratio:5.2f}:1")
         if ratio < AA_BODY:
             failures.append(f"{mode}/text-on-wash {ratio:.2f}:1 < {AA_BODY}")
+        raised = resolve(roles["surface-raised"][mode]["$value"], flat)
+        for name in SYNTAX_ROLES:
+            value = resolve(roles[name][mode]["$value"], flat)
+            ratio = contrast(value, raised)
+            status = "ok" if ratio >= AA_BODY else "FAIL"
+            print(f"{status:4s} {mode:5s} {name:12s} {value} on {raised}  {ratio:5.2f}:1")
+            if ratio < AA_BODY:
+                failures.append(f"{mode}/{name} {ratio:.2f}:1 < {AA_BODY}")
     if failures:
         print("\n" + "\n".join(failures), file=sys.stderr)
         return 1

--- a/tokens/check-contrast.py
+++ b/tokens/check-contrast.py
@@ -13,7 +13,8 @@ HERE = pathlib.Path(__file__).parent
 TEXT_ROLES = ("text", "text-muted", "accent")
 # Syntax roles never sit on the page ground — code blocks wear surface-raised —
 # so they are gated against that instead.
-SYNTAX_ROLES = ("syntax-comment", "syntax-keyword", "syntax-entity", "syntax-string", "syntax-number")
+SYNTAX_ROLES = ("syntax-comment", "syntax-keyword", "syntax-entity", "syntax-string",
+                "syntax-number", "syntax-added", "syntax-deleted")
 AA_BODY = 4.5
 
 

--- a/tokens/primitive.tokens.json
+++ b/tokens/primitive.tokens.json
@@ -54,6 +54,14 @@
       "aurora-purple-soft": {
         "$value": "#c6a9c0",
         "$description": "Lightened nord15 for code numbers on the dark code ground. 4.71:1 on nord1; nord15 itself reaches 3.55:1."
+      },
+      "aurora-red-deep": {
+        "$value": "#b04752",
+        "$description": "Darkened nord11 for removed diff lines on light surfaces. 5.43:1 on white; nord11 itself reaches 4.09:1."
+      },
+      "aurora-red-soft": {
+        "$value": "#daa4a9",
+        "$description": "Lightened nord11 for removed diff lines on the dark code ground. 4.73:1 on nord1; nord11 itself reaches 2.46:1."
       }
     }
   }

--- a/tokens/primitive.tokens.json
+++ b/tokens/primitive.tokens.json
@@ -30,6 +30,30 @@
       "slate-mid": {
         "$value": "#5d6a80",
         "$description": "Muted text on light surfaces. 4.75:1 on nord6, sitting below text (nord3, 6.40:1) so the hierarchy still reads."
+      },
+      "slate-soft": {
+        "$value": "#a9b2c2",
+        "$description": "Comments on the dark code ground. 4.71:1 on nord1, where nord3 — Nord's own comment colour — reaches 1.36:1."
+      },
+      "frost-teal-deep": {
+        "$value": "#447170",
+        "$description": "Darkened nord7 for code entities on light surfaces. 5.47:1 on white; nord7 itself reaches 2.08:1."
+      },
+      "frost-blue-soft": {
+        "$value": "#9bb4ce",
+        "$description": "Lightened nord9 for code keywords on the dark code ground. 4.70:1 on nord1; nord9 itself reaches 3.74:1."
+      },
+      "aurora-green-deep": {
+        "$value": "#577140",
+        "$description": "Darkened nord14 for code strings on light surfaces. 5.47:1 on white; nord14 itself reaches 2.04:1."
+      },
+      "aurora-purple-deep": {
+        "$value": "#895b80",
+        "$description": "Darkened nord15 for code numbers on light surfaces. 5.42:1 on white; nord15 itself reaches 2.83:1."
+      },
+      "aurora-purple-soft": {
+        "$value": "#c6a9c0",
+        "$description": "Lightened nord15 for code numbers on the dark code ground. 4.71:1 on nord1; nord15 itself reaches 3.55:1."
       }
     }
   }

--- a/tokens/semantic.tokens.json
+++ b/tokens/semantic.tokens.json
@@ -63,6 +63,51 @@
         "$value": "#3b4854"
       }
     },
+    "syntax-comment": {
+      "$description": "Code comments and quotes. Syntax roles are gated against surface-raised — the code ground — not the page. 5.47:1 on light, 4.71:1 on dark.",
+      "light": {
+        "$value": "{color.ext.slate-mid}"
+      },
+      "dark": {
+        "$value": "{color.ext.slate-soft}"
+      }
+    },
+    "syntax-keyword": {
+      "$description": "Keywords, literals, tag and selector names. 5.70:1 on light, 4.70:1 on dark.",
+      "light": {
+        "$value": "{color.ext.frost-deep}"
+      },
+      "dark": {
+        "$value": "{color.ext.frost-blue-soft}"
+      }
+    },
+    "syntax-entity": {
+      "$description": "Named things: titles, types, functions, attributes. 5.47:1 on light, 4.83:1 on dark.",
+      "light": {
+        "$value": "{color.ext.frost-teal-deep}"
+      },
+      "dark": {
+        "$value": "{color.nord.7}"
+      }
+    },
+    "syntax-string": {
+      "$description": "String and regexp literals. 5.47:1 on light, 4.94:1 on dark.",
+      "light": {
+        "$value": "{color.ext.aurora-green-deep}"
+      },
+      "dark": {
+        "$value": "{color.nord.14}"
+      }
+    },
+    "syntax-number": {
+      "$description": "Numeric literals. 5.42:1 on light, 4.71:1 on dark.",
+      "light": {
+        "$value": "{color.ext.aurora-purple-deep}"
+      },
+      "dark": {
+        "$value": "{color.ext.aurora-purple-soft}"
+      }
+    },
     "$description": "Semantic layer. Components reference only these; never a primitive directly. Each colour role carries a light and a dark value, emitted as CSS light-dark()."
   },
   "font": {

--- a/tokens/semantic.tokens.json
+++ b/tokens/semantic.tokens.json
@@ -108,6 +108,24 @@
         "$value": "{color.ext.aurora-purple-soft}"
       }
     },
+    "syntax-added": {
+      "$description": "Added diff lines. Shares the string primitives — a role of its own so the diff pairing is legible next to syntax-deleted. 5.47:1 on light, 4.94:1 on dark.",
+      "light": {
+        "$value": "{color.ext.aurora-green-deep}"
+      },
+      "dark": {
+        "$value": "{color.nord.14}"
+      }
+    },
+    "syntax-deleted": {
+      "$description": "Removed diff lines. 5.43:1 on light, 4.73:1 on dark.",
+      "light": {
+        "$value": "{color.ext.aurora-red-deep}"
+      },
+      "dark": {
+        "$value": "{color.ext.aurora-red-soft}"
+      }
+    },
     "$description": "Semantic layer. Components reference only these; never a primitive directly. Each colour role carries a light and a dark value, emitted as CSS light-dark()."
   },
   "font": {

--- a/tokens/style-dictionary.config.mjs
+++ b/tokens/style-dictionary.config.mjs
@@ -139,10 +139,14 @@ StyleDictionary.registerFormat({
     const scale = (prefix) => [...byName.entries()].filter(([n]) => n.startsWith(prefix));
 
     const surface = byName.get('--color-surface').modes;
+    const raised = byName.get('--color-surface-raised').modes;
     const rows = semantic.map(([name, entry]) => {
+      // Syntax roles are read on the code ground, so quote them against it —
+      // the same pairing tokens/check-contrast.py gates.
+      const ground = name.startsWith('--color-syntax-') ? raised : surface;
       const ratio = (mode) => {
         if (name === '--color-surface') return '&#8212;';
-        return `${contrast(entry.modes[mode], surface[mode]).toFixed(2)}:1`;
+        return `${contrast(entry.modes[mode], ground[mode]).toFixed(2)}:1`;
       };
       return `<tr><td><code>${name}</code></td><td><code>${entry.modes.light}</code></td><td><code>${entry.modes.dark}</code></td><td>${ratio('light')}</td><td>${ratio('dark')}</td></tr>`;
     });


### PR DESCRIPTION
## Why

The code block background matched the page exactly, so blocks were invisible. Digging in, the cause was not colour choice — the theme stylesheet was 404ing:

```bash
curl -sL https://unpkg.com/nord-highlightjs@0.2.0/dist/nord.css
```
> `Not found: /nord-highlightjs@0.2.0/dist/nord.css`

`nord-highlightjs@0.2.0` publishes no `dist/` on npm (only `package.json`, README, CHANGELOG, LICENSE); the Renovate bump from `0.1.0` silently removed the file. Code blocks were rendering with no background, no padding and no syntax colours in **both** schemes.

Pinning back would not have fixed dark mode either. `0.1.0` sets `.hljs { background: #2E3440 }`, and `#2e3440` is nord0 — `--color-surface`'s dark value. The block has matched the page ground since the v2 shell landed.

## What changed

**Code block surface** — `pre` now wears `--color-surface-raised` with a hairline and `overflow-x: auto`, the same treatment as inline code and the link card. `:not(:has(code.mermaid))` keeps diagrams out of the box.

**Syntax palette moves into the token pipeline** — seven roles (`syntax-comment` / `-keyword` / `-entity` / `-string` / `-number` / `-added` / `-deleted`) carry the highlight.js classes from `main.css`. `check-contrast.py` gates them against `surface-raised` rather than `surface`, since that is the ground code is read on. Nord's frost/aurora steps clear AA on the dark ground but sit near 2:1 on the light one, so light mode uses darkened `ext.*` derivations — the move `ext.frost-deep` already makes for accent.

```
ok   light syntax-comment #5d6a80 on #ffffff   5.47:1    ok   dark  syntax-comment #a9b2c2 on #3b4252   4.71:1
ok   light syntax-keyword #47698f on #ffffff   5.70:1    ok   dark  syntax-keyword #9bb4ce on #3b4252   4.70:1
ok   light syntax-entity  #447170 on #ffffff   5.47:1    ok   dark  syntax-entity  #8fbcbb on #3b4252   4.83:1
ok   light syntax-string  #577140 on #ffffff   5.47:1    ok   dark  syntax-string  #a3be8c on #3b4252   4.94:1
ok   light syntax-number  #895b80 on #ffffff   5.42:1    ok   dark  syntax-number  #c6a9c0 on #3b4252   4.71:1
ok   light syntax-added   #577140 on #ffffff   5.47:1    ok   dark  syntax-added   #a3be8c on #3b4252   4.94:1
ok   light syntax-deleted #b04752 on #ffffff   5.43:1    ok   dark  syntax-deleted #daa4a9 on #3b4252   4.73:1
```

**Mermaid follows the scheme** — the diagram kept mermaid's default light theme, so on the dark ground the node boxes showed but every edge was drawn in a near-black stroke and disappeared. The module now reads the resolved `color-scheme` (respecting an `only_light` / `only_dark` config, not just the OS preference) and re-renders when the preference changes.

**Dead dependency removed** — the `nord-highlightjs` `<link>`, its `CdnVersions` field and its Renovate entry are gone. One fewer render-blocking CDN request, and the theme can no longer disappear from under us.

## Verification

- `cargo:quality`, `tokens:check`, `e2e:test` (9 passed across chromium / firefox / webkit) all green
- Built `docs/` with the binary from this checkout and compared every code-bearing page in both schemes; computed values confirmed per role
- Storybook `Code` / `Diff` stories and `design/v2/ui-spec.md` §4 updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)