### PR TITLE
v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "1.2.0"
+version = "2.0.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "1.2.0"
+version = "2.0.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "1.2.0"
+version = "2.0.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
## Summary

Version bump to **2.0.0** — the v2 UI generation.

**Breaking**
- `[ssg] sort_key` config removed: every sort view is always generated (`/`, `/backlinks/`, `/scraps/` grouped title index)
- README.md no longer renders on the home — it gets its own `/about/` page (sidebar link when present)
- `/titles/` never shipped in a release; `scraps/index.html` is now the grouped index

**The v2 UI** (#682–#689)
- Persistent sidebar shell — `[[ ]]` brand, search everywhere, sort views with accent-wash active state, top tags as `#[[tag]]` literals; status-bar footer; responsive collapse
- Scrap pages with tags, labeled `backlinks / links` sections, 760px measure, contextual status bar
- Grouped all-scraps index with kana/A–Z/漢字/# jump bar
- Static autolink cards (no more corsproxy runtime fetch)
- Token additions: `accent-wash`, syntax highlight roles; mermaid themed from the page
- Storybook, design-token page and docs re-synced

After merge: tag `v2.0.0` on main, then publish the GitHub Release (triggers crates.io, homebrew tap, floating v2/v2.0 tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)