### PR TITLE
v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "2.0.0"
+version = "2.1.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "2.0.0"
+version = "2.1.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "2.0.0"
+version = "2.1.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
## Summary

Version bump to v2.1.0.

Since v2.0.0:

- **feat(mcp)**: `lookup_scrap_neighborhood` — the neighborhood around a scrap as a graph in one call (nodes with hop distance, edges in link direction, no bodies), depth capped at 5 hops and bounded by a node cap (#696)
- **fix(model)**: `Scrap::links()` now keeps first-occurrence order instead of a HashSet's arbitrary one, so backlink lists, rendered link lists, and bounded graph walks stop reshuffling between reads (#696)
- **chore(deps)**: rmcp v3.2.0 (#692), actions/deploy-pages v5.0.1 (#693), toml v1.1.5 (#694)

Minor bump: a new MCP tool, no breaking change to the CLI or `scraps_libs` API. Note that the ordering fix changes the *order* of `links()` results (and anything rendered from them) — same set, now deterministic.

## Related Issues

<!-- none -->

## Additional Notes

Merging this lets the `v2.1.0` tag be cut from main; publishing the GitHub Release from that tag triggers the crates.io publish, the homebrew-tap update, and the floating `v2` / `v2.1` tag moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
