### PR TITLE
feat(mcp): aggregate wiki-wide task items with list_todos

### DIFF
--- a/plugins/mcp-server/.claude-plugin/plugin.json
+++ b/plugins/mcp-server/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MCP server for Scraps - Connect to a locally running scraps MCP server (scraps mcp serve --http) to browse and search interconnected Markdown documentation with Wiki-link notation",
   "author": {
     "name": "boykush",

--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -172,6 +172,35 @@ Scraps that reference a specific tag.
 
 Returns: `{ results: [{ title, ctx }], count }`.
 
+### `list_todos`
+
+Markdown task list items aggregated across every scrap.
+
+| Parameter | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `status` | `"open"` \| `"done"` \| `"deferred"` \| `"all"` | no | `"open"` | Task status filter |
+
+Returns:
+
+```json
+{
+  "results": [
+    {
+      "scrap": { "title": "borrowing", "ctx": "Programming/Rust" },
+      "status": "open",
+      "text": "implement Drop for X",
+      "line": 3
+    }
+  ],
+  "count": 1
+}
+```
+
+`- [ ]` is `open`, `- [x]` is `done` and `- [-]` is `deferred`; any other symbol
+is skipped, and items inside fenced code blocks are not tasks. Results are
+ordered by context, then title, then line, and carry the same shape as
+`scraps todo --json`. Read the scrap a task sits in with `get_scrap`.
+
 ## Manual setup (without the plugin)
 
 Register the shared server with any MCP-compatible client:

--- a/src/cli/cmd/todo.rs
+++ b/src/cli/cmd/todo.rs
@@ -10,8 +10,7 @@ use crate::cli::config::scrap_config::ScrapConfig;
 use crate::cli::path_resolver::PathResolver;
 use crate::error::ScrapsResult;
 use crate::input::file::read_scraps;
-use crate::usecase::todo::usecase::{StatusFilter, TodoUsecase};
-use scraps_libs::markdown::query::TaskStatus;
+use crate::usecase::todo::usecase::{status_label, StatusFilter, TodoUsecase};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct TodoScrapJson {
@@ -31,14 +30,6 @@ struct TodoItemJson {
 struct TodoResponse {
     results: Vec<TodoItemJson>,
     count: usize,
-}
-
-fn status_label(status: &TaskStatus) -> &'static str {
-    match status {
-        TaskStatus::Open => "open",
-        TaskStatus::Done => "done",
-        TaskStatus::Deferred => "deferred",
-    }
 }
 
 fn scrap_label(title: &str, ctx: Option<&str>) -> String {

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let response: serde_json::Value = serde_json::from_str(&body).unwrap();
         let tools = response["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 9);
 
         server_handle.abort();
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use super::tools::get_scrap::{get_scrap, GetScrapRequest};
 use super::tools::list_tags::list_tags;
+use super::tools::list_todos::{list_todos, ListTodosRequest};
 use super::tools::lookup_scrap_backlinks::{lookup_scrap_backlinks, LookupScrapBacklinksRequest};
 use super::tools::lookup_scrap_links::{lookup_scrap_links, LookupScrapLinksRequest};
 use super::tools::lookup_scrap_neighborhood::{
@@ -120,6 +121,17 @@ impl ScrapsServer {
     ) -> Result<CallToolResult, ErrorData> {
         lookup_tag_backlinks(&self.scraps_dir, &self.exclude_dirs, context, parameters).await
     }
+
+    #[tool(
+        description = "Use when you want the work recorded across the wiki rather than one scrap's: returns the markdown task list items across every scrap, each with the scrap it sits in and its line. Filter with status — 'open' (default), 'done', 'deferred' or 'all'. Read the scrap around a task with get_scrap."
+    )]
+    async fn list_todos(
+        &self,
+        context: RequestContext<RoleServer>,
+        parameters: Parameters<ListTodosRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        list_todos(&self.scraps_dir, &self.exclude_dirs, context, parameters).await
+    }
 }
 
 // Without `router = ...` the macro rebuilds the router (and every tool's
@@ -135,7 +147,8 @@ impl ServerHandler for ScrapsServer {
                  lookup_scrap_links and lookup_scrap_backlinks. For the shape around a scrap \
                  rather than one relation at a time, lookup_scrap_neighborhood returns its \
                  neighborhood as a graph: nodes with their hop distance and the links between \
-                 them, no bodies. For the topic map, list_tags then lookup_tag_backlinks.",
+                 them, no bodies. For the topic map, list_tags then lookup_tag_backlinks. For \
+                 the work recorded across the wiki, list_todos.",
         )
     }
 }
@@ -176,7 +189,7 @@ mod tests {
 
         let tools = client.list_tools(Default::default()).await.unwrap();
 
-        assert_eq!(tools.tools.len(), 8);
+        assert_eq!(tools.tools.len(), 9);
 
         let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
         assert!(tool_names.contains(&"orient"));
@@ -187,6 +200,7 @@ mod tests {
         assert!(tool_names.contains(&"lookup_scrap_backlinks"));
         assert!(tool_names.contains(&"list_tags"));
         assert!(tool_names.contains(&"lookup_tag_backlinks"));
+        assert!(tool_names.contains(&"list_todos"));
 
         client.cancel().await.unwrap();
         server_handle.abort();
@@ -352,6 +366,7 @@ mod tests {
             ("list_tags", serde_json::json!({})),
             ("lookup_tag_backlinks", serde_json::json!({"tag": "rust"})),
             ("orient", serde_json::json!({})),
+            ("list_todos", serde_json::json!({})),
             (
                 "lookup_scrap_neighborhood",
                 serde_json::json!({"title": "source"}),
@@ -605,6 +620,65 @@ mod tests {
 
         client.cancel().await.unwrap();
         server_handle.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_list_todos_defaults_to_open(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap(
+            "Programming/Rust/borrowing.md",
+            b"# borrowing\n\n- [ ] implement Drop for X\n- [x] write tests\n- [-] revisit later\n",
+        );
+
+        let todos = call_tool_json(&project, "list_todos", serde_json::json!({})).await;
+
+        assert_eq!(todos["count"], 1);
+        let item = &todos["results"][0];
+        assert_eq!(item["scrap"]["title"], "borrowing");
+        assert_eq!(item["scrap"]["ctx"], "Programming/Rust");
+        assert_eq!(item["status"], "open");
+        assert_eq!(item["text"], "implement Drop for X");
+        assert_eq!(item["line"], 3);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_list_todos_filters_by_status(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("a.md", b"- [ ] open\n- [x] done\n- [-] deferred\n");
+
+        let done = call_tool_json(
+            &project,
+            "list_todos",
+            serde_json::json!({"status": "done"}),
+        )
+        .await;
+        assert_eq!(done["count"], 1);
+        assert_eq!(done["results"][0]["status"], "done");
+
+        let all =
+            call_tool_json(&project, "list_todos", serde_json::json!({"status": "all"})).await;
+        assert_eq!(all["count"], 3);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_list_todos_empty_points_elsewhere(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("a.md", b"# Just a heading, no tasks.\n");
+
+        let todos = call_tool_json(&project, "list_todos", serde_json::json!({})).await;
+
+        assert_eq!(todos["count"], 0);
+        let next = todos["next"].as_str().unwrap_or_default();
+        assert!(
+            next.contains("search_scraps"),
+            "empty todos should point at another way in: {todos}"
+        );
     }
 
     #[rstest]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,5 +1,6 @@
 pub mod get_scrap;
 pub mod list_tags;
+pub mod list_todos;
 pub mod lookup_scrap_backlinks;
 pub mod lookup_scrap_links;
 pub mod lookup_scrap_neighborhood;

--- a/src/mcp/tools/list_todos.rs
+++ b/src/mcp/tools/list_todos.rs
@@ -1,0 +1,116 @@
+use crate::input::file::read_scraps;
+use crate::mcp::json::scrap::ScrapKeyJson;
+use crate::usecase::todo::usecase::{status_label, StatusFilter, TodoUsecase};
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::ErrorCode;
+use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::schemars::JsonSchema;
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Status filter for task items
+#[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TodoStatus {
+    /// Unchecked `- [ ]` items (default)
+    #[default]
+    Open,
+    /// Checked `- [x]` items
+    Done,
+    /// Deferred `- [-]` items
+    Deferred,
+    /// Every task item, whatever its status
+    All,
+}
+
+impl From<TodoStatus> for StatusFilter {
+    fn from(status: TodoStatus) -> Self {
+        match status {
+            TodoStatus::Open => StatusFilter::Open,
+            TodoStatus::Done => StatusFilter::Done,
+            TodoStatus::Deferred => StatusFilter::Deferred,
+            TodoStatus::All => StatusFilter::All,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ListTodosRequest {
+    /// Status filter: "open" (default), "done", "deferred", or "all"
+    pub status: Option<TodoStatus>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TodoItemJson {
+    pub scrap: ScrapKeyJson,
+    pub status: String,
+    pub text: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListTodosResponse {
+    pub results: Vec<TodoItemJson>,
+    pub count: usize,
+    pub next: String,
+}
+
+pub async fn list_todos(
+    scraps_dir: &Path,
+    exclude_dirs: &[std::path::PathBuf],
+    _context: RequestContext<RoleServer>,
+    Parameters(request): Parameters<ListTodosRequest>,
+) -> Result<CallToolResult, ErrorData> {
+    let scraps = read_scraps::to_all_scraps(scraps_dir, exclude_dirs).map_err(|e| {
+        ErrorData::new(
+            ErrorCode(-32003),
+            format!("Failed to load scraps: {e}"),
+            None,
+        )
+    })?;
+
+    let todo_usecase = TodoUsecase::new();
+
+    let status_filter = request.status.unwrap_or_default().into();
+    let results = todo_usecase
+        .execute(&scraps, status_filter)
+        .map_err(|e| ErrorData::new(ErrorCode(-32004), format!("List todos failed: {e}"), None))?;
+
+    let items: Vec<TodoItemJson> = results
+        .into_iter()
+        .map(|result| TodoItemJson {
+            scrap: ScrapKeyJson {
+                title: result.title.to_string(),
+                ctx: result.ctx.map(|c| c.to_string()),
+            },
+            status: status_label(&result.status).to_string(),
+            text: result.text,
+            line: result.line,
+        })
+        .collect();
+
+    let count = items.len();
+    let next = if count == 0 {
+        "No task items with that status. Widen it with status 'all', or look for the work in prose with search_scraps."
+    } else {
+        "Read the scrap a task sits in with get_scrap {title, ctx}."
+    };
+    let response = ListTodosResponse {
+        results: items,
+        count,
+        next: next.to_string(),
+    };
+
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string(&response).map_err(|e| {
+            ErrorData::new(
+                ErrorCode(-32005),
+                format!("JSON serialization failed: {e}"),
+                None,
+            )
+        })?,
+    )]))
+}

--- a/src/usecase/todo/usecase.rs
+++ b/src/usecase/todo/usecase.rs
@@ -25,6 +25,16 @@ impl StatusFilter {
     }
 }
 
+/// The wire label for a status, shared by `scraps todo --json` and the MCP
+/// tool so both surfaces name the same thing the same way.
+pub fn status_label(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Open => "open",
+        TaskStatus::Done => "done",
+        TaskStatus::Deferred => "deferred",
+    }
+}
+
 /// One task list entry resolved back to its source scrap.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TodoResult {


### PR DESCRIPTION
## Summary

Adds a `list_todos` MCP tool so agents reaching the wiki over MCP can see the work recorded in it. `scraps todo` had no MCP counterpart — the server exposed 8 tools, none of them the task-item aggregation the CLI has had since #487.

The tool reuses `TodoUsecase`, takes the same `status` filter as the CLI (`open` default, `done`, `deferred`, `all`) and returns the same result shape, so both surfaces answer the question identically:

```json
{"scrap": {"title": "borrowing", "ctx": "Programming/Rust"}, "status": "open", "text": "implement Drop for X", "line": 3}
```

MCP adds only the shared `next` hint on top of the CLI's `results` / `count` envelope.

## Why

This started as a proposal to interpret frontmatter and surface it as todos. That direction was dropped: it reverses [#515](https://github.com/boykush/scraps/issues/515) (closed NOT_PLANNED) and v1 design principle 2 — and it goes further than #515 did, since rendering frontmatter *as todos* requires scraps to define what `status:` and `due:` mean, which #515 explicitly ruled out. What the exploration did surface was a real asymmetry: a wiki-wide aggregation available on the CLI but not over MCP.

This is parity for an existing command, not a promotion of MCP. CLI + JSON stays the agent-integration primary per vision §1.

## Changes

- **New** `src/mcp/tools/list_todos.rs` — thin adapter over `TodoUsecase`, with a `TodoStatus` request enum mirroring the CLI's `CliTodoStatus`
- **Refactor** `status_label` lifted from `src/cli/cmd/todo.rs` into `src/usecase/todo/usecase.rs` — the status wire label is a contract shared by both surfaces, and a second copy would let them drift
- Tool registered in `src/mcp/server.rs`; server instructions gained a closing sentence pointing at it
- `plugins/mcp-server/README.md` documents the tool; plugin version 2.1.0 → 2.2.0 (matching the bump when `lookup_scrap_neighborhood` was added in #696)

## Test plan

Built TDD, Red (`tool not found`) → Green. The existing cross-tool invariants cover the new tool without modification:

- [x] `test_tool_descriptions_open_with_when_to_use` — description opens with "Use when"
- [x] `test_tool_descriptions_name_a_follow_up_tool` — names `get_scrap` as the next step
- [x] `test_every_response_carries_a_next_hint` — `list_todos` added to the sweep

Plus three new cases: default-to-open, `status` filtering (`done` / `all`), and an empty response pointing at `search_scraps`. Tool counts in `src/mcp/server.rs` and `src/mcp/http.rs` bumped 8 → 9.

- [x] `mise run cargo:quality` green (282 + 311 tests)
- [x] Smoke-tested over `mcp serve --http` against a real wiki: `results` shape matches `scraps todo --json` exactly, and an invalid `status` is rejected by the schema (`unknown variant 'bogus', expected one of 'open', 'done', 'deferred', 'all'`)

## Reviewer notes

The branch name mentions frontmatter; the change deliberately does not touch it, for the reason in **Why** above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)