### PR TITLE
docs(mcp-server): document the orient tool

### DIFF
--- a/plugins/mcp-server/.claude-plugin/plugin.json
+++ b/plugins/mcp-server/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCP server for Scraps - Connect to a locally running scraps MCP server (scraps mcp serve --http) to browse and search interconnected Markdown documentation with Wiki-link notation",
   "author": {
     "name": "boykush",

--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -59,6 +59,31 @@ One process serves one wiki. The server binds loopback with no authentication; i
 
 All operations run against the current state of the Scraps wiki. Search uses fuzzy matching.
 
+### `orient`
+
+Where to start on an unfamiliar wiki: its scale, its folder contexts, and the
+head of its topic map in one call. Takes no parameters.
+
+Returns:
+
+```json
+{
+  "scrap_count": 128,
+  "tag_count": 24,
+  "contexts": ["Book", "Kubernetes"],
+  "top_tags": [
+    { "title": "rust", "backlinks_count": 31 },
+    { "title": "go", "backlinks_count": 12 }
+  ],
+  "next": "Search content with search_scraps, or expand a top tag with lookup_tag_backlinks {tag}; the full tag list is list_tags."
+}
+```
+
+`contexts` lists every folder context in the wiki, sorted by name. `top_tags`
+is capped at 10, ranked by backlink count and tie-broken by title — the whole
+list is `list_tags`' job. Bodies stay out: read a scrap with `get_scrap`. On an
+empty wiki `next` says so instead of naming tools.
+
 ### `search_scraps`
 
 Search titles + body content with fuzzy matching.


### PR DESCRIPTION
## Summary

`plugins/mcp-server/README.md` documented 8 of the server's 9 MCP tools. The missing one was `orient` — registered in `src/mcp/server.rs` since it landed, and the tool whose whole job is to be called first on an unfamiliar wiki. A reader working from the README had no way to discover the entry point.

Adds an `### orient` section as the **first** tool entry, matching the order a session actually uses these in.

Documented shape read off `src/mcp/tools/orient.rs` and pinned by the three `test_orient_*` cases in `src/mcp/server.rs`:

- `scrap_count` / `tag_count` — wiki scale
- `contexts` — every folder context, deduped and sorted by name
- `top_tags` — capped at `TOP_TAGS_LIMIT` (10), ranked by `backlinks_count` descending, tie-broken by title so the head of the topic map is stable
- `next` — quoted verbatim from the non-empty branch, with a note that an empty wiki gets a different string

Plugin version 2.2.0 → 2.2.1 (docs-only, so patch), which `plugins:check-version` requires alongside any plugin content change.

## Related Issues

<!-- none -->

## Additional Notes

**One deliberate style deviation.** The neighbouring sections' JSON blocks omit `next`, even though those tools emit it too. This section spells it out: `orient` returns no content of its own, so the routing hint *is* the payload — hiding it would misrepresent what the tool gives you.

**Left for a follow-up (not in this PR):** the `list_tags` Returns line still reads `[{ title, backlinks_count }]`, but `src/mcp/tools/list_tags.rs:57` returns the `{ results, count, next }` envelope — and `test_list_tags_uses_results_envelope` asserts exactly that. Stale since the envelope was introduced; out of scope here, happy to fix separately.

## Test plan

Docs-only — no Rust changed, so no behaviour to test. Verified instead that the documentation is true:

- [x] Field list cross-checked against `src/mcp/tools/orient.rs` (`TOP_TAGS_LIMIT = 10`, the `sort_by` tie-break, both `next` branches)
- [x] Cross-checked against `test_orient_gathers_scale_contexts_and_top_tags`, `test_orient_ranks_and_caps_top_tags`, `test_orient_names_entry_tools_in_next`
- [x] `mise exec -- hk run pre-commit` green (`plugin_version` passes with the 2.2.1 bump)

## Reviewer notes

This branch started from `c401754`, before [#698](https://github.com/boykush/scraps/pull/698) merged. I fast-forwarded to `origin/main` and re-applied on top rather than pushing a stale base — so the version bump is 2.2.0 → 2.2.1, not 2.1.0 → 2.1.1, and #698's `list_todos` section is untouched at the end of the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)