### PR TITLE
feat(frontmatter): aggregate YAML frontmatter wiki-wide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,9 @@ dependencies = [
  "iso639_enum",
  "itertools",
  "rstest",
+ "serde_json",
  "url",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -2019,6 +2021,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ thiserror = "=2.0.20"
 url = { version = "=2.5.8", features = ["serde"] }
 itertools = "=0.15.0"
 serde = { version = "=1.0.229", features = ["derive"] }
-serde_json = "=1.0.151"
+# preserve_order keeps frontmatter keys in the order the author wrote them,
+# which is the point of passing them through untouched.
+serde_json = { version = "=1.0.151", features = ["preserve_order"] }
 toml = "=1.1.5"
 rayon = "=1.12.0"
 clap = { version = "=4.6.6", features = ["derive", "env"] }
@@ -71,7 +73,7 @@ include = [
 [dependencies]
 # sub crates
 scraps_libs.workspace = true
-scraps_libs.features = ["git", "html", "lang", "markdown", "model", "search", "slugify"]
+scraps_libs.features = ["frontmatter", "git", "html", "lang", "markdown", "model", "search", "slugify"]
 #external crates
 url.workspace = true
 itertools.workspace = true

--- a/docs/Reference/CLI Overview.md
+++ b/docs/Reference/CLI Overview.md
@@ -17,6 +17,7 @@ the authoritative reference for flags and arguments. This page is the
 | `scraps tag list` | List all tags with backlink counts | ✓ |
 | `scraps tag backlinks <tag>` | Scraps referencing a tag | ✓ |
 | `scraps todo` | Aggregate GFM task list items wiki-wide | ✓ |
+| `scraps frontmatter` | Aggregate YAML frontmatter wiki-wide | ✓ |
 | `scraps mcp serve` | Start an MCP server over stdio, or `--http` | – |
 
 `-C` / `--directory` (or `SCRAPS_DIRECTORY` env) runs as if started in the
@@ -50,5 +51,13 @@ directly to `scraps get <title> --ctx <ctx> --heading <heading>`.
 
 `scraps backlinks --json` remains scrap-level inbound discovery and returns
 the scraps that link to the requested scrap.
+
+`scraps frontmatter --json` returns every scrap that carries a YAML
+frontmatter block, with its keys parsed as-is. Scraps defines none of those
+keys and gives them no meaning: a scrap's title, context, tags and links still
+come only from the filesystem and Wiki-link syntax, never from frontmatter. A
+block that is absent, unclosed or malformed is skipped rather than raising an
+error, and frontmatter stays part of the scrap body — it is not stripped from
+`scraps get --json body` or from the built site.
 
 For agent integration, see [[How-to/Integrate with AI Assistants]].

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -16,12 +16,15 @@ itertools.workspace = true
 comrak = { version = "=0.54.0", default-features = false }
 iso639_enum = "=0.6.0"
 fuzzy-matcher = { version = "=0.3.7", optional = true }
+yaml-rust2 = { version = "=0.11.0", optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
 
 [features]
 error = []
+frontmatter = ["markdown", "dep:yaml-rust2", "dep:serde_json"]
 git = []
 git_test = []
 html = ["markdown", "model", "slugify"]

--- a/modules/libs/src/markdown/query.rs
+++ b/modules/libs/src/markdown/query.rs
@@ -1,6 +1,8 @@
 mod code_blocks;
 mod common;
 mod embeds;
+#[cfg(feature = "frontmatter")]
+mod frontmatter;
 mod headings;
 mod images;
 mod section;
@@ -11,6 +13,8 @@ mod wikilinks;
 
 pub use code_blocks::{code_blocks, CodeBlock};
 pub use embeds::{embeds, EmbedRef};
+#[cfg(feature = "frontmatter")]
+pub use frontmatter::frontmatter;
 pub use headings::{headings, Heading};
 pub use images::images;
 pub use section::{heading_slug, section};

--- a/modules/libs/src/markdown/query/frontmatter.rs
+++ b/modules/libs/src/markdown/query/frontmatter.rs
@@ -1,0 +1,111 @@
+use comrak::{nodes::NodeValue, parse_document, Arena};
+use serde_json::{Map, Number, Value};
+use yaml_rust2::yaml::{Yaml, YamlLoader};
+
+use super::common::options;
+
+const DELIMITER: &str = "---";
+
+/// The YAML frontmatter block of a scrap, as opaque structured data.
+///
+/// Scraps assigns no meaning to any key — this is passthrough, so the caller
+/// sees exactly what the author wrote. A block that is absent, empty, unclosed
+/// or malformed reads as `None`, so a retrofit wiki still builds.
+pub fn frontmatter(text: &str) -> Option<Value> {
+    let arena = Arena::new();
+    let mut opts = options();
+    // Only this query recognises the block; the others still read it as
+    // content, which is the behaviour the rest of the pipeline was built on.
+    opts.extension.front_matter_delimiter = Some(DELIMITER.to_string());
+    let root = parse_document(&arena, text, &opts);
+
+    let block = root
+        .descendants()
+        .find_map(|node| match &node.data().value {
+            NodeValue::FrontMatter(raw) => Some(raw.clone()),
+            _ => None,
+        })?;
+
+    let docs = YamlLoader::load_from_str(strip_delimiters(&block)?).ok()?;
+    to_json(docs.into_iter().next()?)
+}
+
+fn strip_delimiters(block: &str) -> Option<&str> {
+    let opened = block.trim_start().strip_prefix(DELIMITER)?;
+    let closing = opened.rfind(DELIMITER)?;
+    Some(&opened[..closing])
+}
+
+fn to_json(yaml: Yaml) -> Option<Value> {
+    let value = match yaml {
+        Yaml::Null => Value::Null,
+        Yaml::Boolean(b) => Value::Bool(b),
+        Yaml::Integer(i) => Value::Number(i.into()),
+        // A float YAML cannot express in JSON (inf, nan) stays as its literal.
+        Yaml::Real(r) => r
+            .parse::<f64>()
+            .ok()
+            .and_then(Number::from_f64)
+            .map_or(Value::String(r), Value::Number),
+        Yaml::String(s) => Value::String(s),
+        Yaml::Array(items) => Value::Array(items.into_iter().filter_map(to_json).collect()),
+        Yaml::Hash(entries) => {
+            let mut object = Map::new();
+            for (key, value) in entries {
+                object.insert(key_to_string(key)?, to_json(value)?);
+            }
+            Value::Object(object)
+        }
+        Yaml::Alias(_) | Yaml::BadValue => return None,
+    };
+    Some(value)
+}
+
+fn key_to_string(key: Yaml) -> Option<String> {
+    match key {
+        Yaml::String(s) => Some(s),
+        Yaml::Integer(i) => Some(i.to_string()),
+        Yaml::Boolean(b) => Some(b.to_string()),
+        Yaml::Real(r) => Some(r),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[case::scalars(
+        "---\nstatus: draft\nowner: alice\ndone: true\ncount: 3\nratio: 1.5\nempty:\n---\n\n# Body\n",
+        json!({"status": "draft", "owner": "alice", "done": true, "count": 3, "ratio": 1.5, "empty": null})
+    )]
+    #[case::nested(
+        "---\ntaxonomy:\n  - infra\n  - rollout\nauthor:\n  name: alice\n  team: sre\n---\n\n# Body\n",
+        json!({"taxonomy": ["infra", "rollout"], "author": {"name": "alice", "team": "sre"}})
+    )]
+    #[case::sequence_root("---\n- one\n- two\n---\n\n# Body\n", json!(["one", "two"]))]
+    #[case::no_body("---\nstatus: draft\n---\n", json!({"status": "draft"}))]
+    fn it_parses_yaml_frontmatter(#[case] input: &str, #[case] expected: Value) {
+        assert_eq!(frontmatter(input), Some(expected));
+    }
+
+    #[rstest]
+    #[case::absent("# Body\n\nNo frontmatter here.\n")]
+    #[case::empty_block("---\n---\n\n# Body\n")]
+    #[case::not_at_start("# Body\n\n---\nstatus: draft\n---\n")]
+    #[case::unclosed("---\nstatus: draft\n\n# Body\n")]
+    #[case::malformed("---\nstatus: [unclosed\n---\n\n# Body\n")]
+    #[case::thematic_break("Some text\n\n---\n\nMore text\n")]
+    fn it_returns_none(#[case] input: &str) {
+        assert_eq!(frontmatter(input), None);
+    }
+
+    #[rstest]
+    fn it_does_not_read_a_fenced_block_as_frontmatter() {
+        let input = "# Body\n\n```markdown\n---\nstatus: draft\n---\n```\n";
+        assert_eq!(frontmatter(input), None);
+    }
+}

--- a/plugins/mcp-server/.claude-plugin/plugin.json
+++ b/plugins/mcp-server/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "MCP server for Scraps - Connect to a locally running scraps MCP server (scraps mcp serve --http) to browse and search interconnected Markdown documentation with Wiki-link notation",
   "author": {
     "name": "boykush",

--- a/plugins/mcp-server/README.md
+++ b/plugins/mcp-server/README.md
@@ -226,6 +226,30 @@ is skipped, and items inside fenced code blocks are not tasks. Results are
 ordered by context, then title, then line, and carry the same shape as
 `scraps todo --json`. Read the scrap a task sits in with `get_scrap`.
 
+### `list_frontmatter`
+
+YAML frontmatter aggregated across every scrap that carries a block. Takes no
+parameters.
+
+Returns:
+
+```json
+{
+  "results": [
+    {
+      "scrap": { "title": "borrowing", "ctx": "Programming/Rust" },
+      "frontmatter": { "status": "review", "owner": "bob", "taxonomy": ["rust", "memory"] }
+    }
+  ],
+  "count": 1
+}
+```
+
+Keys are passed through in the order they were written and are **not**
+interpreted — scraps defines no frontmatter fields, so a `tags:` key there is
+not a scraps tag (`#[[tag]]` is, via `list_tags`). Scraps without a block are
+omitted, and a malformed block is skipped rather than failing the call.
+
 ## Manual setup (without the plugin)
 
 Register the shared server with any MCP-compatible client:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,6 +137,12 @@ pub enum SubCommands {
         tag_command: TagSubCommands,
     },
 
+    #[command(about = "Aggregate YAML frontmatter across the wiki")]
+    Frontmatter {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
     #[command(about = "Aggregate markdown task list items across the wiki")]
     Todo {
         #[arg(

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,5 +1,6 @@
 pub mod backlinks;
 pub mod build;
+pub mod frontmatter;
 pub mod get;
 pub mod init;
 pub mod links;

--- a/src/cli/cmd/frontmatter.rs
+++ b/src/cli/cmd/frontmatter.rs
@@ -1,0 +1,189 @@
+use std::io::Write;
+use std::path::Path;
+
+use colored::Colorize;
+use comfy_table::presets::NOTHING;
+use comfy_table::{Cell, Table};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::cli::config::scrap_config::ScrapConfig;
+use crate::cli::path_resolver::PathResolver;
+use crate::error::ScrapsResult;
+use crate::input::file::read_scraps;
+use crate::usecase::frontmatter::usecase::FrontmatterUsecase;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct FrontmatterScrapJson {
+    title: String,
+    ctx: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct FrontmatterItemJson {
+    scrap: FrontmatterScrapJson,
+    frontmatter: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct FrontmatterResponse {
+    results: Vec<FrontmatterItemJson>,
+    count: usize,
+}
+
+fn scrap_label(title: &str, ctx: Option<&str>) -> String {
+    match ctx {
+        Some(c) if !c.is_empty() => format!("{c}/{title}"),
+        _ => title.to_string(),
+    }
+}
+
+/// Table cells hold one line, so a nested value is shown as compact JSON
+/// rather than flattened into keys scraps would then have to name.
+fn cell_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// A non-object frontmatter (a bare sequence, say) has no keys to spread over
+/// rows, so the whole document occupies one.
+fn rows(value: &Value) -> Vec<(String, String)> {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| (key.clone(), cell_value(value)))
+            .collect(),
+        other => vec![(String::new(), other.to_string())],
+    }
+}
+
+pub fn run(json: bool, project_path: Option<&Path>, writer: &mut impl Write) -> ScrapsResult<()> {
+    let path_resolver = PathResolver::new(project_path)?;
+    let config = ScrapConfig::from_path(project_path)?;
+    let scraps_dir_path = path_resolver.scraps_dir();
+    let exclude_dirs = vec![
+        path_resolver.static_dir(),
+        path_resolver.output_dir(&config),
+    ];
+
+    let scraps = read_scraps::to_all_scraps(&scraps_dir_path, &exclude_dirs)?;
+
+    let usecase = FrontmatterUsecase::new();
+    let results = usecase.execute(&scraps)?;
+
+    if json {
+        let items: Vec<FrontmatterItemJson> = results
+            .into_iter()
+            .map(|r| FrontmatterItemJson {
+                scrap: FrontmatterScrapJson {
+                    title: r.title.to_string(),
+                    ctx: r.ctx.map(|c| c.to_string()),
+                },
+                frontmatter: r.frontmatter,
+            })
+            .collect();
+        let response = FrontmatterResponse {
+            count: items.len(),
+            results: items,
+        };
+        writeln!(writer, "{}", serde_json::to_string(&response)?)?;
+    } else {
+        if results.is_empty() {
+            return Ok(());
+        }
+
+        let mut table = Table::new();
+        table.load_style(NOTHING);
+        table.set_header(vec![
+            Cell::new("Scrap".bold()),
+            Cell::new("Key".bold()),
+            Cell::new("Value".bold()),
+        ]);
+
+        for r in &results {
+            let scrap = scrap_label(
+                &r.title.to_string(),
+                r.ctx.as_ref().map(|c| c.to_string()).as_deref(),
+            );
+            for (key, value) in rows(&r.frontmatter) {
+                table.add_row(vec![Cell::new(&scrap), Cell::new(key), Cell::new(value)]);
+            }
+        }
+        writeln!(writer, "{table}")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{temp_scrap_project, TempScrapProject};
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    fn run_text_lists_keys_per_scrap(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project
+            .add_config(b"")
+            .add_scrap("a.md", b"---\nstatus: draft\nowner: alice\n---\n\n# A\n")
+            .add_scrap("b.md", b"# B\n\nNo frontmatter.\n");
+
+        let mut buf = Vec::new();
+        run(false, Some(project.project_root.as_path()), &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("status"));
+        assert!(output.contains("draft"));
+        assert!(output.contains("alice"));
+        assert!(!output.contains("No frontmatter"));
+    }
+
+    #[rstest]
+    fn run_json_outputs_results(#[from(temp_scrap_project)] project: TempScrapProject) {
+        project.add_config(b"").add_scrap(
+            "Programming/Rust/borrowing.md",
+            b"---\nstatus: draft\ntaxonomy:\n  - infra\n---\n\n# borrowing\n",
+        );
+
+        let mut buf = Vec::new();
+        run(true, Some(project.project_root.as_path()), &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: FrontmatterResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 1);
+        let item = &response.results[0];
+        assert_eq!(item.scrap.title, "borrowing");
+        assert_eq!(item.scrap.ctx.as_deref(), Some("Programming/Rust"));
+        assert_eq!(
+            item.frontmatter,
+            json!({"status": "draft", "taxonomy": ["infra"]})
+        );
+    }
+
+    #[rstest]
+    fn run_json_outputs_empty_without_frontmatter(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project
+            .add_config(b"")
+            .add_scrap("a.md", b"# A\n\nProse.\n");
+
+        let mut buf = Vec::new();
+        run(true, Some(project.project_root.as_path()), &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let response: FrontmatterResponse = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response.count, 0);
+        assert!(response.results.is_empty());
+    }
+
+    #[rstest]
+    fn run_fails_without_config(#[from(temp_scrap_project)] project: TempScrapProject) {
+        let mut buf = Vec::new();
+        let result = run(false, Some(project.project_root.as_path()), &mut buf);
+        assert!(result.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,9 @@ fn main() -> error::ScrapsResult<()> {
                 cli::cmd::tag::backlinks::run(&tag, json, directory, &mut std::io::stdout())
             }
         },
+        cli::SubCommands::Frontmatter { json } => {
+            cli::cmd::frontmatter::run(json, directory, &mut std::io::stdout())
+        }
         cli::SubCommands::Todo { status, json } => {
             cli::cmd::todo::run(status.into(), json, directory, &mut std::io::stdout())
         }

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let response: serde_json::Value = serde_json::from_str(&body).unwrap();
         let tools = response["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 9);
+        assert_eq!(tools.len(), 10);
 
         server_handle.abort();
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use super::tools::get_scrap::{get_scrap, GetScrapRequest};
+use super::tools::list_frontmatter::list_frontmatter;
 use super::tools::list_tags::list_tags;
 use super::tools::list_todos::{list_todos, ListTodosRequest};
 use super::tools::lookup_scrap_backlinks::{lookup_scrap_backlinks, LookupScrapBacklinksRequest};
@@ -132,6 +133,16 @@ impl ScrapsServer {
     ) -> Result<CallToolResult, ErrorData> {
         list_todos(&self.scraps_dir, &self.exclude_dirs, context, parameters).await
     }
+
+    #[tool(
+        description = "Use when the wiki was retrofitted from files carrying YAML frontmatter and you want that metadata across it: returns each scrap that has a frontmatter block together with its parsed keys. The keys are the author's own — scraps defines none of them and reads them as opaque data, so its own typed metadata is still #[[tag]] via list_tags. Read the scrap behind an entry with get_scrap."
+    )]
+    async fn list_frontmatter(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        list_frontmatter(&self.scraps_dir, &self.exclude_dirs, context).await
+    }
 }
 
 // Without `router = ...` the macro rebuilds the router (and every tool's
@@ -148,7 +159,8 @@ impl ServerHandler for ScrapsServer {
                  rather than one relation at a time, lookup_scrap_neighborhood returns its \
                  neighborhood as a graph: nodes with their hop distance and the links between \
                  them, no bodies. For the topic map, list_tags then lookup_tag_backlinks. For \
-                 the work recorded across the wiki, list_todos.",
+                 the work recorded across the wiki, list_todos; for a wiki retrofitted from \
+                 files with YAML frontmatter, list_frontmatter.",
         )
     }
 }
@@ -189,7 +201,7 @@ mod tests {
 
         let tools = client.list_tools(Default::default()).await.unwrap();
 
-        assert_eq!(tools.tools.len(), 9);
+        assert_eq!(tools.tools.len(), 10);
 
         let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
         assert!(tool_names.contains(&"orient"));
@@ -201,6 +213,7 @@ mod tests {
         assert!(tool_names.contains(&"list_tags"));
         assert!(tool_names.contains(&"lookup_tag_backlinks"));
         assert!(tool_names.contains(&"list_todos"));
+        assert!(tool_names.contains(&"list_frontmatter"));
 
         client.cancel().await.unwrap();
         server_handle.abort();
@@ -367,6 +380,7 @@ mod tests {
             ("lookup_tag_backlinks", serde_json::json!({"tag": "rust"})),
             ("orient", serde_json::json!({})),
             ("list_todos", serde_json::json!({})),
+            ("list_frontmatter", serde_json::json!({})),
             (
                 "lookup_scrap_neighborhood",
                 serde_json::json!({"title": "source"}),
@@ -683,6 +697,46 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn test_call_list_frontmatter_passes_keys_through(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap(
+            "Book/reading.md",
+            b"---\nstatus: draft\ntaxonomy:\n  - infra\n---\n\n# reading\n",
+        );
+        project.add_scrap("plain.md", b"# plain\n\nNo frontmatter.\n");
+
+        let response = call_tool_json(&project, "list_frontmatter", serde_json::json!({})).await;
+
+        assert_eq!(response["count"], 1);
+        let item = &response["results"][0];
+        assert_eq!(item["scrap"]["title"], "reading");
+        assert_eq!(item["scrap"]["ctx"], "Book");
+        assert_eq!(
+            item["frontmatter"],
+            serde_json::json!({"status": "draft", "taxonomy": ["infra"]})
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_call_list_frontmatter_empty_points_at_tags(
+        #[from(temp_scrap_project)] project: TempScrapProject,
+    ) {
+        project.add_scrap("plain.md", b"# plain\n\n#[[rust]]\n");
+
+        let response = call_tool_json(&project, "list_frontmatter", serde_json::json!({})).await;
+
+        assert_eq!(response["count"], 0);
+        let next = response["next"].as_str().unwrap_or_default();
+        assert!(
+            next.contains("list_tags"),
+            "empty frontmatter should point at scraps' own metadata: {response}"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
     async fn test_call_lookup_scrap_links(#[from(temp_scrap_project)] project: TempScrapProject) {
         project.add_scrap("source.md", b"# Source\n\n[[target]]");
         project.add_scrap("target.md", b"# Target\n\nTarget content");
@@ -954,8 +1008,10 @@ mod tests {
             "the map should carry no bodies: {map}"
         );
         let node = map["nodes"][0].as_object().unwrap();
+        let mut keys = node.keys().cloned().collect::<Vec<_>>();
+        keys.sort();
         assert_eq!(
-            node.keys().cloned().collect::<Vec<_>>(),
+            keys,
             vec!["ctx", "hop", "title"],
             "a node carries only its key and distance"
         );

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,4 +1,5 @@
 pub mod get_scrap;
+pub mod list_frontmatter;
 pub mod list_tags;
 pub mod list_todos;
 pub mod lookup_scrap_backlinks;

--- a/src/mcp/tools/list_frontmatter.rs
+++ b/src/mcp/tools/list_frontmatter.rs
@@ -1,0 +1,80 @@
+use crate::input::file::read_scraps;
+use crate::mcp::json::scrap::ScrapKeyJson;
+use crate::usecase::frontmatter::usecase::FrontmatterUsecase;
+use rmcp::model::ErrorCode;
+use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer};
+use serde::Serialize;
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub struct FrontmatterItemJson {
+    pub scrap: ScrapKeyJson,
+    pub frontmatter: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListFrontmatterResponse {
+    pub results: Vec<FrontmatterItemJson>,
+    pub count: usize,
+    pub next: String,
+}
+
+pub async fn list_frontmatter(
+    scraps_dir: &Path,
+    exclude_dirs: &[std::path::PathBuf],
+    _context: RequestContext<RoleServer>,
+) -> Result<CallToolResult, ErrorData> {
+    let scraps = read_scraps::to_all_scraps(scraps_dir, exclude_dirs).map_err(|e| {
+        ErrorData::new(
+            ErrorCode(-32003),
+            format!("Failed to load scraps: {e}"),
+            None,
+        )
+    })?;
+
+    let frontmatter_usecase = FrontmatterUsecase::new();
+
+    let results = frontmatter_usecase.execute(&scraps).map_err(|e| {
+        ErrorData::new(
+            ErrorCode(-32004),
+            format!("List frontmatter failed: {e}"),
+            None,
+        )
+    })?;
+
+    let items: Vec<FrontmatterItemJson> = results
+        .into_iter()
+        .map(|result| FrontmatterItemJson {
+            scrap: ScrapKeyJson {
+                title: result.title.to_string(),
+                ctx: result.ctx.map(|c| c.to_string()),
+            },
+            frontmatter: result.frontmatter,
+        })
+        .collect();
+
+    let count = items.len();
+    let next = if count == 0 {
+        "No scrap carries frontmatter. A scraps wiki types its own metadata as #[[tag]] instead — start from list_tags."
+    } else {
+        "Keys are the author's own; scraps gives them no meaning. Read the scrap behind an entry with get_scrap {title, ctx}."
+    };
+    let response = ListFrontmatterResponse {
+        results: items,
+        count,
+        next: next.to_string(),
+    };
+
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string(&response).map_err(|e| {
+            ErrorData::new(
+                ErrorCode(-32005),
+                format!("JSON serialization failed: {e}"),
+                None,
+            )
+        })?,
+    )]))
+}

--- a/src/usecase.rs
+++ b/src/usecase.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod frontmatter;
 pub mod init;
 pub mod lint;
 pub mod progress;

--- a/src/usecase/frontmatter.rs
+++ b/src/usecase/frontmatter.rs
@@ -1,0 +1,1 @@
+pub mod usecase;

--- a/src/usecase/frontmatter/usecase.rs
+++ b/src/usecase/frontmatter/usecase.rs
@@ -1,0 +1,122 @@
+use crate::error::ScrapsResult;
+use scraps_libs::markdown::query::frontmatter;
+use scraps_libs::model::context::Ctx;
+use scraps_libs::model::scrap::Scrap;
+use scraps_libs::model::title::Title;
+use serde_json::Value;
+
+/// One scrap's frontmatter, resolved back to the scrap it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrontmatterResult {
+    pub title: Title,
+    pub ctx: Option<Ctx>,
+    pub frontmatter: Value,
+}
+
+pub struct FrontmatterUsecase;
+
+impl FrontmatterUsecase {
+    pub fn new() -> FrontmatterUsecase {
+        FrontmatterUsecase
+    }
+
+    pub fn execute(&self, scraps: &[Scrap]) -> ScrapsResult<Vec<FrontmatterResult>> {
+        let mut results: Vec<FrontmatterResult> = scraps
+            .iter()
+            .filter_map(|scrap| {
+                frontmatter(scrap.md_text()).map(|value| FrontmatterResult {
+                    title: scrap.title().clone(),
+                    ctx: scrap.ctx().clone(),
+                    frontmatter: value,
+                })
+            })
+            .collect();
+
+        results.sort_by(|a, b| {
+            let a_ctx = a.ctx.as_ref().map(|c| c.to_string()).unwrap_or_default();
+            let b_ctx = b.ctx.as_ref().map(|c| c.to_string()).unwrap_or_default();
+            a_ctx
+                .cmp(&b_ctx)
+                .then_with(|| a.title.to_string().cmp(&b.title.to_string()))
+        });
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx(s: &str) -> Ctx {
+        Ctx::from(s)
+    }
+
+    #[test]
+    fn it_collects_frontmatter_from_scraps_that_have_it() {
+        let scraps = vec![
+            Scrap::new("a", &None, "---\nstatus: draft\n---\n\n# A\n"),
+            Scrap::new("b", &None, "# B\n\nNo frontmatter.\n"),
+        ];
+
+        let results = FrontmatterUsecase::new().execute(&scraps).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title.to_string(), "a");
+        assert_eq!(results[0].frontmatter, json!({"status": "draft"}));
+    }
+
+    #[test]
+    fn it_passes_keys_through_without_interpreting_them() {
+        let scraps = vec![Scrap::new(
+            "a",
+            &None,
+            "---\nowner: alice\ntags:\n  - infra\nnested:\n  k: v\n---\n",
+        )];
+
+        let results = FrontmatterUsecase::new().execute(&scraps).unwrap();
+
+        assert_eq!(
+            results[0].frontmatter,
+            json!({"owner": "alice", "tags": ["infra"], "nested": {"k": "v"}})
+        );
+    }
+
+    #[test]
+    fn it_sorts_by_ctx_then_title() {
+        let scraps = vec![
+            Scrap::new("z", &None, "---\nk: 1\n---\n"),
+            Scrap::new("b", &Some(ctx("Book")), "---\nk: 2\n---\n"),
+            Scrap::new("a", &Some(ctx("Book")), "---\nk: 3\n---\n"),
+        ];
+
+        let results = FrontmatterUsecase::new().execute(&scraps).unwrap();
+
+        let order: Vec<String> = results.iter().map(|r| r.title.to_string()).collect();
+        assert_eq!(order, vec!["z", "a", "b"]);
+    }
+
+    #[test]
+    fn it_skips_malformed_frontmatter_rather_than_failing() {
+        let scraps = vec![Scrap::new(
+            "a",
+            &None,
+            "---\nstatus: [unclosed\n---\n\n# A\n",
+        )];
+
+        let results = FrontmatterUsecase::new().execute(&scraps).unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn it_returns_empty_when_no_scrap_has_frontmatter() {
+        let scraps = vec![Scrap::new("a", &None, "# A\n\nJust prose.\n")];
+
+        assert!(FrontmatterUsecase::new()
+            .execute(&scraps)
+            .unwrap()
+            .is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `scraps frontmatter --json` and the MCP tool `list_frontmatter`. Both return every scrap that carries a YAML frontmatter block, together with its parsed keys.

```json
{
  "results": [
    {
      "scrap": { "title": "borrowing", "ctx": "Programming/Rust" },
      "frontmatter": { "status": "review", "owner": "bob", "taxonomy": ["rust", "memory"] }
    }
  ],
  "count": 1
}
```

**This is passthrough, not interpretation.** Scraps defines no frontmatter fields and gives no key a meaning — `title`, `ctx`, tags and links still come only from the filesystem and Wiki-link syntax. A `tags:` key in frontmatter is not a scraps tag.

## Why this shape

v1 design principle 2 preserves a read-only frontmatter adapter as an explicit exception ("passthrough only, no semantic interpretation"). [#515](https://github.com/boykush/scraps/issues/515) proposed realizing it as a field on `scraps get --json` and was closed NOT_PLANNED.

The surface is what changed. Principle 7 splits wiki-wide aggregation (its own command) from single-scrap introspection (`get --json`), and that is also where the value sits: "which scraps are draft, who owns what" cannot be answered one scrap at a time, whereas per-scrap frontmatter adds little over reading the body. So this lands as a standalone command plus its MCP counterpart, matching `scraps todo`.

## Dependency cost: zero new crates

- `yaml-rust2` was **already compiled into the binary** via `config`, so making it a direct dependency adds no build time and no transitive deps — consistent with principle 8 (lean core)
- `serde_json/preserve_order` keeps keys in the order the author wrote them, which is the point of passing them through; `indexmap` was already in the tree
- In libs it is gated behind a new `frontmatter` feature with optional deps, following the existing `search = ["fuzzy-matcher"]` pattern
- `scraps build` never calls the parser, so the build-time budget is untouched

## Deliberately not in scope

**Frontmatter is still rendered as content.** Only this query enables comrak's `front_matter_delimiter`; every other query reads the block as before, so nothing else changes shape. That means a frontmatter block still renders as an `<h2>` on the scrap page and fills the card summary on index pages — the pre-existing behaviour, unchanged by this PR. Fixing it touches `Summary::from_md_text` (a hand-rolled line scanner that does not go through comrak) as well as the shared comrak options, and is a separate decision about output.

Malformed, unclosed, empty and non-leading blocks are skipped rather than raised, so a half-migrated wiki still builds.

## Test plan

TDD across all three layers, Red → Green:

- [x] libs — 11 cases: scalars, nested maps/sequences, sequence root, absent, empty, not-at-start, unclosed, malformed, fenced-block-is-not-frontmatter
- [x] usecase — passthrough fidelity, ctx/title ordering, malformed skipped
- [x] CLI — text and `--json`, empty wiki, missing config
- [x] MCP — key passthrough over the protocol, and an empty response pointing at `list_tags`; the existing cross-tool invariants (description opens with "Use when", names a follow-up tool, response carries `next`) cover the new tool unmodified. Tool counts 9 → 10.

`test_neighborhood_leaves_bodies_to_get_scrap` asserted node keys in BTreeMap order; with `preserve_order` the set is identical but the order is insertion order, so the assertion now sorts first — its stated intent ("a node carries only its key and distance") is about the set.

- [x] `mise run cargo:quality` green (293 + 322 tests)
- [x] `mise run cargo:deny` — advisories, bans, licenses, sources all ok
- [x] Smoke-tested against a real wiki over both `scraps frontmatter --json` and `mcp serve --http`

🤖 Generated with [Claude Code](https://claude.com/claude-code)