### PR TITLE
docs(vision): reconcile the frontmatter principle with what shipped

### DIFF
--- a/design/v1/vision.md
+++ b/design/v1/vision.md
@@ -66,9 +66,11 @@ the story.
 Scraps takes the position that per-file metadata belongs in markdown syntax
 (`#[[tag]]`, `[[link]]`, `![[embed]]`), not in a YAML/TOML frontmatter block:
 
-- **No native frontmatter.** A read-only Obsidian-style adapter is allowed
-  (passthrough only, no semantic interpretation; see #515) but scraps defines
-  no frontmatter fields of its own.
+- **No scraps-defined frontmatter.** The read-only adapter this exception
+  allows now exists as `scraps frontmatter` / `list_frontmatter` (#700): a YAML
+  block is parsed and handed back untouched. Scraps still defines no
+  frontmatter field and interprets no key — title, ctx, tags and links come
+  only from the filesystem and Wiki-link syntax.
 - **No page-level alias.** Filesystem identity is the unique key; if you need
   another name, create another scrap.
 - **Author / mtime / etc. is delegated to git** via the `GitCommand` trait —
@@ -169,7 +171,8 @@ keeps lint, search, build, and resolution free of `if archived` special cases.
 
 `scraps template generate / list` and `src/usecase/template/` are gone.
 `modules/libs/src/markdown/frontmatter.rs` is gone (templates were its only
-consumer). `TemplateError` and `templates_dir` are removed from `PathResolver`
+consumer); the read-only parser that returned later is a different thing at
+`markdown/query/frontmatter.rs`, per principle 2. `TemplateError` and `templates_dir` are removed from `PathResolver`
 and `TempScrapProject`. The replacement is the AI-skill authoring path
 (`scraps-writer`, planned `scraps-agent`). PR #490.
 
@@ -233,7 +236,9 @@ workspace orchestration is a v1.1+ question.
 The following are intentionally not v1, with the reasoning preserved here so
 that future contributors can re-evaluate from the right premises:
 
-- **Templates / frontmatter.** Removed. Authoring goes through skills (#490).
+- **Templates, and frontmatter as an authoring surface.** Removed; authoring
+  goes through skills (#490). Reading a block back as opaque passthrough is the
+  separate, allowed thing — see principle 2.
 - **Per-file `author` metadata.** Git plus a `GitCommand` extension covers it.
 - **`missing_ref` lint.** Requires a Japanese tokenizer; plugin candidate.
 - **`co_mention` lint.** Subsumed by `lookup_scrap_backlinks`.

--- a/docs/How-to/Integrate with AI Assistants.md
+++ b/docs/How-to/Integrate with AI Assistants.md
@@ -20,6 +20,7 @@ server.
 ❯ scraps backlinks "Configuration" --json
 ❯ scraps tag list --json
 ❯ scraps todo --status all --json
+❯ scraps frontmatter --json
 ```
 
 `scraps get --json` defaults to `title`, `ctx`, and `body`. It can project


### PR DESCRIPTION
## Summary

Docs only. Brings `design/v1/vision.md` back in line with main before cutting a release that contains `scraps frontmatter`.

## Why

[#700](https://github.com/boykush/scraps/pull/700) realized the read-only frontmatter adapter that principle 2 had been holding open as an exception. Three places still read as though it had not:

- Principle 2 described the adapter as *allowed* and pointed at [#515](https://github.com/boykush/scraps/issues/515), which is closed NOT_PLANNED — a reader following the reference lands on a declined issue for a feature that exists.
- **Out of Scope (v1)** listed "Templates / frontmatter. Removed." flatly. Releasing a version whose changelog adds `scraps frontmatter` would directly contradict it.
- Principle 11 notes `modules/libs/src/markdown/frontmatter.rs` is gone, which is still true of that path but now invites the conclusion that no frontmatter parsing exists.

## What changed

The word "frontmatter" was covering two different things, so they are separated rather than reversed:

- **as an authoring surface** — still removed, authoring still goes through skills (#490)
- **as something read back, opaque and uninterpreted** — this is what shipped

The principle itself is unchanged: scraps defines no frontmatter field and interprets no key; title, ctx, tags and links still come only from the filesystem and Wiki-link syntax.

Also adds `scraps frontmatter --json` to the CLI sampler in `docs/How-to/Integrate with AI Assistants.md`, which listed every other JSON read but this one. `docs/Reference/CLI Overview.md` already covers it from #700.

## Test plan

- [x] `scraps -C docs build` succeeds; `scraps -C docs lint` reports only the 3 pre-existing warnings from `docs/README.md`
- [x] No code changes, so no `cargo:quality` surface is touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)