### PR TITLE
v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "2.1.0"
+version = "2.2.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "2.1.0"
+version = "2.2.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "2.1.0"
+version = "2.2.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
Version bump for the v2.2.0 release. Contents since v2.1.0:

### ✨ Features

- **feat(mcp): aggregate wiki-wide task items with `list_todos`** (#698)

  `scraps todo` had no MCP counterpart, so agents reaching the wiki over MCP could not see the work recorded in it. The tool reuses `TodoUsecase`, takes the same `status` filter as the CLI and returns the same result shape. Parity for an existing command — CLI + JSON stays the agent-integration primary.

- **feat(frontmatter): aggregate YAML frontmatter wiki-wide** (#700)

  Adds `scraps frontmatter --json` and the MCP tool `list_frontmatter`, returning every scrap that carries a YAML block together with its parsed keys. Passthrough, not interpretation: scraps defines no frontmatter field and gives no key a meaning, so title, ctx, tags and links still come only from the filesystem and Wiki-link syntax. Realizes the read-only adapter that design principle 2 preserved as an exception. `yaml-rust2` was already compiled in via `config`, so the parser costs no new dependency.

### 📖 Documentation

- **docs(mcp-server): document the orient tool** (#699) — the plugin README covered every MCP tool except the session-start entry point.
- **docs(vision): reconcile the frontmatter principle with what shipped** (#701) — principle 2 pointed at a NOT_PLANNED issue for a feature that now exists, and Out of Scope still listed frontmatter flatly as removed. Separates frontmatter as an authoring surface (still removed) from reading a block back as opaque passthrough (shipped).

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)