### PR TITLE
feat(build): draw each scrap's neighbourhood as a build-time SVG

### DIFF
--- a/docs/Reference/Static Site.md
+++ b/docs/Reference/Static Site.md
@@ -26,6 +26,10 @@ fully supported.
 
 ![[Reference/Static Site/Color Scheme]]
 
+## [[Reference/Static Site/Neighbourhood Graph|Neighbourhood graph]]
+
+![[Reference/Static Site/Neighbourhood Graph]]
+
 ## [[Reference/Static Site/Tag Pages|Tag pages]]
 
 ![[Reference/Static Site/Tag Pages]]

--- a/docs/Reference/Static Site/Neighbourhood Graph.md
+++ b/docs/Reference/Static Site/Neighbourhood Graph.md
@@ -1,0 +1,17 @@
+#[[Emit/Static Site]]
+
+Every scrap page that has at least one connection draws its direct
+neighbours as an inline SVG, above the backlinks and links lists. The
+drawing is generated at build time — no JavaScript is fetched or run for
+it, and no extra file is emitted.
+
+Direction is carried by position rather than colour: backlinks sit on the
+left arc, links on the right, and scraps linked both ways sit on the
+vertical. Arrowheads always point at the scrap being referenced. Colours
+come from the same tokens as the rest of the page, so the graph follows
+[[Reference/Static Site/Color Scheme]] without a redraw.
+
+A hub scrap can carry hundreds of connections, past which the labels stop
+being readable. At most 18 neighbours are drawn, chosen round-robin across
+the three directions so a scrap with many backlinks and one outgoing link
+still shows that link; the remainder is reported as a `+N more` count.

--- a/src/usecase/build/css/builtins/main.css
+++ b/src/usecase/build/css/builtins/main.css
@@ -679,6 +679,63 @@ ul.scrap-links {
     }
 }
 
+/* neighbourhood graph — direction is carried by which side a scrap sits on
+   (backlinks left, links right, mutual vertical) and by the arrowheads, so
+   the drawing needs no colour of its own to be read. */
+svg.scrap-graph {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: var(--space-5) auto 0;
+
+    line.edge {
+        stroke: var(--color-rule);
+        stroke-width: 1.2;
+        fill: none;
+    }
+
+    path.head {
+        fill: var(--color-text-muted);
+    }
+
+    circle.dot {
+        fill: var(--color-text-muted);
+    }
+
+    circle.dot.center {
+        fill: var(--color-accent);
+        stroke: var(--color-surface);
+        stroke-width: 2;
+    }
+
+    text.label {
+        font-size: var(--font-size-xs);
+        fill: var(--color-text);
+    }
+
+    text.label.center {
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-medium);
+    }
+
+    text.more {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        fill: var(--color-text-muted);
+    }
+
+    a.scrap:hover {
+        circle.dot {
+            fill: var(--color-accent);
+        }
+
+        text.label {
+            fill: var(--color-accent);
+            text-decoration: underline;
+        }
+    }
+}
+
 /* scraps index — every scrap on one page, grouped by the title's initial */
 div.scraps-index {
     p.list-head {

--- a/src/usecase/build/html/builtins/macros.html
+++ b/src/usecase/build/html/builtins/macros.html
@@ -50,6 +50,31 @@
     </ul>
 {% endcomponent scrap_links %}
 
+{% component scrap_graph(graph, base_url, center_title) %}
+    <svg class="scrap-graph" viewBox="0 0 {{ graph.width }} {{ graph.height }}" role="img" aria-label="{{ center_title }} and its neighbours">
+        <defs>
+            <marker id="scrap-graph-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                <path class="head" d="M0 0 L8 4 L0 8 z" />
+            </marker>
+        </defs>
+        {% for node in graph.nodes %}
+            <line class="edge {{ node.dir }}" x1="{{ node.x1 }}" y1="{{ node.y1 }}" x2="{{ node.x2 }}" y2="{{ node.y2 }}"{% if node.arrow_start %} marker-start="url(#scrap-graph-arrow)"{% endif %}{% if node.arrow_end %} marker-end="url(#scrap-graph-arrow)"{% endif %} />
+        {% endfor %}
+        {% for node in graph.nodes %}
+            <a class="scrap {{ node.dir }}" href="{{ base_url }}scraps/{{ node.html_file_name }}">
+                <title>{% if node.ctx %}{{ node.ctx }}&#47;{% endif %}{{ node.title }}</title>
+                <circle class="dot" cx="{{ node.x }}" cy="{{ node.y }}" r="{{ node.r }}" />
+                <text class="label" x="{{ node.label_x }}" y="{{ node.label_y }}" text-anchor="{{ node.anchor }}">{{ node.label }}</text>
+            </a>
+        {% endfor %}
+        <circle class="dot center" cx="{{ graph.center_x }}" cy="{{ graph.center_y }}" r="{{ graph.center_r }}" />
+        <text class="label center" x="{{ graph.center_x }}" y="{{ graph.center_label_y }}" text-anchor="middle">{{ graph.center_label }}</text>
+        {% if graph.dropped > 0 %}
+            <text class="more" x="{{ graph.more_x }}" y="{{ graph.more_y }}" text-anchor="end">+{{ graph.dropped }} more</text>
+        {% endif %}
+    </svg>
+{% endcomponent scrap_graph %}
+
 {% component tag_links(tags, base_url, slice_size=100) %}
     <ul class="tag-links">
         {% for tag in tags | slice(end=slice_size) %}

--- a/src/usecase/build/html/builtins/scrap.html
+++ b/src/usecase/build/html/builtins/scrap.html
@@ -32,6 +32,12 @@
             {% for element in scrap.content.elements %}{% if element.raw %}{{ element.raw | safe }}{% elif element.autolink %}{{ <link_card autolink={element.autolink} /> }}{% endif %}{% endfor %}
         </div>
     </div>
+    {% if scrap_graph %}
+        <section class="connections graph">
+            <p class="section-head">neighbourhood</p>
+            {{ <scrap_graph graph={scrap_graph} base_url={base_url} center_title={scrap.title} /> }}
+        </section>
+    {% endif %}
     {% if linked_scraps | length > 0 %}
         <section class="connections">
             <p class="section-head">backlinks &#183; {{ linked_scraps | length }}</p>

--- a/src/usecase/build/html/scrap_render.rs
+++ b/src/usecase/build/html/scrap_render.rs
@@ -6,6 +6,7 @@ use crate::service::tera_render::{render_to_file, user_template_glob};
 use crate::usecase::build::model::backlinks_map::BacklinksMap;
 use crate::usecase::build::model::html::HtmlMetadata;
 use crate::usecase::build::model::scrap_detail::ScrapDetail;
+use crate::usecase::build::model::scrap_graph::{ScrapGraph, MAX_NODES};
 use crate::usecase::build::model::site_nav::SiteNav;
 use scraps_libs::model::base_url::BaseUrl;
 use scraps_libs::model::file::ScrapFileStem;
@@ -17,6 +18,7 @@ use crate::usecase::build::html::templates;
 
 use super::serde::link_scraps::LinkScrapsTera;
 use super::serde::scrap_detail::ScrapDetailTera;
+use super::serde::scrap_graph::ScrapGraphTera;
 use super::serde::tag::TagTera;
 
 pub struct ScrapRender {
@@ -70,6 +72,17 @@ impl ScrapRender {
             .filter_map(|key| scraps_by_key.get(key).cloned())
             .collect::<Vec<_>>();
         context.insert("outbound_scraps", &LinkScrapsTera::new(&outbound_scraps));
+
+        // Both lists are already in hand, so the neighborhood costs no extra
+        // walk over the wiki.
+        if let Some(graph) = ScrapGraph::new(
+            &scrap.title().to_string(),
+            &linked_scraps,
+            &outbound_scraps,
+            MAX_NODES,
+        ) {
+            context.insert("scrap_graph", &ScrapGraphTera::from(&graph));
+        }
 
         // The stem may contain `/`-separated context directories, which
         // `render_to_file` creates on the way.
@@ -174,5 +187,68 @@ mod tests {
         assert!(result4.contains(">links &#183; 1"));
         assert!(result4.contains("tags/design.html"));
         assert!(result4.contains("#[["));
+    }
+
+    #[test]
+    fn it_draws_the_neighbourhood_only_when_there_is_one() {
+        let base_url = &BaseUrl::new(Url::parse("http://localhost:1112/").unwrap()).unwrap();
+        let metadata = HtmlMetadata::new(&LangCode::default(), "Scrap", &None, &None);
+
+        let linked = &Scrap::new("linked", &None, "");
+        let linking = &Scrap::new("linking", &None, "[[linked]]");
+        let alone = &Scrap::new("alone", &None, "no wiki links here");
+        let scraps = vec![linked.to_owned(), linking.to_owned(), alone.to_owned()];
+        let scrap_texts = scraps
+            .iter()
+            .map(|scrap| (scrap.self_key(), scrap.md_text().to_string()))
+            .collect();
+        let backlinks_map = BacklinksMap::new(&scraps);
+        let scraps_by_key: HashMap<_, _> = scraps
+            .iter()
+            .map(|scrap| (scrap.self_key(), scrap.clone()))
+            .collect();
+        let site_nav = SiteNav::new(
+            scraps.len(),
+            Tags::new(&scraps),
+            false,
+            chrono_tz::UTC,
+            false,
+        );
+
+        let project = crate::test_fixtures::TempScrapProject::new();
+        let render = ScrapRender::new(&project.static_dir, &project.output_dir).unwrap();
+        let render_one = |scrap: &Scrap| {
+            render
+                .run(
+                    base_url,
+                    &metadata,
+                    &ScrapDetail::new(scrap, &None, base_url, &scrap_texts),
+                    &backlinks_map,
+                    &scraps_by_key,
+                    &site_nav,
+                )
+                .unwrap();
+        };
+
+        render_one(linked);
+        render_one(linking);
+        render_one(alone);
+
+        let read = |stem: &str| {
+            fs::read_to_string(project.output_dir.join(format!("scraps/{stem}.html"))).unwrap()
+        };
+
+        // The backlink points at the scrap being read, so the arrow lands on
+        // the centre and no arrow is drawn at the neighbour.
+        let backlinked = read("linked");
+        assert!(backlinked.contains("<svg class=\"scrap-graph\""));
+        assert!(backlinked.contains("marker-start=\"url(#scrap-graph-arrow)\""));
+        assert!(!backlinked.contains("marker-end=\"url(#scrap-graph-arrow)\""));
+
+        let outbound = read("linking");
+        assert!(outbound.contains("marker-end=\"url(#scrap-graph-arrow)\""));
+        assert!(!outbound.contains("marker-start=\"url(#scrap-graph-arrow)\""));
+
+        assert!(!read("alone").contains("scrap-graph"));
     }
 }

--- a/src/usecase/build/html/serde.rs
+++ b/src/usecase/build/html/serde.rs
@@ -2,6 +2,7 @@ pub mod content;
 pub mod index_scraps;
 pub mod link_scraps;
 pub mod scrap_detail;
+pub mod scrap_graph;
 pub mod tag;
 pub mod tags;
 pub mod title_index;

--- a/src/usecase/build/html/serde/scrap_graph.rs
+++ b/src/usecase/build/html/serde/scrap_graph.rs
@@ -1,0 +1,151 @@
+use scraps_libs::model::file::ScrapFileStem;
+
+use crate::usecase::build::model::scrap_graph::{GraphNode, LinkDir, ScrapGraph, NODE_R};
+
+#[derive(serde::Serialize, Clone, PartialEq, Debug)]
+struct SerializeGraphNode {
+    ctx: Option<String>,
+    title: String,
+    label: String,
+    html_file_name: String,
+    /// "in" | "out" | "both" — a class hook so a user template can style the
+    /// directions without re-deriving them.
+    dir: &'static str,
+    x: f32,
+    y: f32,
+    r: f32,
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    label_x: f32,
+    label_y: f32,
+    anchor: &'static str,
+    arrow_start: bool,
+    arrow_end: bool,
+}
+
+impl SerializeGraphNode {
+    fn new(node: &GraphNode, center_x: f32, center_y: f32) -> SerializeGraphNode {
+        let (x1, y1) = node.edge_start(center_x, center_y);
+        let (x2, y2) = node.edge_end(center_x, center_y);
+        let title = node.key.title().to_string();
+        SerializeGraphNode {
+            ctx: node.key.ctx().as_ref().map(|ctx| ctx.to_string()),
+            label: node.label.clone(),
+            title,
+            html_file_name: format!("{}.html", ScrapFileStem::from(node.key.clone())),
+            dir: match node.dir {
+                LinkDir::In => "in",
+                LinkDir::Out => "out",
+                LinkDir::Both => "both",
+            },
+            x: node.x,
+            y: node.y,
+            r: NODE_R,
+            x1,
+            y1,
+            x2,
+            y2,
+            label_x: node.label_x(center_x),
+            label_y: node.label_y(),
+            anchor: node.label_anchor(center_x),
+            arrow_start: node.arrow_at_center(),
+            arrow_end: node.arrow_at_node(),
+        }
+    }
+}
+
+#[derive(serde::Serialize, PartialEq, Debug)]
+pub struct ScrapGraphTera {
+    width: f32,
+    height: f32,
+    center_x: f32,
+    center_y: f32,
+    center_r: f32,
+    center_label: String,
+    center_label_y: f32,
+    more_x: f32,
+    more_y: f32,
+    dropped: usize,
+    nodes: Vec<SerializeGraphNode>,
+}
+
+impl From<&ScrapGraph> for ScrapGraphTera {
+    fn from(graph: &ScrapGraph) -> Self {
+        ScrapGraphTera {
+            width: graph.width,
+            height: graph.height,
+            center_x: graph.center_x,
+            center_y: graph.center_y,
+            center_r: graph.center_r(),
+            center_label: graph.center_label.clone(),
+            center_label_y: graph.center_label_y(),
+            more_x: graph.width - 10.0,
+            more_y: graph.height - 10.0,
+            dropped: graph.dropped,
+            nodes: graph
+                .nodes
+                .iter()
+                .map(|node| SerializeGraphNode::new(node, graph.center_x, graph.center_y))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use scraps_libs::model::{context::Ctx, scrap::Scrap};
+
+    use crate::usecase::build::model::scrap_graph::MAX_NODES;
+
+    use super::*;
+
+    #[test]
+    fn it_serializes_direction_and_link_target() {
+        let inbound = vec![Scrap::new("in", &Some(Ctx::from("guide")), "")];
+        let outbound = vec![Scrap::new("out", &None, "")];
+        let graph = ScrapGraph::new("center", &inbound, &outbound, MAX_NODES).unwrap();
+
+        let tera = ScrapGraphTera::from(&graph);
+
+        let backlink = tera.nodes.iter().find(|n| n.title == "in").unwrap();
+        assert_eq!(backlink.dir, "in");
+        assert_eq!(backlink.ctx, Some("guide".to_string()));
+        assert_eq!(backlink.html_file_name, "guide/in.html");
+        assert!(backlink.arrow_start && !backlink.arrow_end);
+        assert_eq!(backlink.anchor, "end");
+
+        let link = tera.nodes.iter().find(|n| n.title == "out").unwrap();
+        assert_eq!(link.dir, "out");
+        assert!(!link.arrow_start && link.arrow_end);
+        assert_eq!(link.anchor, "start");
+    }
+
+    #[test]
+    fn it_stops_edges_short_of_both_endpoints() {
+        let outbound = vec![Scrap::new("out", &None, "")];
+        let graph = ScrapGraph::new("center", &[], &outbound, MAX_NODES).unwrap();
+
+        let tera = ScrapGraphTera::from(&graph);
+
+        let node = &tera.nodes[0];
+        let from_center =
+            ((node.x1 - tera.center_x).powi(2) + (node.y1 - tera.center_y).powi(2)).sqrt();
+        assert!(from_center > 0.0, "edge starts away from the centre point");
+        let to_node = ((node.x - node.x2).powi(2) + (node.y - node.y2).powi(2)).sqrt();
+        assert!(to_node > 0.0, "edge stops short of the node circle");
+    }
+
+    #[test]
+    fn it_shortens_a_long_title_but_keeps_it_for_the_tooltip() {
+        let long = "a very long scrap title that will not fit on one node";
+        let graph =
+            ScrapGraph::new("center", &[], &[Scrap::new(long, &None, "")], MAX_NODES).unwrap();
+
+        let tera = ScrapGraphTera::from(&graph);
+
+        assert_eq!(tera.nodes[0].title, long);
+        assert_eq!(tera.nodes[0].label, "a very long scra…");
+    }
+}

--- a/src/usecase/build/model.rs
+++ b/src/usecase/build/model.rs
@@ -6,6 +6,7 @@ pub mod html;
 pub mod list_view_configs;
 pub mod paging;
 pub mod scrap_detail;
+pub mod scrap_graph;
 pub mod site_nav;
 pub mod sort;
 pub mod summary;

--- a/src/usecase/build/model/scrap_graph.rs
+++ b/src/usecase/build/model/scrap_graph.rs
@@ -1,0 +1,455 @@
+use std::collections::HashSet;
+use std::f32::consts::PI;
+
+use scraps_libs::model::{key::ScrapKey, scrap::Scrap};
+
+/// Neighbours drawn around one scrap. A wiki hub carries hundreds of
+/// backlinks, and past this many the labels stop being readable however
+/// they are placed, so the rest is reported as a count instead.
+pub const MAX_NODES: usize = 18;
+
+pub const NODE_R: f32 = 5.0;
+const CENTER_R: f32 = 8.5;
+const BASE_RADIUS: f32 = 150.0;
+/// Arc length one neighbour needs before its label starts touching the next.
+const NODE_GAP: f32 = 26.0;
+const SPREAD_SIDE: f32 = PI * 0.66;
+const SPREAD_BOTH: f32 = PI * 0.30;
+const PAD_Y: f32 = 60.0;
+const LABEL_OFFSET: f32 = 9.0;
+const ARROW_CLEARANCE: f32 = 5.0;
+/// SVG text neither wraps nor ellipsises, so a long title is cut before it
+/// reaches the markup. The full title stays on the node as a tooltip.
+const LABEL_CHARS: usize = 16;
+/// `--font-size-xs`, the size `main.css` gives these labels. There is no text
+/// engine at build time, so the box a label needs has to be estimated from it.
+const LABEL_FONT_PX: f32 = 12.0;
+/// A drawn label's box is taller than its font size; two rows closer than this
+/// touch. Measured against the shipped font stack, not derived.
+const LABEL_GAP: f32 = LABEL_FONT_PX * 1.75;
+const MIN_PAD_X: f32 = 90.0;
+
+/// Which way the link between the centre scrap and a neighbour runs.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum LinkDir {
+    /// The neighbour links here: a backlink.
+    In,
+    /// The centre scrap links out to the neighbour.
+    Out,
+    /// Both directions exist.
+    Both,
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct GraphNode {
+    pub key: ScrapKey,
+    /// The title as drawn: cut to [`LABEL_CHARS`] so it fits on one node.
+    pub label: String,
+    pub dir: LinkDir,
+    pub x: f32,
+    pub y: f32,
+}
+
+fn label_of(title: &str) -> String {
+    let chars: Vec<char> = title.chars().collect();
+    if chars.len() <= LABEL_CHARS {
+        title.to_string()
+    } else {
+        format!("{}…", chars[..LABEL_CHARS].iter().collect::<String>())
+    }
+}
+
+/// Wide enough for the label not to be clipped by the viewBox. The factors are
+/// upper bounds measured against the shipped font stack, not exact advances —
+/// they only ever decide how much empty margin the drawing carries.
+fn label_width(label: &str) -> f32 {
+    label
+        .chars()
+        .map(|c| if c.is_ascii() { 0.80 } else { 1.05 })
+        .sum::<f32>()
+        * LABEL_FONT_PX
+}
+
+/// A scrap and its direct neighbours, already laid out. Direction is carried
+/// by position — backlinks left, links right, mutual on the vertical — so the
+/// drawing stays readable without a second colour to decode.
+#[derive(PartialEq, Clone, Debug)]
+pub struct ScrapGraph {
+    pub nodes: Vec<GraphNode>,
+    /// The centre scrap's own title, cut the same way a neighbour's is.
+    pub center_label: String,
+    pub dropped: usize,
+    pub width: f32,
+    pub height: f32,
+    pub center_x: f32,
+    pub center_y: f32,
+}
+
+impl ScrapGraph {
+    pub fn center_r(&self) -> f32 {
+        CENTER_R
+    }
+
+    pub fn center_label_y(&self) -> f32 {
+        self.center_y + CENTER_R + 15.0
+    }
+}
+
+fn sort_key(key: &ScrapKey) -> (String, String) {
+    (
+        key.ctx()
+            .as_ref()
+            .map(|ctx| ctx.to_string())
+            .unwrap_or_default(),
+        key.title().to_string(),
+    )
+}
+
+impl ScrapGraph {
+    /// `None` when the scrap has no neighbour to draw. `inbound` and `outbound`
+    /// are the same lists the connections sections render, so no extra walk
+    /// over the wiki happens here.
+    pub fn new(
+        center_title: &str,
+        inbound: &[Scrap],
+        outbound: &[Scrap],
+        limit: usize,
+    ) -> Option<ScrapGraph> {
+        let ins: HashSet<ScrapKey> = inbound.iter().map(|scrap| scrap.self_key()).collect();
+        let outs: HashSet<ScrapKey> = outbound.iter().map(|scrap| scrap.self_key()).collect();
+
+        let mut both: Vec<ScrapKey> = ins.intersection(&outs).cloned().collect();
+        let mut only_in: Vec<ScrapKey> = ins.difference(&outs).cloned().collect();
+        let mut only_out: Vec<ScrapKey> = outs.difference(&ins).cloned().collect();
+        for group in [&mut both, &mut only_in, &mut only_out] {
+            group.sort_by_key(sort_key);
+        }
+
+        let total = both.len() + only_in.len() + only_out.len();
+        if total == 0 {
+            return None;
+        }
+        let selected = Self::select(&both, &only_in, &only_out, limit);
+
+        let mut nodes: Vec<GraphNode> = selected
+            .into_iter()
+            .map(|(key, dir)| GraphNode {
+                label: label_of(&key.title().to_string()),
+                key,
+                dir,
+                x: 0.0,
+                y: 0.0,
+            })
+            .collect();
+        Self::place(&mut nodes);
+        Self::declutter(&mut nodes);
+
+        // Padding follows the longest label rather than a fixed margin: a
+        // clipped title is worse than a wide drawing, and short titles keep
+        // the graph compact.
+        let center_label = label_of(center_title);
+        let pad_x = nodes
+            .iter()
+            .map(|node| &node.label)
+            .chain(std::iter::once(&center_label))
+            .fold(MIN_PAD_X, |m, label| {
+                m.max(label_width(label) + LABEL_OFFSET * 2.0)
+            });
+        let ext_x = nodes.iter().fold(90.0_f32, |m, n| m.max(n.x.abs()));
+        let ext_y = nodes.iter().fold(70.0_f32, |m, n| m.max(n.y.abs()));
+        let width = (ext_x + pad_x) * 2.0;
+        let height = (ext_y + PAD_Y) * 2.0;
+        let (center_x, center_y) = (width / 2.0, height / 2.0);
+        for node in nodes.iter_mut() {
+            node.x += center_x;
+            node.y += center_y;
+        }
+
+        Some(ScrapGraph {
+            dropped: total - nodes.len(),
+            nodes,
+            center_label,
+            width,
+            height,
+            center_x,
+            center_y,
+        })
+    }
+
+    /// Truncating one sorted list would let a hub's backlinks crowd out the
+    /// handful of outgoing links entirely, so the cap is spent round-robin and
+    /// every direction that exists keeps a seat.
+    fn select(
+        both: &[ScrapKey],
+        only_in: &[ScrapKey],
+        only_out: &[ScrapKey],
+        limit: usize,
+    ) -> Vec<(ScrapKey, LinkDir)> {
+        let groups = [
+            (both, LinkDir::Both),
+            (only_in, LinkDir::In),
+            (only_out, LinkDir::Out),
+        ];
+        let mut taken = [0usize; 3];
+        let mut out: Vec<(ScrapKey, LinkDir)> = Vec::new();
+
+        while out.len() < limit {
+            let mut progressed = false;
+            for (i, (group, dir)) in groups.iter().enumerate() {
+                if out.len() >= limit {
+                    break;
+                }
+                if let Some(key) = group.get(taken[i]) {
+                    taken[i] += 1;
+                    out.push((key.clone(), *dir));
+                    progressed = true;
+                }
+            }
+            if !progressed {
+                break;
+            }
+        }
+        out.sort_by_key(|entry| sort_key(&entry.0));
+        out
+    }
+
+    /// Backlinks on the left arc, links on the right, mutual on the vertical.
+    /// A hub hangs a dozen neighbours off one side, so the radius grows out of
+    /// the count rather than staying fixed.
+    fn place(nodes: &mut [GraphNode]) {
+        for (dir, base, spread) in [
+            (LinkDir::In, PI, SPREAD_SIDE),
+            (LinkDir::Out, 0.0, SPREAD_SIDE),
+            (LinkDir::Both, PI * 1.5, SPREAD_BOTH),
+        ] {
+            let idx: Vec<usize> = (0..nodes.len()).filter(|&i| nodes[i].dir == dir).collect();
+            let count = idx.len() as f32;
+            let radius = BASE_RADIUS.max(count * NODE_GAP / spread);
+            for (k, &i) in idx.iter().enumerate() {
+                let t = if count <= 1.0 {
+                    0.5
+                } else {
+                    k as f32 / (count - 1.0)
+                };
+                let angle = base - spread / 2.0 + spread * t;
+                nodes[i].x = radius * angle.cos();
+                nodes[i].y = radius * angle.sin();
+            }
+        }
+    }
+
+    /// Even spacing along an arc still lets two labels on the same side land at
+    /// the same height. Push them apart vertically; the side they sit on — the
+    /// part that carries the direction — does not move.
+    fn declutter(nodes: &mut [GraphNode]) {
+        for left in [true, false] {
+            let mut idx: Vec<usize> = (0..nodes.len())
+                .filter(|&i| (nodes[i].x < 0.0) == left)
+                .collect();
+            idx.sort_by(|&a, &b| nodes[a].y.total_cmp(&nodes[b].y));
+            let before: f32 = idx.iter().map(|&i| nodes[i].y).sum();
+            for k in 1..idx.len() {
+                let prev = nodes[idx[k - 1]].y;
+                if nodes[idx[k]].y - prev < LABEL_GAP {
+                    nodes[idx[k]].y = prev + LABEL_GAP;
+                }
+            }
+            // The pass only ever pushes down, so the whole side would sink
+            // below the centre. Give back the drift it introduced.
+            if !idx.is_empty() {
+                let after: f32 = idx.iter().map(|&i| nodes[i].y).sum();
+                let drift = (after - before) / idx.len() as f32;
+                for &i in &idx {
+                    nodes[i].y -= drift;
+                }
+            }
+        }
+    }
+}
+
+impl GraphNode {
+    /// Where the edge meets the centre node, clear of its circle.
+    pub fn edge_start(&self, center_x: f32, center_y: f32) -> (f32, f32) {
+        let (ux, uy) = self.unit(center_x, center_y);
+        (center_x + ux * CENTER_R, center_y + uy * CENTER_R)
+    }
+
+    /// Where the edge stops short of this node, leaving room for the arrowhead.
+    pub fn edge_end(&self, center_x: f32, center_y: f32) -> (f32, f32) {
+        let (ux, uy) = self.unit(center_x, center_y);
+        let back = NODE_R + ARROW_CLEARANCE;
+        (self.x - ux * back, self.y - uy * back)
+    }
+
+    /// Every label hangs off one side or the other. A centred label would sit
+    /// above its node and spread both ways, which is the one shape the
+    /// vertical declutter pass cannot keep clear of its neighbours.
+    pub fn label_anchor(&self, center_x: f32) -> &'static str {
+        if self.x < center_x {
+            "end"
+        } else {
+            "start"
+        }
+    }
+
+    pub fn label_x(&self, center_x: f32) -> f32 {
+        if self.label_anchor(center_x) == "end" {
+            self.x - LABEL_OFFSET
+        } else {
+            self.x + LABEL_OFFSET
+        }
+    }
+
+    pub fn label_y(&self) -> f32 {
+        self.y + 4.0
+    }
+
+    pub fn arrow_at_center(&self) -> bool {
+        matches!(self.dir, LinkDir::In | LinkDir::Both)
+    }
+
+    pub fn arrow_at_node(&self) -> bool {
+        matches!(self.dir, LinkDir::Out | LinkDir::Both)
+    }
+
+    fn unit(&self, center_x: f32, center_y: f32) -> (f32, f32) {
+        let (dx, dy) = (self.x - center_x, self.y - center_y);
+        let distance = (dx * dx + dy * dy).sqrt().max(0.001);
+        (dx / distance, dy / distance)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scrap(title: &str, text: &str) -> Scrap {
+        Scrap::new(title, &None, text)
+    }
+
+    fn dir_of(graph: &ScrapGraph, title: &str) -> LinkDir {
+        graph
+            .nodes
+            .iter()
+            .find(|node| node.key.title().to_string() == title)
+            .unwrap_or_else(|| panic!("{title} not in graph"))
+            .dir
+    }
+
+    #[test]
+    fn it_returns_none_without_neighbors() {
+        assert_eq!(ScrapGraph::new("center", &[], &[], MAX_NODES), None);
+    }
+
+    #[test]
+    fn it_classifies_each_neighbor_by_direction() {
+        let inbound = vec![scrap("in", ""), scrap("mutual", "")];
+        let outbound = vec![scrap("out", ""), scrap("mutual", "")];
+
+        let graph = ScrapGraph::new("center", &inbound, &outbound, MAX_NODES).unwrap();
+
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(dir_of(&graph, "in"), LinkDir::In);
+        assert_eq!(dir_of(&graph, "out"), LinkDir::Out);
+        assert_eq!(dir_of(&graph, "mutual"), LinkDir::Both);
+        assert_eq!(graph.dropped, 0);
+    }
+
+    #[test]
+    fn it_puts_backlinks_left_and_links_right() {
+        let inbound = vec![scrap("in", "")];
+        let outbound = vec![scrap("out", "")];
+
+        let graph = ScrapGraph::new("center", &inbound, &outbound, MAX_NODES).unwrap();
+
+        let node = |title: &str| {
+            graph
+                .nodes
+                .iter()
+                .find(|n| n.key.title().to_string() == title)
+                .unwrap()
+                .clone()
+        };
+        assert!(node("in").x < graph.center_x);
+        assert!(node("out").x > graph.center_x);
+    }
+
+    #[test]
+    fn it_keeps_both_directions_when_the_cap_bites() {
+        // A hub: many backlinks, one outgoing link. Alphabetically the link
+        // sorts last, so a plain truncation would drop it.
+        let inbound: Vec<Scrap> = (0..30).map(|i| scrap(&format!("a{i:02}"), "")).collect();
+        let outbound = vec![scrap("zzz", "")];
+
+        let graph = ScrapGraph::new("center", &inbound, &outbound, MAX_NODES).unwrap();
+
+        assert_eq!(graph.nodes.len(), MAX_NODES);
+        assert_eq!(graph.dropped, 31 - MAX_NODES);
+        assert_eq!(dir_of(&graph, "zzz"), LinkDir::Out);
+    }
+
+    #[test]
+    fn it_orders_nodes_independently_of_read_order() {
+        let forward = vec![scrap("a", ""), scrap("b", ""), scrap("c", "")];
+        let reversed = vec![scrap("c", ""), scrap("b", ""), scrap("a", "")];
+
+        let one = ScrapGraph::new("center", &forward, &[], MAX_NODES).unwrap();
+        let other = ScrapGraph::new("center", &reversed, &[], MAX_NODES).unwrap();
+
+        assert_eq!(one, other);
+    }
+
+    #[test]
+    fn it_separates_labels_that_share_a_height() {
+        let inbound: Vec<Scrap> = (0..12).map(|i| scrap(&format!("in{i:02}"), "")).collect();
+
+        let graph = ScrapGraph::new("center", &inbound, &[], MAX_NODES).unwrap();
+
+        let mut ys: Vec<f32> = graph
+            .nodes
+            .iter()
+            .filter(|n| n.x < graph.center_x)
+            .map(|n| n.y)
+            .collect();
+        ys.sort_by(f32::total_cmp);
+        for pair in ys.windows(2) {
+            assert!(
+                pair[1] - pair[0] >= LABEL_GAP - 0.01,
+                "labels {} and {} are too close",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn it_sizes_the_viewbox_around_the_nodes() {
+        let inbound: Vec<Scrap> = (0..16).map(|i| scrap(&format!("in{i:02}"), "")).collect();
+
+        let graph = ScrapGraph::new("center", &inbound, &[], MAX_NODES).unwrap();
+
+        for node in &graph.nodes {
+            assert!(node.x > 0.0 && node.x < graph.width);
+            assert!(node.y > 0.0 && node.y < graph.height);
+        }
+    }
+
+    #[test]
+    fn it_points_arrows_at_the_referenced_side() {
+        let inbound = vec![scrap("in", ""), scrap("mutual", "")];
+        let outbound = vec![scrap("out", ""), scrap("mutual", "")];
+
+        let graph = ScrapGraph::new("center", &inbound, &outbound, MAX_NODES).unwrap();
+
+        let node = |title: &str| {
+            graph
+                .nodes
+                .iter()
+                .find(|n| n.key.title().to_string() == title)
+                .unwrap()
+        };
+        assert!(node("in").arrow_at_center() && !node("in").arrow_at_node());
+        assert!(!node("out").arrow_at_center() && node("out").arrow_at_node());
+        assert!(node("mutual").arrow_at_center() && node("mutual").arrow_at_node());
+    }
+}


### PR DESCRIPTION
## What

Every scrap page with at least one connection now renders its direct neighbours as an inline SVG, above the backlinks and links lists.

## Why

The backlinks and links lists tell you *what* a scrap connects to, but not *which way*. This adds a small drawing that answers that at a glance, without pulling the site toward a general-purpose graph explorer.

Direction is carried by **position rather than colour** — backlinks on the left arc, links on the right, mutual on the vertical — with arrowheads always pointing at the referenced side.

Two consequences of that choice:

- **No new colour tokens.** Nothing to run through `tokens:check-contrast`, and the drawing stays readable in print or for a reader who cannot separate the two hues.
- **No JavaScript.** The layout is computed in Rust at build time and the colours resolve from the existing tokens, so light/dark follows the page with no redraw. Nothing is fetched from a CDN, and no extra file is emitted.

Alternatives considered and dropped: mermaid (its ELK force layouts silently fall back to dagre under the CDN loading this project uses, and making them work costs an import map plus three more pinned dependencies), and a client-side force layout (7–57KB of JS for pan/zoom this view does not need yet).

## How

`ScrapGraph` is built from the two lists `render_scrap` already holds, so **no extra walk over the wiki happens**. At most 18 neighbours are drawn, selected round-robin across the three directions so a hub's backlinks cannot crowd out its handful of outgoing links; the remainder is reported as a `+N more` count.

The drawing lives in a `scrap_graph` component in `macros.html`, so it is overridable like every other component.

## Verification

Built `boykush/wiki` (1036 scraps) and measured **all 1016 graph-bearing pages** in a browser:

- 0 label overlaps, 0 labels clipped by the viewBox
- viewBox median 668px wide, max 915×731
- 39 pages hit the node cap and show `+N more`

Three issues surfaced and were fixed during that pass: a label gap smaller than the rendered glyph box, CJK titles overflowing an under-estimated width, and a node landing exactly on the vertical axis whose centred label fell outside the left/right declutter pass (fixed structurally by anchoring every label to one side).

**Performance:** `mise run perf:test` on that wiki reports **0.785s** against the 4s threshold — within run-to-run variance of the 0.845s baseline.

`mise run cargo:quality` passes: 311 + 294 tests, fmt, clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)