### PR TITLE
v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraps"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "scraps_libs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "comrak",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 edition = "2021"
 authors = ["boykush <boykush315@gmail.com>"]
 license = "MIT"
-version = "2.2.0"
+version = "2.3.0"
 description = "Scraps is a portable CLI knowledge hub for managing interconnected Markdown documentation with Wiki-link notation."
 homepage = "https://boykush.github.io/scraps"
 repository = "https://github.com/boykush/scraps"
 documentation = "https://boykush.github.io/scraps"
 rust-version = "1.92"
 [workspace.dependencies.scraps_libs]
-version = "2.2.0"
+version = "2.3.0"
 path = "modules/libs"
 [workspace.dependencies]
 anyhow = "=1.0.104"

--- a/modules/libs/Cargo.toml
+++ b/modules/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scraps_libs"
 edition = "2021"
-version = "2.2.0"
+version = "2.3.0"
 authors.workspace = true
 license.workspace = true
 description.workspace = true


### PR DESCRIPTION
Bump `scraps` and `scraps_libs` to 2.3.0.

Changes since v2.2.0:

- feat(build): draw each scrap's neighbourhood as a build-time SVG (#703)
- fix(deps): update rust crate comrak to v0.55.0 (#704)
- fix(deps): update rust crate yaml-rust2 to v0.12.0 (#705)
- chore(deps): update rust crate rstest to v0.27.0 (#707)

🤖 Generated with [Claude Code](https://claude.com/claude-code)